### PR TITLE
Add missing interface declaration for img_set_tags

### DIFF
--- a/include/img.h
+++ b/include/img.h
@@ -91,6 +91,7 @@ extern "C" {
     int         img_read_mar345 (img_handle img,
                                  const char *name);
     int         img_get_tags (img_handle img);
+    int         img_set_tags (img_handle img, int tags);
     int         img_delete_fieldnumber (img_handle img, int x);
     
     img_handle  img_make_handle    ( void );

--- a/src/img.c
+++ b/src/img.c
@@ -1705,9 +1705,6 @@ int img_read_mar345 (img_handle img, const char *name)
 }
 
 
-int img_set_tags (img_handle img, int tags);
-
-
   /* Read a file */
 
 int img_read (img_handle img, const char *name)


### PR DESCRIPTION
`img_set_tags` is present in `img.c`, but appears to be missing from the `img.h` file. 

[CCTBX](https://github.com/cctbx/cctbx_project/blob/9c5cce6eb5509b6ce613e46888f73b4bca0f2976/cbflib_adaptbx/detectors/mar_adaptor.h#L13-L17) has been manually defining this with `extern "C" {`, but would be nice to be exported directly, unless there is a reason it has been omitted.