### PR TITLE
Syntax fixes and text changes in cif_img_1.8.4.dic (draft version)

### DIFF
--- a/doc/cif_img_1.8.4.dic
+++ b/doc/cif_img_1.8.4.dic
@@ -1278,7 +1278,7 @@ save__array_data.external_format
    _array_data.array_id
    _array_data.binary_id
    _array_data.external_format
-   _array_data.location_uri
+   _array_data.external_location_uri
    _array_data.external_path
    _array_data.external_frame
    1 1 HDF5 https://zenodo.org/record/12345/files/tartaric.h5 /entry1/detector1/data 1
@@ -1297,7 +1297,7 @@ save__array_data.external_format
    _array_data.binary_id
    _array_data.external_format
    _array_data.external_version
-   _array_data.location_uri
+   _array_data.external_location_uri
    1 1 Bruker Smart6000 https://uni_repo.edu/5341/run1/tartaric.001 
    1 2 Bruker Smart6000 https://uni_repo.edu/5341/run1/tartaric.002
    ...
@@ -1313,7 +1313,7 @@ save__array_data.external_format
    _array_data.array_id
    _array_data.binary_id
    _array_data.external_format
-   _array_data.location_uri
+   _array_data.external_location_uri
    _array_data.external_archive_format
    _array_data.external_archive_path
    1 1 SMV
@@ -1339,7 +1339,7 @@ save__array_data.external_version
 ;
    An identifier for the version of the file format described by _array_data.external_format. 
 ;
-   _item.name                 '_array_data.external_format'
+   _item.name                 '_array_data.external_version'
    _item.category_id            array_data
    _item.mandatory_code         no
    _item.type_code              code
@@ -1382,7 +1382,7 @@ save__array_data.external_version
    _array_data.array_id
    _array_data.binary_id
    _array_data.external_format
-   _array_data.location_uri
+   _array_data.external_location_uri
    _array_data.external_path
    _array_data.external_frame
    1 1 HDF5 https://zenodo.org/record/12345/files/tartaric.h5 /entry1/detector1/data 1
@@ -1401,7 +1401,7 @@ save__array_data.external_version
    _array_data.binary_id
    _array_data.external_format
    _array_data.external_version
-   _array_data.location_uri
+   _array_data.external_location_uri
    1 1 Bruker Smart6000 https://uni_repo.edu/5341/run1/tartaric.001 
    1 2 Bruker Smart6000 https://uni_repo.edu/5341/run1/tartaric.002
    ...
@@ -1417,7 +1417,7 @@ save__array_data.external_version
    _array_data.array_id
    _array_data.binary_id
    _array_data.external_format
-   _array_data.location_uri
+   _array_data.external_location_uri
    _array_data.external_archive_format
    _array_data.external_archive_path
    1 1 SMV
@@ -3804,7 +3804,7 @@ save_AXIS
       (5)  Of those not directed along a, none is shorter than b.
       (6)  Of those not lying in the ab plane, none is shorter than c.
       (7)  The three angles between the basis vectors a, b and c are
-      either all acute (<90 degrees) or all obtuse (≥90 degrees)."
+      either all acute (<90 degrees) or all obtuse (>=90 degrees)."
 
     These rules do not produce a unique result that is stable under
     the assumption of experimental errors, and the resulting cell
@@ -11829,7 +11829,7 @@ save__diffrn_frame_data.details
    _dictionary_history.update
    _dictionary_history.revision
 
-   1.8.4    2021-03-16 and 2021-04-15
+   1.8.4    '2021-03-16 and 2021-04-15'
 
 ;   Copy-editing refinements (bm)
 


### PR DESCRIPTION
1) Fixes syntax error in _dictionary_history loop
2) Fixes non-ASCII text in save_AXIS _category.description
3) Changes _array_data.location_uri to _array_data.external_location_uri in various places
4) Corrects _item.name for _array_data.external_version (hopefully got it right this time!)