### PR TITLE
Add --reverse option, add recognition of old AustSync detector.

### DIFF
--- a/examples/adscimg2cbf.c
+++ b/examples/adscimg2cbf.c
@@ -90,6 +90,7 @@ static void usage( void )
     fprintf(stderr,"\t--beam_center_mosflm		Beam center in ADSC header: MOSFLM coordinates.\n");
     fprintf(stderr,"\t--beam_center_ulhc		Beam center in ADSC header: origin: upper left hand corner of image.(HKL mm)\n");
     fprintf(stderr,"\t--beam_center_llhc		Beam center in ADSC header: origin: lower left hand corner of image.(adxv mm)\n");
+    fprintf(stderr,"\t--reverse                         Rotation axis points in opposite direction to fast pixel direction on detector");
     fprintf(stderr,"\t--region-of-interest=fastlow,fasthigh,slowlow,slowhigh\n");
     fprintf(stderr,"\t                          Region of interest to map to CBF\n");
     fprintf(stderr,"\t--sensor-thickness=0.00000000\n");
@@ -142,7 +143,8 @@ int adscimg2cbf_sub2(char *header,
                      const char *cliphighstr,
                      const char *rad_smoothstr,
                      int transpose,
-                     int interleave);
+                     int interleave,
+                     int reverse);
 
 
 int	main(int argc, char *argv[])
@@ -171,6 +173,7 @@ int	main(int argc, char *argv[])
     int     bin=0;
     int     transpose=0;
     int     interleave=0;
+    int     reverse=1;
     int     *new_int_data, *old_int_data;
     size_t  new_int_data_size, old_int_data_size;
     double  thickness=0.;
@@ -194,7 +197,7 @@ int	main(int argc, char *argv[])
 					".img.Z",
 					NULL
 				     };
-    static char	*flags[32] = {
+    static char	*flags[33] = {
 					"--cbf_byte_offset",            /* 0 */
 					"--cbf_packed_v2",              /* 1 */
 					"--cbf_packed",                 /* 2 */
@@ -226,6 +229,7 @@ int	main(int argc, char *argv[])
                     "--output",                     /*28 */
                     "--transpose",                  /*29 */
                     "--interleave",                 /*30 */
+                    "--reverse",                    /*31 */
 					NULL
 				   };
 
@@ -374,6 +378,9 @@ int	main(int argc, char *argv[])
                     } else {
                         interleave = atoi(argval[1]);
                     }
+                    break;
+                case 31:
+                    reverse = -1;
                     break;
 
             }
@@ -628,7 +635,8 @@ int	main(int argc, char *argv[])
                                           cliphighstr,
                                           rad_smoothstr,
                                           transpose,
-                                          interleave);
+                                          interleave,
+                                          reverse);
             free(hptr);
             if (old_int_data && old_int_data_size) free(old_int_data);
             old_int_data = new_int_data;

--- a/examples/adscimg2cbf_sub.c
+++ b/examples/adscimg2cbf_sub.c
@@ -390,8 +390,9 @@ static char	*which_facility(int serial_number)
 		case 927:	
 			return("soleil");
 			break;
+                case 457:
 		case 928:
-			return("as");
+			return("as_mx1");
 			break;
 		case 929:
 			return("pohang");
@@ -496,7 +497,8 @@ int	adscimg2cbf_sub2(char *header,
                      const char * cliphighstr,
                      const char * rad_smoothstr,
                      int transpose,
-                     int interleave)
+                     int interleave,
+                     int reverse)
 {
     FILE *out;
     
@@ -1310,6 +1312,15 @@ int	adscimg2cbf_sub2(char *header,
         cbf_failnez (cbf_set_doublevalue  (cbf, "%.2f", 0.0));
         
         /* Make the _axis category */
+
+        /* The default detector axis definitions assume that
+        the rotation axis points in the same direction as 
+        ELEMENT_X. If reverse is set, the rotation axis points 
+        in the opposite direction to ELEMENT_X which is
+        equivalent to a 180 degree rotation about the Z axis
+        and thus X-> -X and Y -> -Y compared to the default
+        axes.
+        */
         
         cbf_failnez (cbf_require_category (cbf, "axis"));
         
@@ -1408,11 +1419,11 @@ int	adscimg2cbf_sub2(char *header,
         cbf_failnez (cbf_next_row         (cbf));
         cbf_failnez (cbf_set_value        (cbf, "0"));
         cbf_failnez (cbf_next_row         (cbf));
-        cbf_failnez (cbf_set_value        (cbf, "1"));
+        cbf_failnez (cbf_set_integervalue (cbf, reverse));
         cbf_failnez (cbf_next_row         (cbf));
         cbf_failnez (cbf_set_value        (cbf, "0"));
         cbf_failnez (cbf_next_row         (cbf));
-        cbf_failnez (cbf_set_value        (cbf, "1"));
+        cbf_failnez (cbf_set_integervalue (cbf, reverse));
         cbf_failnez (cbf_next_row         (cbf));
         cbf_failnez (cbf_set_value        (cbf, "0"));
         
@@ -1422,19 +1433,19 @@ int	adscimg2cbf_sub2(char *header,
         cbf_failnez (cbf_next_row         (cbf));
         cbf_failnez (cbf_set_value        (cbf, "0"));
         cbf_failnez (cbf_next_row         (cbf));
-        cbf_failnez (cbf_set_value        (cbf, "-1"));
+        cbf_failnez (cbf_set_integervalue (cbf, -1*reverse));
         cbf_failnez (cbf_next_row         (cbf));
         cbf_failnez (cbf_set_value        (cbf, "0"));
         cbf_failnez (cbf_next_row         (cbf));
-        cbf_failnez (cbf_set_value        (cbf, "1"));
+        cbf_failnez (cbf_set_integervalue (cbf, reverse));
         cbf_failnez (cbf_next_row         (cbf));
         cbf_failnez (cbf_set_value        (cbf, "0"));
         cbf_failnez (cbf_next_row         (cbf));
-        cbf_failnez (cbf_set_value        (cbf, "1"));
+        cbf_failnez (cbf_set_integervalue (cbf, reverse));
         cbf_failnez (cbf_next_row         (cbf));
         cbf_failnez (cbf_set_value        (cbf, "0"));
         cbf_failnez (cbf_next_row         (cbf));
-        cbf_failnez (cbf_set_value        (cbf, "1"));
+        cbf_failnez (cbf_set_integervalue (cbf, -1*reverse));
         
         cbf_failnez (cbf_require_column   (cbf, "vector[3]"));
         cbf_failnez (cbf_rewind_row       (cbf));
@@ -1475,7 +1486,7 @@ int	adscimg2cbf_sub2(char *header,
         cbf_failnez (cbf_next_row         (cbf));
         cbf_failnez (cbf_set_value        (cbf, "0"));
         cbf_failnez (cbf_next_row         (cbf));
-        cbf_failnez (cbf_set_doublevalue  (cbf, "%.3f", det_beam_center_to_origin_dist_x));
+        cbf_failnez (cbf_set_doublevalue  (cbf, "%.3f", det_beam_center_to_origin_dist_x * reverse));
         cbf_failnez (cbf_next_row         (cbf));
         cbf_failnez (cbf_set_value        (cbf, "0"));
         
@@ -1498,7 +1509,7 @@ int	adscimg2cbf_sub2(char *header,
         cbf_failnez (cbf_next_row         (cbf));
         cbf_failnez (cbf_set_value        (cbf, "0"));
         cbf_failnez (cbf_next_row         (cbf));
-        cbf_failnez (cbf_set_doublevalue  (cbf, "%.3f", det_beam_center_to_origin_dist_y));
+        cbf_failnez (cbf_set_doublevalue  (cbf, "%.3f", det_beam_center_to_origin_dist_y * reverse));
         cbf_failnez (cbf_next_row         (cbf));
         cbf_failnez (cbf_set_value        (cbf, "0"));
         
@@ -1670,7 +1681,7 @@ int	adscimg2cbf_sub2(char *header,
         cbf_failnez (cbf_rewind_row       (cbf));
         cbf_failnez (cbf_set_doublevalue  (cbf, "%.6f", pixel_size));
         cbf_failnez (cbf_next_row         (cbf));
-        cbf_failnez (cbf_set_doublevalue  (cbf, "%.6f", -pixel_size));
+        cbf_failnez (cbf_set_doublevalue  (cbf, "%.6f", pixel_size));
         
         
         /* Make the _array_intensities category */
@@ -2094,6 +2105,7 @@ int     adscimg2cbf_sub(char *header,
                             NULL,
                             NULL,
                             0,
-                            0);
+                            0,
+                            1);
 }
 


### PR DESCRIPTION
The current adsc converter implicitly assumes that the X axis direction coincides with the fast direction on the detector. The `--reverse` option has been added to handle the case that these axes point in opposite directions. A reversal in X direction is equivalent to a rotation of 180 degrees around Z, thus X->-X and Y->-Y.

In addition, the `ELEMENT_Y` axis for the detector was originally fixed to `[0 1 0]` which is "up" for the non-reverse case, even though the "natural" direction for `ELEMENT_Y` is always down because the origin of detector coordinates is at the top left looking from the sample. As a result, the `displacement_increment` for this axis was negative. The current pull request changes this so that the `ELEMENT_Y` direction is always down and the `displacement_increment` is always positive.

Recognition of an old Australian Synchrotron MX-1 detector has also been added.