### PR TITLE
Fix HDF5-related undefined behavior

### DIFF
--- a/src/cbf.c
+++ b/src/cbf.c
@@ -8395,9 +8395,9 @@ int cbf_mpint_rightshift_acc(unsigned int * acc, size_t acsize, int shift) {
   
   extrabits = 0;
 
-  if (acc[acsize-1]&sign) extrabits = (~0)<<(sizeof(unsigned int)*CHAR_BIT-shift);
+  if (acc[acsize-1]&sign) extrabits = (~0u)<<(sizeof(unsigned int)*CHAR_BIT-shift);
 
-  mask = ~((~0)<<(sizeof(unsigned int)*CHAR_BIT-shift));
+  mask = ~((~0u)<<(sizeof(unsigned int)*CHAR_BIT-shift));
 
   for (iint = acsize; iint; iint--) {
 

--- a/src/cbf_copy.c
+++ b/src/cbf_copy.c
@@ -2288,9 +2288,9 @@ extern "C" {
                 
                 index = elsize*(fastlow +indexmid*dimfast+indexslow*dimfast*dimmid);
                 
-                memmove(tdst,src+index,(1+fasthigh-fastlow)*elsize);
+                memmove(tdst,(char *)src+index,(1+fasthigh-fastlow)*elsize);
                 
-                tdst += (1+fasthigh-fastlow)*elsize;
+                tdst = (char *)tdst + (1+fasthigh-fastlow)*elsize;
                 
             }
         }

--- a/src/cbf_hdf5.c
+++ b/src/cbf_hdf5.c
@@ -304,6 +304,11 @@ extern "C" {
      int real,
      const char *byteorder);
 
+    int cbf_read_h5file_group(const cbf_handle handle,
+                        const cbf_h5handle h5handle,
+                        const unsigned long int flags,
+                        hid_t group);
+
     /* CBF column -- NeXus DataSet Mapping Tables
      applicable to categories that map to
      datasets or to attributes
@@ -17951,7 +17956,7 @@ _cbf_pilatusAxis2nexusAxisAttrs(h4data,units,depends_on,exsisItem,cmp)
 
         char svndate[] = CBF_SVN_DATE_STRING;
 
-        char buffer[140];
+        char buffer[140] = {0};
 
         int ii, irev, idate;
 
@@ -18033,7 +18038,7 @@ _cbf_pilatusAxis2nexusAxisAttrs(h4data,units,depends_on,exsisItem,cmp)
 
         char svndate[] = CBF_SVN_DATE_STRING;
 
-        char buffer[140];
+        char buffer[140] = {0};
 
         int ii, irev, idate;
 
@@ -19021,6 +19026,7 @@ _cbf_pilatusAxis2nexusAxisAttrs(h4data,units,depends_on,exsisItem,cmp)
             } else {
                 const htri_t vlstr = H5Tis_variable_str(data_type);
                 char * * lvalue = NULL;
+                char * llvalue = NULL;
                 int freelvalue = 0;
                 if (vlstr<0) {
                     cbf_debug_print("Couldn't check for a variable-length string");
@@ -19038,7 +19044,6 @@ _cbf_pilatusAxis2nexusAxisAttrs(h4data,units,depends_on,exsisItem,cmp)
                 } else {
                     /* I have a fixed-length string */
                     const size_t len = H5Tget_size(data_type);
-                    char * llvalue = NULL;
                     if (!len) {
                         cbf_debug_print("Couldn't get length of string");
                         error |= CBF_H5ERROR;

--- a/src/img.c
+++ b/src/img.c
@@ -1331,7 +1331,7 @@ int img_read_mar345header (img_handle img, FILE *file, int *org_data)
 
           *C = '\0';
           
-      for (C = C64+strlen(C64)-1; (C != C64-1 && *C == ' '); C-- ) *C = '\0';
+      for (C = C64+strlen(C64); (C > C64 && *--C == ' '); ) *C = '\0';
 
       C = C64 + strcspn (C64, " ");
 


### PR DESCRIPTION
This commit fixes several undefined and implementation-defined
behaviors in libcbf, identified from an analysis of warnings
emitted by GCC.  The motivation was to address crashes in the
nexus2cbf example program that exhibit a sensitivity to (at
least) compiler optimization level. Specific issues addressed
include

 - left-shifting negative integers
 - pointer arithmetic involving type `void *`
 - calling a function that has no in-scope declaration
 - string / character-array manipulation with dependencies on
   uninitialized, unset contents of local arrays
 - computing a pointer to before the start of an object
 - accessing an object (via pointer) after the end of the
   object's lifetime

It was the last of those, in function `_cbf_nx2cbfDread_scalar_string`,
that seems to have been the main source of the specific problem
that motivated these changes.

Fixes #15