### PR TITLE
move hdf5.h outside extern C

### DIFF
--- a/include/cbf.h
+++ b/include/cbf.h
@@ -250,6 +250,8 @@
 #ifndef CBF_H
 #define CBF_H
 
+#include "hdf5.h"
+
 #ifdef __cplusplus
 
 extern "C" {
@@ -299,7 +301,6 @@ _CBF_STR(CBF_VERS_RELEASE) CBF_VERS_SUBRELEASE
 #endif
     
 #include "cbf_tree.h"
-#include "hdf5.h"
 
 #include <stdlib.h>
 #include <limits.h>


### PR DESCRIPTION
Move hdf5.h outside of the extern C block.  This make cbflib compile if the hdf5 library is build with c++ bindings.