### PR TITLE
Add CBFLIB_DONT_BUILD_HDF5 option to Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,6 +282,8 @@ CBF_PREFIX  ?= $(HOME)
 #
 CLEANTESTS = yes
 
+CBFLIB_DONT_BUILD_HDF5?=no
+
 
 MSYS2=no
 CBFLIB_DONT_USE_LOCAL_HDF5?=no
@@ -300,6 +302,13 @@ NUWEB_DEP=nuweb-1.60
 NUWEB_DEP2=$(BIN)/nuweb
 endif
 
+
+ifeq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+CBFLIB_DONT_USE_LOCAL_HDF5=yes
+CBFLIB_DONT_USE_LZ4=yes
+CBFLIB_DONT_USE_BSHUF=yes
+CBFLIB_DONT_USE_BLOSC=yes
+endif
 
 
 CBFLIB_DONT_HAVE_FGETLN ?= yes
@@ -403,6 +412,12 @@ else
 H5DUMP = /MINGW32/bin/h5dump
 endif
 
+ifeq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+HDF5LIBS_LOCAL =
+HDF5LIBS_SYSTEM =
+HDF5SOLIBS_LOCAL =
+HDF5SOLIBS_SYSTEM =
+endif
 
 CBFLIB_DONT_USE_LZ4 ?= no
 ifneq ($(CBFLIB_DONT_USE_LZ4),yes)
@@ -623,8 +638,10 @@ BSHUFFLAG =
 endif
 
 
-
 MISCFLAG = $(NOLLFLAG) $(ULPFLAG)
+ifneq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+MISCFLAG += -DUSE_HDF5
+endif
 
 #
 # PY2CBF definitions
@@ -679,7 +696,7 @@ EXTRALIBS = -lm
 M4FLAGS = -Dfcb_bytes_in_rec=131072
 TIME = time
 
-ifneq ($(NOFORTRAN),)
+ifeq ($(NOFORTRAN),yes)
 F90C =
 endif
 
@@ -786,8 +803,6 @@ SOURCE   =  $(SRC)/cbf.c               \
 	$(SRC)/cbf_copy.c          \
 	$(SRC)/cbf_file.c          \
 	$(SRC)/cbf_getopt.c        \
-	$(SRC)/cbf_hdf5.c          \
-	$(SRC)/cbf_hdf5_filter.c   \
 	$(SRC)/cbf_lex.c           \
 	$(SRC)/cbf_minicbf_header.c\
 	$(SRC)/cbf_nibble_offset.c \
@@ -808,6 +823,10 @@ SOURCE   =  $(SRC)/cbf.c               \
 	$(SRC)/md5c.c              \
 	$(SRC)/img.c               \
 	$(SRC_FGETLN) $(SRC_REALPATH)
+ifneq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+SOURCE  += $(SRC)/cbf_hdf5.c \
+	$(SRC)/cbf_hdf5_filter.c
+endif
 
 ifneq ($(CBFLIB_DONT_USE_PY2CIFRW),yes)
 PY2SOURCE  = $(SRC)/drel_lex.py		   \
@@ -823,6 +842,7 @@ PY3SOURCE  = $(SRC)/drel_lex.py		   \
 	$(SRC)/drel_prep.py
 endif
 
+ifneq ($(NOFORTRAN),yes)
 F90SOURCE = $(SRC)/fcb_atol_wcnt.f90     \
 	$(SRC)/fcb_ci_strncmparr.f90 \
 	$(SRC)/fcb_exit_binary.f90   \
@@ -836,8 +856,8 @@ F90SOURCE = $(SRC)/fcb_atol_wcnt.f90     \
 	$(SRC)/fcb_read_line.f90     \
 	$(SRC)/fcb_read_xds_i2.f90   \
 	$(SRC)/fcb_skip_whitespace.f90
-	
-	
+endif
+
 #
 # Header files
 #
@@ -854,8 +874,6 @@ HEADERS   =  $(INCLUDE)/cbf.h               \
 	$(INCLUDE)/cbf_copy.h          \
 	$(INCLUDE)/cbf_file.h          \
 	$(INCLUDE)/cbf_getopt.h        \
-	$(INCLUDE)/cbf_hdf5.h          \
-	$(INCLUDE)/cbf_hdf5_filter.h   \
 	$(INCLUDE)/cbf_lex.h           \
 	$(INCLUDE)/cbf_minicbf_header.h\
 	$(INCLUDE)/cbf_nibble_offset.h \
@@ -876,6 +894,10 @@ HEADERS   =  $(INCLUDE)/cbf.h               \
 	$(INCLUDE)/cbff.h              \
 	$(INCLUDE)/md5.h               \
 	$(INCLUDE)/img.h
+ifneq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+HEADERS  += $(INCLUDE)/cbf_hdf5.h \
+	$(INCLUDE)/cbf_hdf5_filter.h
+endif
 
 #
 # m4 macro files
@@ -2068,7 +2090,7 @@ $(BIN)/tiff2cbf: $(LIB)/libcbf.a $(EXAMPLES)/tiff2cbf.c $(EXAMPLES)/tif_sprint.c
 	$(GOPTLIB)	$(GOPTINC) $(TIFF)
 	mkdir -p $(BIN)
 	$(CC) $(CFLAGS) $(LDFLAGS) $(MISCFLAG) $(CBF_REGEXFLAG) $(INCLUDES) $(WARNINGS) \
-	-I$(TIFF)/libtiff $(EXAMPLES)/tiff2cbf.c $(GOPTLIB) -L$(LIB) \
+	-I$(TIFF)/libtiff $(EXAMPLES)/tiff2cbf.c $(EXAMPLES)/tif_sprint.c $(GOPTLIB) -L$(LIB) \
 	-lcbf -L$(TIFF_PREFIX)/lib -ltiff $(REGEX_LIBS_STATIC) $(HDF5LIBS_LOCAL) $(EXTRALIBS) $(HDF5LIBS_SYSTEM) -limg -o $@
 
 #

--- a/Makefile_DIALS
+++ b/Makefile_DIALS
@@ -282,6 +282,8 @@ CBF_PREFIX  ?= $(HOME)
 #
 CLEANTESTS = yes
 
+CBFLIB_DONT_BUILD_HDF5?=no
+
 
 MSYS2=no
 CBFLIB_DONT_USE_LOCAL_HDF5?=no
@@ -300,6 +302,13 @@ NUWEB_DEP=nuweb-1.60
 NUWEB_DEP2=$(BIN)/nuweb
 endif
 
+
+ifeq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+CBFLIB_DONT_USE_LOCAL_HDF5=yes
+CBFLIB_DONT_USE_LZ4=yes
+CBFLIB_DONT_USE_BSHUF=yes
+CBFLIB_DONT_USE_BLOSC=yes
+endif
 
 
 CBFLIB_DONT_HAVE_FGETLN ?= yes
@@ -403,6 +412,12 @@ else
 H5DUMP = /MINGW32/bin/h5dump
 endif
 
+ifeq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+HDF5LIBS_LOCAL =
+HDF5LIBS_SYSTEM =
+HDF5SOLIBS_LOCAL =
+HDF5SOLIBS_SYSTEM =
+endif
 
 CBFLIB_DONT_USE_LZ4 ?= no
 ifneq ($(CBFLIB_DONT_USE_LZ4),yes)
@@ -570,21 +585,27 @@ PYSWIG = swig -python
 JSWIG = swig -java
 
 #
+# Java SDK root directory
+#
+ifeq ($(JDKDIR),)
+	JDKDIR 	=	/etc/alternatives/java_sdk
+endif
+
+#
+# Launcher for Java
+#
+JAVA = $(JDKDIR)/bin/java
+
+#
 # Compiler for Java
 #
-JAVAC = javac
+JAVAC = $(JDKDIR)/bin/javac
 
 #
 # Java archiver for compiled classes
 #
-JAR = jar
+JAR = $(JDKDIR)/bin/jar
 
-#
-# Java SDK root directory
-#
-ifeq ($(JDKDIR),)
-	JDKDIR 	=	/usr/lib/java
-endif
 
 ifneq ($(CBF_DONT_USE_LONG_LONG),)
 NOLLFLAG = -DCBF_DONT_USE_LONG_LONG
@@ -617,8 +638,10 @@ BSHUFFLAG =
 endif
 
 
-
 MISCFLAG = $(NOLLFLAG) $(ULPFLAG)
+ifneq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+MISCFLAG += -DUSE_HDF5
+endif
 
 #
 # PY2CBF definitions
@@ -674,7 +697,7 @@ EXTRALIBS = -lm
 M4FLAGS = -Dfcb_bytes_in_rec=131072
 TIME = time
 
-ifneq ($(NOFORTRAN),)
+ifeq ($(NOFORTRAN),yes)
 F90C =
 endif
 
@@ -781,8 +804,6 @@ SOURCE   =  $(SRC)/cbf.c               \
 	$(SRC)/cbf_copy.c          \
 	$(SRC)/cbf_file.c          \
 	$(SRC)/cbf_getopt.c        \
-	$(SRC)/cbf_hdf5.c          \
-	$(SRC)/cbf_hdf5_filter.c   \
 	$(SRC)/cbf_lex.c           \
 	$(SRC)/cbf_minicbf_header.c\
 	$(SRC)/cbf_nibble_offset.c \
@@ -803,6 +824,10 @@ SOURCE   =  $(SRC)/cbf.c               \
 	$(SRC)/md5c.c              \
 	$(SRC)/img.c               \
 	$(SRC_FGETLN) $(SRC_REALPATH)
+ifneq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+SOURCE  += $(SRC)/cbf_hdf5.c \
+	$(SRC)/cbf_hdf5_filter.c
+endif
 
 ifneq ($(CBFLIB_DONT_USE_PY2CIFRW),yes)
 PY2SOURCE  = $(SRC)/drel_lex.py		   \
@@ -818,6 +843,7 @@ PY3SOURCE  = $(SRC)/drel_lex.py		   \
 	$(SRC)/drel_prep.py
 endif
 
+ifneq ($(NOFORTRAN),yes)
 F90SOURCE = $(SRC)/fcb_atol_wcnt.f90     \
 	$(SRC)/fcb_ci_strncmparr.f90 \
 	$(SRC)/fcb_exit_binary.f90   \
@@ -831,8 +857,8 @@ F90SOURCE = $(SRC)/fcb_atol_wcnt.f90     \
 	$(SRC)/fcb_read_line.f90     \
 	$(SRC)/fcb_read_xds_i2.f90   \
 	$(SRC)/fcb_skip_whitespace.f90
-	
-	
+endif
+
 #
 # Header files
 #
@@ -849,8 +875,6 @@ HEADERS   =  $(INCLUDE)/cbf.h               \
 	$(INCLUDE)/cbf_copy.h          \
 	$(INCLUDE)/cbf_file.h          \
 	$(INCLUDE)/cbf_getopt.h        \
-	$(INCLUDE)/cbf_hdf5.h          \
-	$(INCLUDE)/cbf_hdf5_filter.h   \
 	$(INCLUDE)/cbf_lex.h           \
 	$(INCLUDE)/cbf_minicbf_header.h\
 	$(INCLUDE)/cbf_nibble_offset.h \
@@ -871,6 +895,10 @@ HEADERS   =  $(INCLUDE)/cbf.h               \
 	$(INCLUDE)/cbff.h              \
 	$(INCLUDE)/md5.h               \
 	$(INCLUDE)/img.h
+ifneq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+HEADERS  += $(INCLUDE)/cbf_hdf5.h \
+	$(INCLUDE)/cbf_hdf5_filter.h
+endif
 
 #
 # m4 macro files
@@ -1723,7 +1751,7 @@ $(PY2CBF)/pycbf_testfelaxes.py  \
 $(PY2CBF)/xmas/readmarheader.py \
 $(PY2CBF)/xmas/xmasheaders.py   \
 $(PY2CBF)/xmas/xmas_cif_template.cif : $(NUWEB_DEP) $(NUWEB_DEP2) $(PY2CBF)/pycbf.w
-	(cd $(PY2CBF); $(NUWEB) pycbf.w)
+	(cd $(PY2CBF); $(NUWEB) pycbf.w )
 	touch $(PY2CBF)/py2setup_py.m4
  
 $(PY2CBF)/_py2cbf.$(PY2CBFEXT):	$(PY2CBF)  shared \
@@ -1797,7 +1825,8 @@ $(PY3CBF)/xmas/readmarheader.py \
 $(PY3CBF)/xmas/xmasheaders.py   \
 $(PY3CBF)/xmas/xmas_cif_template.cif: $(NUWEB_DEP) $(NUWEB_DEP2) $(PY3CBF)/pycbf.w
 	(cd $(PY3CBF); $(NUWEB) pycbf.w )
-	touch $(PY3CBF)/py3setup_py.m4 
+	touch $(PY3CBF)/py3setup_py.m4
+
 
 $(PY3CBF)/_pycbf.$(PY3CBFEXT):	$(PY3CBF)  shared \
 	$(PY3CBF)/py3setup.py                    \
@@ -2137,7 +2166,7 @@ $(BIN)/ctestcbf: $(EXAMPLES)/testcbf.c $(LIB)/libcbf.a
 $(BIN)/testcbf.class: $(EXAMPLES)/testcbf.java $(JCBF)/cbflib-$(VERSION).jar $(SOLIB)/libcbf_wrap.so
 	mkdir -p $(BIN)
 	$(JAVAC) -cp $(JCBF)/cbflib-$(VERSION).jar -d $(BIN) $(EXAMPLES)/testcbf.java
-	
+
 ifneq ($(CBF_USE_ULP),)
 #
 # testulp test program
@@ -2705,7 +2734,7 @@ py3cbfuserinstall: $(PY3CBF)/_pycbf.$(PY3CBFEXT) $(PY3CBF)/py3cbfuserinstall
 
 javatests: $(BIN)/ctestcbf $(BIN)/testcbf.class $(SOLIB)/libcbf_wrap.so
 	$(LDPREFIX)  $(BIN)/ctestcbf > testcbfc.txt
-	$(LDPREFIX) java -cp $(JCBF)/cbflib-$(VERSION).jar:$(BIN) testcbf > testcbfj.txt
+	$(LDPREFIX) $(JAVA) -cp $(JCBF)/cbflib-$(VERSION).jar:$(BIN) testcbf > testcbfj.txt
 	$(DIFF) testcbfc.txt testcbfj.txt
 
 dectristests: $(BIN)/cbf_template_t $(TEMPLATES)/cbf_test_orig.out

--- a/Makefile_LINUX
+++ b/Makefile_LINUX
@@ -282,6 +282,8 @@ CBF_PREFIX  ?= $(HOME)
 #
 CLEANTESTS = yes
 
+CBFLIB_DONT_BUILD_HDF5?=no
+
 
 MSYS2=no
 CBFLIB_DONT_USE_LOCAL_HDF5?=no
@@ -300,6 +302,13 @@ NUWEB_DEP=nuweb-1.60
 NUWEB_DEP2=$(BIN)/nuweb
 endif
 
+
+ifeq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+CBFLIB_DONT_USE_LOCAL_HDF5=yes
+CBFLIB_DONT_USE_LZ4=yes
+CBFLIB_DONT_USE_BSHUF=yes
+CBFLIB_DONT_USE_BLOSC=yes
+endif
 
 
 CBFLIB_DONT_HAVE_FGETLN ?= yes
@@ -403,6 +412,12 @@ else
 H5DUMP = /MINGW32/bin/h5dump
 endif
 
+ifeq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+HDF5LIBS_LOCAL =
+HDF5LIBS_SYSTEM =
+HDF5SOLIBS_LOCAL =
+HDF5SOLIBS_SYSTEM =
+endif
 
 CBFLIB_DONT_USE_LZ4 ?= no
 ifneq ($(CBFLIB_DONT_USE_LZ4),yes)
@@ -623,8 +638,10 @@ BSHUFFLAG =
 endif
 
 
-
 MISCFLAG = $(NOLLFLAG) $(ULPFLAG)
+ifneq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+MISCFLAG += -DUSE_HDF5
+endif
 
 #
 # PY2CBF definitions
@@ -675,7 +692,7 @@ EXTRALIBS = -lm
 M4FLAGS = -Dfcb_bytes_in_rec=131072
 TIME = time
 
-ifneq ($(NOFORTRAN),)
+ifeq ($(NOFORTRAN),yes)
 F90C =
 endif
 
@@ -782,8 +799,6 @@ SOURCE   =  $(SRC)/cbf.c               \
 	$(SRC)/cbf_copy.c          \
 	$(SRC)/cbf_file.c          \
 	$(SRC)/cbf_getopt.c        \
-	$(SRC)/cbf_hdf5.c          \
-	$(SRC)/cbf_hdf5_filter.c   \
 	$(SRC)/cbf_lex.c           \
 	$(SRC)/cbf_minicbf_header.c\
 	$(SRC)/cbf_nibble_offset.c \
@@ -804,6 +819,10 @@ SOURCE   =  $(SRC)/cbf.c               \
 	$(SRC)/md5c.c              \
 	$(SRC)/img.c               \
 	$(SRC_FGETLN) $(SRC_REALPATH)
+ifneq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+SOURCE  += $(SRC)/cbf_hdf5.c \
+	$(SRC)/cbf_hdf5_filter.c
+endif
 
 ifneq ($(CBFLIB_DONT_USE_PY2CIFRW),yes)
 PY2SOURCE  = $(SRC)/drel_lex.py		   \
@@ -819,6 +838,7 @@ PY3SOURCE  = $(SRC)/drel_lex.py		   \
 	$(SRC)/drel_prep.py
 endif
 
+ifneq ($(NOFORTRAN),yes)
 F90SOURCE = $(SRC)/fcb_atol_wcnt.f90     \
 	$(SRC)/fcb_ci_strncmparr.f90 \
 	$(SRC)/fcb_exit_binary.f90   \
@@ -832,8 +852,8 @@ F90SOURCE = $(SRC)/fcb_atol_wcnt.f90     \
 	$(SRC)/fcb_read_line.f90     \
 	$(SRC)/fcb_read_xds_i2.f90   \
 	$(SRC)/fcb_skip_whitespace.f90
-	
-	
+endif
+
 #
 # Header files
 #
@@ -850,8 +870,6 @@ HEADERS   =  $(INCLUDE)/cbf.h               \
 	$(INCLUDE)/cbf_copy.h          \
 	$(INCLUDE)/cbf_file.h          \
 	$(INCLUDE)/cbf_getopt.h        \
-	$(INCLUDE)/cbf_hdf5.h          \
-	$(INCLUDE)/cbf_hdf5_filter.h   \
 	$(INCLUDE)/cbf_lex.h           \
 	$(INCLUDE)/cbf_minicbf_header.h\
 	$(INCLUDE)/cbf_nibble_offset.h \
@@ -872,6 +890,10 @@ HEADERS   =  $(INCLUDE)/cbf.h               \
 	$(INCLUDE)/cbff.h              \
 	$(INCLUDE)/md5.h               \
 	$(INCLUDE)/img.h
+ifneq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+HEADERS  += $(INCLUDE)/cbf_hdf5.h \
+	$(INCLUDE)/cbf_hdf5_filter.h
+endif
 
 #
 # m4 macro files
@@ -2064,7 +2086,7 @@ $(BIN)/tiff2cbf: $(LIB)/libcbf.a $(EXAMPLES)/tiff2cbf.c $(EXAMPLES)/tif_sprint.c
 	$(GOPTLIB)	$(GOPTINC) $(TIFF)
 	mkdir -p $(BIN)
 	$(CC) $(CFLAGS) $(LDFLAGS) $(MISCFLAG) $(CBF_REGEXFLAG) $(INCLUDES) $(WARNINGS) \
-	-I$(TIFF)/libtiff $(EXAMPLES)/tiff2cbf.c $(GOPTLIB) -L$(LIB) \
+	-I$(TIFF)/libtiff $(EXAMPLES)/tiff2cbf.c $(EXAMPLES)/tif_sprint.c $(GOPTLIB) -L$(LIB) \
 	-lcbf -L$(TIFF_PREFIX)/lib -ltiff $(REGEX_LIBS_STATIC) $(HDF5LIBS_LOCAL) $(EXTRALIBS) $(HDF5LIBS_SYSTEM) -limg -o $@
 
 #

--- a/Makefile_MINGW
+++ b/Makefile_MINGW
@@ -282,6 +282,8 @@ CBF_PREFIX  ?= $(HOME)
 #
 CLEANTESTS = yes
 
+CBFLIB_DONT_BUILD_HDF5?=no
+
 
 MSYS2=no
 CBFLIB_DONT_USE_LOCAL_HDF5?=no
@@ -300,6 +302,13 @@ NUWEB_DEP=nuweb-1.60
 NUWEB_DEP2=$(BIN)/nuweb
 endif
 
+
+ifeq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+CBFLIB_DONT_USE_LOCAL_HDF5=yes
+CBFLIB_DONT_USE_LZ4=yes
+CBFLIB_DONT_USE_BSHUF=yes
+CBFLIB_DONT_USE_BLOSC=yes
+endif
 
 
 CBFLIB_DONT_HAVE_FGETLN ?= yes
@@ -403,6 +412,12 @@ else
 H5DUMP = /MINGW32/bin/h5dump
 endif
 
+ifeq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+HDF5LIBS_LOCAL =
+HDF5LIBS_SYSTEM =
+HDF5SOLIBS_LOCAL =
+HDF5SOLIBS_SYSTEM =
+endif
 
 CBFLIB_DONT_USE_LZ4 ?= no
 ifneq ($(CBFLIB_DONT_USE_LZ4),yes)
@@ -623,8 +638,10 @@ BSHUFFLAG =
 endif
 
 
-
 MISCFLAG = $(NOLLFLAG) $(ULPFLAG)
+ifneq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+MISCFLAG += -DUSE_HDF5
+endif
 
 #
 # PY2CBF definitions
@@ -686,7 +703,7 @@ SHAR	= shar
 AR		=  ar
 RANLIB  =  ranlib
 
-ifneq ($(NOFORTRAN),)
+ifeq ($(NOFORTRAN),yes)
 F90C =
 endif
 
@@ -793,8 +810,6 @@ SOURCE   =  $(SRC)/cbf.c               \
 	$(SRC)/cbf_copy.c          \
 	$(SRC)/cbf_file.c          \
 	$(SRC)/cbf_getopt.c        \
-	$(SRC)/cbf_hdf5.c          \
-	$(SRC)/cbf_hdf5_filter.c   \
 	$(SRC)/cbf_lex.c           \
 	$(SRC)/cbf_minicbf_header.c\
 	$(SRC)/cbf_nibble_offset.c \
@@ -815,6 +830,10 @@ SOURCE   =  $(SRC)/cbf.c               \
 	$(SRC)/md5c.c              \
 	$(SRC)/img.c               \
 	$(SRC_FGETLN) $(SRC_REALPATH)
+ifneq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+SOURCE  += $(SRC)/cbf_hdf5.c \
+	$(SRC)/cbf_hdf5_filter.c
+endif
 
 ifneq ($(CBFLIB_DONT_USE_PY2CIFRW),yes)
 PY2SOURCE  = $(SRC)/drel_lex.py		   \
@@ -830,6 +849,7 @@ PY3SOURCE  = $(SRC)/drel_lex.py		   \
 	$(SRC)/drel_prep.py
 endif
 
+ifneq ($(NOFORTRAN),yes)
 F90SOURCE = $(SRC)/fcb_atol_wcnt.f90     \
 	$(SRC)/fcb_ci_strncmparr.f90 \
 	$(SRC)/fcb_exit_binary.f90   \
@@ -843,8 +863,8 @@ F90SOURCE = $(SRC)/fcb_atol_wcnt.f90     \
 	$(SRC)/fcb_read_line.f90     \
 	$(SRC)/fcb_read_xds_i2.f90   \
 	$(SRC)/fcb_skip_whitespace.f90
-	
-	
+endif
+
 #
 # Header files
 #
@@ -861,8 +881,6 @@ HEADERS   =  $(INCLUDE)/cbf.h               \
 	$(INCLUDE)/cbf_copy.h          \
 	$(INCLUDE)/cbf_file.h          \
 	$(INCLUDE)/cbf_getopt.h        \
-	$(INCLUDE)/cbf_hdf5.h          \
-	$(INCLUDE)/cbf_hdf5_filter.h   \
 	$(INCLUDE)/cbf_lex.h           \
 	$(INCLUDE)/cbf_minicbf_header.h\
 	$(INCLUDE)/cbf_nibble_offset.h \
@@ -883,6 +901,10 @@ HEADERS   =  $(INCLUDE)/cbf.h               \
 	$(INCLUDE)/cbff.h              \
 	$(INCLUDE)/md5.h               \
 	$(INCLUDE)/img.h
+ifneq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+HEADERS  += $(INCLUDE)/cbf_hdf5.h \
+	$(INCLUDE)/cbf_hdf5_filter.h
+endif
 
 #
 # m4 macro files
@@ -2075,7 +2097,7 @@ $(BIN)/tiff2cbf: $(LIB)/libcbf.a $(EXAMPLES)/tiff2cbf.c $(EXAMPLES)/tif_sprint.c
 	$(GOPTLIB)	$(GOPTINC) $(TIFF)
 	mkdir -p $(BIN)
 	$(CC) $(CFLAGS) $(LDFLAGS) $(MISCFLAG) $(CBF_REGEXFLAG) $(INCLUDES) $(WARNINGS) \
-	-I$(TIFF)/libtiff $(EXAMPLES)/tiff2cbf.c $(GOPTLIB) -L$(LIB) \
+	-I$(TIFF)/libtiff $(EXAMPLES)/tiff2cbf.c $(EXAMPLES)/tif_sprint.c $(GOPTLIB) -L$(LIB) \
 	-lcbf -L$(TIFF_PREFIX)/lib -ltiff $(REGEX_LIBS_STATIC) $(HDF5LIBS_LOCAL) $(EXTRALIBS) $(HDF5LIBS_SYSTEM) -limg -o $@
 
 #

--- a/Makefile_MSYS2
+++ b/Makefile_MSYS2
@@ -282,6 +282,8 @@ CBF_PREFIX  ?= $(HOME)
 #
 CLEANTESTS = yes
 
+CBFLIB_DONT_BUILD_HDF5?=no
+
 
 MSYS2=yes
 CBFLIB_DONT_USE_LOCAL_HDF5?=yes
@@ -299,6 +301,13 @@ NUWEB_DEP=nuweb-1.60
 NUWEB_DEP2=$(BIN)/nuweb
 endif
 
+
+ifeq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+CBFLIB_DONT_USE_LOCAL_HDF5=yes
+CBFLIB_DONT_USE_LZ4=yes
+CBFLIB_DONT_USE_BSHUF=yes
+CBFLIB_DONT_USE_BLOSC=yes
+endif
 
 
 CBFLIB_DONT_HAVE_FGETLN ?= yes
@@ -402,6 +411,12 @@ else
 H5DUMP = /MINGW32/bin/h5dump
 endif
 
+ifeq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+HDF5LIBS_LOCAL =
+HDF5LIBS_SYSTEM =
+HDF5SOLIBS_LOCAL =
+HDF5SOLIBS_SYSTEM =
+endif
 
 CBFLIB_DONT_USE_LZ4 ?= no
 ifneq ($(CBFLIB_DONT_USE_LZ4),yes)
@@ -622,8 +637,10 @@ BSHUFFLAG =
 endif
 
 
-
 MISCFLAG = $(NOLLFLAG) $(ULPFLAG)
+ifneq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+MISCFLAG += -DUSE_HDF5
+endif
 
 #
 # PY2CBF definitions
@@ -674,7 +691,7 @@ PY2CBFEXT = pyd
 PY3CBFEXT = pyd
 TIME = time
 
-ifneq ($(NOFORTRAN),)
+ifeq ($(NOFORTRAN),yes)
 F90C =
 endif
 
@@ -781,8 +798,6 @@ SOURCE   =  $(SRC)/cbf.c               \
 	$(SRC)/cbf_copy.c          \
 	$(SRC)/cbf_file.c          \
 	$(SRC)/cbf_getopt.c        \
-	$(SRC)/cbf_hdf5.c          \
-	$(SRC)/cbf_hdf5_filter.c   \
 	$(SRC)/cbf_lex.c           \
 	$(SRC)/cbf_minicbf_header.c\
 	$(SRC)/cbf_nibble_offset.c \
@@ -803,6 +818,10 @@ SOURCE   =  $(SRC)/cbf.c               \
 	$(SRC)/md5c.c              \
 	$(SRC)/img.c               \
 	$(SRC_FGETLN) $(SRC_REALPATH)
+ifneq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+SOURCE  += $(SRC)/cbf_hdf5.c \
+	$(SRC)/cbf_hdf5_filter.c
+endif
 
 ifneq ($(CBFLIB_DONT_USE_PY2CIFRW),yes)
 PY2SOURCE  = $(SRC)/drel_lex.py		   \
@@ -818,6 +837,7 @@ PY3SOURCE  = $(SRC)/drel_lex.py		   \
 	$(SRC)/drel_prep.py
 endif
 
+ifneq ($(NOFORTRAN),yes)
 F90SOURCE = $(SRC)/fcb_atol_wcnt.f90     \
 	$(SRC)/fcb_ci_strncmparr.f90 \
 	$(SRC)/fcb_exit_binary.f90   \
@@ -831,8 +851,8 @@ F90SOURCE = $(SRC)/fcb_atol_wcnt.f90     \
 	$(SRC)/fcb_read_line.f90     \
 	$(SRC)/fcb_read_xds_i2.f90   \
 	$(SRC)/fcb_skip_whitespace.f90
-	
-	
+endif
+
 #
 # Header files
 #
@@ -849,8 +869,6 @@ HEADERS   =  $(INCLUDE)/cbf.h               \
 	$(INCLUDE)/cbf_copy.h          \
 	$(INCLUDE)/cbf_file.h          \
 	$(INCLUDE)/cbf_getopt.h        \
-	$(INCLUDE)/cbf_hdf5.h          \
-	$(INCLUDE)/cbf_hdf5_filter.h   \
 	$(INCLUDE)/cbf_lex.h           \
 	$(INCLUDE)/cbf_minicbf_header.h\
 	$(INCLUDE)/cbf_nibble_offset.h \
@@ -871,6 +889,10 @@ HEADERS   =  $(INCLUDE)/cbf.h               \
 	$(INCLUDE)/cbff.h              \
 	$(INCLUDE)/md5.h               \
 	$(INCLUDE)/img.h
+ifneq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+HEADERS  += $(INCLUDE)/cbf_hdf5.h \
+	$(INCLUDE)/cbf_hdf5_filter.h
+endif
 
 #
 # m4 macro files
@@ -2063,7 +2085,7 @@ $(BIN)/tiff2cbf: $(LIB)/libcbf.a $(EXAMPLES)/tiff2cbf.c $(EXAMPLES)/tif_sprint.c
 	$(GOPTLIB)	$(GOPTINC) $(TIFF)
 	mkdir -p $(BIN)
 	$(CC) $(CFLAGS) $(LDFLAGS) $(MISCFLAG) $(CBF_REGEXFLAG) $(INCLUDES) $(WARNINGS) \
-	-I$(TIFF)/libtiff $(EXAMPLES)/tiff2cbf.c $(GOPTLIB) -L$(LIB) \
+	-I$(TIFF)/libtiff $(EXAMPLES)/tiff2cbf.c $(EXAMPLES)/tif_sprint.c $(GOPTLIB) -L$(LIB) \
 	-lcbf -L$(TIFF_PREFIX)/lib -ltiff $(REGEX_LIBS_STATIC) $(HDF5LIBS_LOCAL) $(EXTRALIBS) $(HDF5LIBS_SYSTEM) -limg -o $@
 
 #

--- a/Makefile_OSX
+++ b/Makefile_OSX
@@ -282,6 +282,8 @@ CBF_PREFIX  ?= $(HOME)
 #
 CLEANTESTS = yes
 
+CBFLIB_DONT_BUILD_HDF5?=no
+
 
 MSYS2=no
 CBFLIB_DONT_USE_LOCAL_HDF5?=no
@@ -300,6 +302,13 @@ NUWEB_DEP=nuweb-1.60
 NUWEB_DEP2=$(BIN)/nuweb
 endif
 
+
+ifeq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+CBFLIB_DONT_USE_LOCAL_HDF5=yes
+CBFLIB_DONT_USE_LZ4=yes
+CBFLIB_DONT_USE_BSHUF=yes
+CBFLIB_DONT_USE_BLOSC=yes
+endif
 
 
 CBFLIB_DONT_HAVE_FGETLN ?= yes
@@ -403,6 +412,12 @@ else
 H5DUMP = /MINGW32/bin/h5dump
 endif
 
+ifeq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+HDF5LIBS_LOCAL =
+HDF5LIBS_SYSTEM =
+HDF5SOLIBS_LOCAL =
+HDF5SOLIBS_SYSTEM =
+endif
 
 CBFLIB_DONT_USE_LZ4 ?= no
 ifneq ($(CBFLIB_DONT_USE_LZ4),yes)
@@ -623,8 +638,10 @@ BSHUFFLAG =
 endif
 
 
-
 MISCFLAG = $(NOLLFLAG) $(ULPFLAG)
+ifneq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+MISCFLAG += -DUSE_HDF5
+endif
 
 #
 # PY2CBF definitions
@@ -672,7 +689,7 @@ M4FLAGS = -Dfcb_bytes_in_rec=131072
 TIME = time
 DOWNLOAD = /sw/bin/wget -N
 
-ifneq ($(NOFORTRAN),)
+ifeq ($(NOFORTRAN),yes)
 F90C =
 endif
 
@@ -779,8 +796,6 @@ SOURCE   =  $(SRC)/cbf.c               \
 	$(SRC)/cbf_copy.c          \
 	$(SRC)/cbf_file.c          \
 	$(SRC)/cbf_getopt.c        \
-	$(SRC)/cbf_hdf5.c          \
-	$(SRC)/cbf_hdf5_filter.c   \
 	$(SRC)/cbf_lex.c           \
 	$(SRC)/cbf_minicbf_header.c\
 	$(SRC)/cbf_nibble_offset.c \
@@ -801,6 +816,10 @@ SOURCE   =  $(SRC)/cbf.c               \
 	$(SRC)/md5c.c              \
 	$(SRC)/img.c               \
 	$(SRC_FGETLN) $(SRC_REALPATH)
+ifneq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+SOURCE  += $(SRC)/cbf_hdf5.c \
+	$(SRC)/cbf_hdf5_filter.c
+endif
 
 ifneq ($(CBFLIB_DONT_USE_PY2CIFRW),yes)
 PY2SOURCE  = $(SRC)/drel_lex.py		   \
@@ -816,6 +835,7 @@ PY3SOURCE  = $(SRC)/drel_lex.py		   \
 	$(SRC)/drel_prep.py
 endif
 
+ifneq ($(NOFORTRAN),yes)
 F90SOURCE = $(SRC)/fcb_atol_wcnt.f90     \
 	$(SRC)/fcb_ci_strncmparr.f90 \
 	$(SRC)/fcb_exit_binary.f90   \
@@ -829,8 +849,8 @@ F90SOURCE = $(SRC)/fcb_atol_wcnt.f90     \
 	$(SRC)/fcb_read_line.f90     \
 	$(SRC)/fcb_read_xds_i2.f90   \
 	$(SRC)/fcb_skip_whitespace.f90
-	
-	
+endif
+
 #
 # Header files
 #
@@ -847,8 +867,6 @@ HEADERS   =  $(INCLUDE)/cbf.h               \
 	$(INCLUDE)/cbf_copy.h          \
 	$(INCLUDE)/cbf_file.h          \
 	$(INCLUDE)/cbf_getopt.h        \
-	$(INCLUDE)/cbf_hdf5.h          \
-	$(INCLUDE)/cbf_hdf5_filter.h   \
 	$(INCLUDE)/cbf_lex.h           \
 	$(INCLUDE)/cbf_minicbf_header.h\
 	$(INCLUDE)/cbf_nibble_offset.h \
@@ -869,6 +887,10 @@ HEADERS   =  $(INCLUDE)/cbf.h               \
 	$(INCLUDE)/cbff.h              \
 	$(INCLUDE)/md5.h               \
 	$(INCLUDE)/img.h
+ifneq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+HEADERS  += $(INCLUDE)/cbf_hdf5.h \
+	$(INCLUDE)/cbf_hdf5_filter.h
+endif
 
 #
 # m4 macro files
@@ -2061,7 +2083,7 @@ $(BIN)/tiff2cbf: $(LIB)/libcbf.a $(EXAMPLES)/tiff2cbf.c $(EXAMPLES)/tif_sprint.c
 	$(GOPTLIB)	$(GOPTINC) $(TIFF)
 	mkdir -p $(BIN)
 	$(CC) $(CFLAGS) $(LDFLAGS) $(MISCFLAG) $(CBF_REGEXFLAG) $(INCLUDES) $(WARNINGS) \
-	-I$(TIFF)/libtiff $(EXAMPLES)/tiff2cbf.c $(GOPTLIB) -L$(LIB) \
+	-I$(TIFF)/libtiff $(EXAMPLES)/tiff2cbf.c $(EXAMPLES)/tif_sprint.c $(GOPTLIB) -L$(LIB) \
 	-lcbf -L$(TIFF_PREFIX)/lib -ltiff $(REGEX_LIBS_STATIC) $(HDF5LIBS_LOCAL) $(EXTRALIBS) $(HDF5LIBS_SYSTEM) -limg -o $@
 
 #

--- a/include/cbf.h
+++ b/include/cbf.h
@@ -250,7 +250,9 @@
 #ifndef CBF_H
 #define CBF_H
 
+#ifdef USE_HDF5
 #include "hdf5.h"
+#endif
 
 #ifdef __cplusplus
 

--- a/m4/Makefile.m4
+++ b/m4/Makefile.m4
@@ -284,6 +284,8 @@ CBF_PREFIX  ?= $(HOME)
 #
 CLEANTESTS = yes
 
+CBFLIB_DONT_BUILD_HDF5?=no
+
 'm4_ifelse(cbf_system,`MSYS2',`
 MSYS2=yes
 CBFLIB_DONT_USE_LOCAL_HDF5?=yes
@@ -306,6 +308,13 @@ NUWEB_DEP=nuweb-1.60
 NUWEB_DEP2=$(BIN)/nuweb
 endif
 
+
+ifeq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+CBFLIB_DONT_USE_LOCAL_HDF5=yes
+CBFLIB_DONT_USE_LZ4=yes
+CBFLIB_DONT_USE_BSHUF=yes
+CBFLIB_DONT_USE_BLOSC=yes
+endif
 
 
 CBFLIB_DONT_HAVE_FGETLN ?= yes
@@ -409,6 +418,12 @@ else
 H5DUMP = /MINGW32/bin/h5dump
 endif
 
+ifeq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+HDF5LIBS_LOCAL =
+HDF5LIBS_SYSTEM =
+HDF5SOLIBS_LOCAL =
+HDF5SOLIBS_SYSTEM =
+endif
 
 CBFLIB_DONT_USE_LZ4 ?= no
 ifneq ($(CBFLIB_DONT_USE_LZ4),yes)
@@ -629,8 +644,10 @@ BSHUFFLAG =
 endif
 
 
-
 MISCFLAG = $(NOLLFLAG) $(ULPFLAG)
+ifneq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+MISCFLAG += -DUSE_HDF5
+endif
 
 #
 # PY2CBF definitions
@@ -1004,7 +1021,7 @@ EXTRALIBS = -lm
 M4FLAGS = -Dfcb_bytes_in_rec=131072
 TIME = time')`
 
-ifneq ($(NOFORTRAN),)
+ifeq ($(NOFORTRAN),yes)
 F90C =
 endif
 
@@ -1111,8 +1128,6 @@ SOURCE   =  $(SRC)/cbf.c               \
 	$(SRC)/cbf_copy.c          \
 	$(SRC)/cbf_file.c          \
 	$(SRC)/cbf_getopt.c        \
-	$(SRC)/cbf_hdf5.c          \
-	$(SRC)/cbf_hdf5_filter.c   \
 	$(SRC)/cbf_lex.c           \
 	$(SRC)/cbf_minicbf_header.c\
 	$(SRC)/cbf_nibble_offset.c \
@@ -1133,6 +1148,10 @@ SOURCE   =  $(SRC)/cbf.c               \
 	$(SRC)/md5c.c              \
 	$(SRC)/img.c               \
 	$(SRC_FGETLN) $(SRC_REALPATH)
+ifneq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+SOURCE  += $(SRC)/cbf_hdf5.c \
+	$(SRC)/cbf_hdf5_filter.c
+endif
 
 ifneq ($(CBFLIB_DONT_USE_PY2CIFRW),yes)
 PY2SOURCE  = $(SRC)/drel_lex.py		   \
@@ -1148,6 +1167,7 @@ PY3SOURCE  = $(SRC)/drel_lex.py		   \
 	$(SRC)/drel_prep.py
 endif
 
+ifneq ($(NOFORTRAN),yes)
 F90SOURCE = $(SRC)/fcb_atol_wcnt.f90     \
 	$(SRC)/fcb_ci_strncmparr.f90 \
 	$(SRC)/fcb_exit_binary.f90   \
@@ -1161,8 +1181,8 @@ F90SOURCE = $(SRC)/fcb_atol_wcnt.f90     \
 	$(SRC)/fcb_read_line.f90     \
 	$(SRC)/fcb_read_xds_i2.f90   \
 	$(SRC)/fcb_skip_whitespace.f90
-	
-	
+endif
+
 #
 # Header files
 #
@@ -1179,8 +1199,6 @@ HEADERS   =  $(INCLUDE)/cbf.h               \
 	$(INCLUDE)/cbf_copy.h          \
 	$(INCLUDE)/cbf_file.h          \
 	$(INCLUDE)/cbf_getopt.h        \
-	$(INCLUDE)/cbf_hdf5.h          \
-	$(INCLUDE)/cbf_hdf5_filter.h   \
 	$(INCLUDE)/cbf_lex.h           \
 	$(INCLUDE)/cbf_minicbf_header.h\
 	$(INCLUDE)/cbf_nibble_offset.h \
@@ -1201,6 +1219,10 @@ HEADERS   =  $(INCLUDE)/cbf.h               \
 	$(INCLUDE)/cbff.h              \
 	$(INCLUDE)/md5.h               \
 	$(INCLUDE)/img.h
+ifneq ($(CBFLIB_DONT_BUILD_HDF5),yes)
+HEADERS  += $(INCLUDE)/cbf_hdf5.h \
+	$(INCLUDE)/cbf_hdf5_filter.h
+endif
 
 #
 # m4 macro files
@@ -2393,7 +2415,7 @@ $(BIN)/tiff2cbf: $(LIB)/libcbf.a $(EXAMPLES)/tiff2cbf.c $(EXAMPLES)/tif_sprint.c
 	$(GOPTLIB)	$(GOPTINC) $(TIFF)
 	mkdir -p $(BIN)
 	$(CC) $(CFLAGS) $(LDFLAGS) $(MISCFLAG) $(CBF_REGEXFLAG) $(INCLUDES) $(WARNINGS) \
-	-I$(TIFF)/libtiff $(EXAMPLES)/tiff2cbf.c $(GOPTLIB) -L$(LIB) \
+	-I$(TIFF)/libtiff $(EXAMPLES)/tiff2cbf.c $(EXAMPLES)/tif_sprint.c $(GOPTLIB) -L$(LIB) \
 	-lcbf -L$(TIFF_PREFIX)/lib -ltiff $(REGEX_LIBS_STATIC) $(HDF5LIBS_LOCAL) $(EXTRALIBS) $(HDF5LIBS_SYSTEM) -limg -o $@
 
 #


### PR DESCRIPTION
Exclude Fortran build when specified. Also add missing file in tiff2cbf and update DIALS Makefile