### PR TITLE
Add _array_data_external_data.file_compression.

### DIFF
--- a/doc/cif_img_1.8.6.dic
+++ b/doc/cif_img_1.8.6.dic
@@ -65,6 +65,7 @@ data_cif_img.dic
 #                  _array_data_external_data.archive_format
 #                  _array_data_external_data.archive_path
 #                  _array_data_external_data.format
+#                  _array_data_external_data.file_compression
 #                  _array_data_external_data.frame
 #                  _array_data_external_data.id
 #                  _array_data_external_data.path
@@ -1419,6 +1420,9 @@ save__array_data_external_data.format
     _array_data_external_data.format,
     _array_data_external_data.path, and
     _array_data_external_data.frame  directly.
+    In either case, if the file
+    thus specified has been compressed, _array_data_external_data.file_compression
+    is used to specify the compression type.
 
 ;
 
@@ -1532,7 +1536,59 @@ save__array_data_external_data.format
     Frames with SMV format are contained at data.proteindiffraction.org in a tarred
     archive compressed with bzip2.
 ;
+
+; 
+   loop_
+   _array_data_external_data.id
+   _array_data_external_data.format
+   _array_data_external_data.uri
+   _array_data_external_data.archive_format
+   _array_data_external_data.archive_path
+   _array_data_external_data.file_compression
+   1 SMV
+       https://data.proteindiffraction.org/ssgcid/4jga.tar
+       TAR
+       3lls/series/200873f12_x0085.img.bz2 BZ2
+   1 SMV
+       https://data.proteindiffraction.org/ssgcid/4jga.tar
+       TAR
+       3lls/series/200873f12_x0085.img.bz2 BZ2
+;
+
+;
+
+   Frames with SMV format are contained at data.proteindiffraction.org in a tarred
+   archive with each frame individually compressed with Bzip2.
+   
+;
+
+
     save_
+
+save__array_data_external_data.file_compression
+   _item_description.description
+;
+
+   The type of compression used for the file corresponding to
+   a single frame, if any.
+
+;
+
+   _item.name                 '_array_data_external_data.file_compression'
+   _item.category_id            array_data_external_data
+   _item.mandatory_code         no
+   _item.type_code              code
+   _item_default.value          .
+
+   loop_
+   _item_enumeration.value
+   _item_enumeration.detail
+   GZ            'A Gzipped file'
+   BZ2           'File compressed with Bzip2'
+   .             'Individual file compression not used'
+
+save_
+
 
 save__array_data_external_data.id
     _item_description.description


### PR DESCRIPTION
This pull request updates the previous request #39. The new data name `_array_data_external_data.file_compression` is needed to cover the situation where each individual file containing a single frame has been compressed, as happens often in proteindiffraction.org (for example).