### PR TITLE
Add ImgCIF 1.8.7 and clarify overload

### DIFF
--- a/doc/cif_img_1.8.7.dic
+++ b/doc/cif_img_1.8.7.dic
@@ -15,8 +15,8 @@ data_cif_img.dic
 #             and Crystallographic Binary File Dictionary (CBF)              #
 #            Extending the Macromolecular CIF Dictionary (mmCIF)             #
 #                                                                            #
-#                              Version 1.8.6                                 #
-#                              of 2022-05-11                                 #
+#                              Version 1.8.7                                 #
+#                              of 2022-12-31                                 #
 #                                                                            #
 #                                                                            #
 #    ###################################################################     #
@@ -697,7 +697,7 @@ data_cif_img.dic
 
 ;
     _dictionary.title           cif_img.dic
-    _dictionary.version         1.8.6
+    _dictionary.version         1.8.7
     _dictionary.datablock_id    cif_img.dic
 
 #########################
@@ -10951,6 +10951,12 @@ save__diffrn_frame_data.details
     _dictionary_history.version
     _dictionary_history.update
     _dictionary_history.revision
+
+    1.8.7    2022-12-31
+
+;   Start of new version
+
+;
 
     1.8.6    2022-05-11
 

--- a/doc/cif_img_1.8.7.dic
+++ b/doc/cif_img_1.8.7.dic
@@ -1,0 +1,11735 @@
+#  [IUCr Home Page]  [CIF Home Page] [CBF/imgCIF] [CBFlib] #
+
+  # imgCIF/CBF #
+
+  # Extensions Dictionary #
+
+data_cif_img.dic
+
+    _datablock.id               cif_img.dic
+    _datablock.description
+;
+##############################################################################
+#                                                                            #
+#                       Image CIF Dictionary (imgCIF)                        #
+#             and Crystallographic Binary File Dictionary (CBF)              #
+#            Extending the Macromolecular CIF Dictionary (mmCIF)             #
+#                                                                            #
+#                              Version 1.8.6                                 #
+#                              of 2022-05-11                                 #
+#                                                                            #
+#                                                                            #
+#    ###################################################################     #
+#    # *** WARNING *** THIS IS A DRAFT FOR DISCUSSION *** WARNING ***  #     #
+#    #                 SUBJECT TO CHANGE WITHOUT NOTICE                #     #
+#    #       SEND COMMENTS TO imgcif-l@iucr.org CITING THE VERSION     #     #
+#    ###################################################################     #
+#            This draft edited by B. McMahon and H. J. Bernstein             #
+#                                                                            #
+#     by Andrew P. Hammersley, Herbert J. Bernstein and John D. Westbrook    #
+#                                                                            #
+# This dictionary was adapted from a format discussed at the imgCIF Workshop #
+# held at BNL Oct 1997 and the Crystallographic Binary File Format Draft     #
+# Proposal by Andrew Hammersley.  The first DDL 2.1 Version was created by   #
+# John Westbrook.  This version is being prepared in support of the 2021     #
+# revisions to ITVG, and was drafted by Herbert J. Bernstein and             #
+# incorporates comments by James Hester, I. David Brown, John Westbrook,     #
+# Brian McMahon, Bob Sweet, Paul Ellis, Harry Powell, Wilfred Li,            #
+# Gotzon Madariaga, Frances C. Bernstein, Chris Nielsen, Nicola Ashcroft and #
+# others and reflects comments in                                            #
+# Bernstein, H. J., Foerster, A., Bhowmick, A., Brewster, A. S.,             #
+# Brockhauser, S., Gelisio, L., Hall, D. R., Leonarski, F., Mariani, V.,     #
+# Santoni, G., Vonrhein, C. & Winter, G. (2020). "Gold Standard for          #
+# Macromolecular Crystallography Diffraction Data", IUCrJ, 7, 784--792,      #
+# https://doi.org/10.1107/S2052252520008672,                                 #
+# https://doi.org//10.1107/S2052252520008672/ti5018sup1.pdf,                 #
+# https://doi.org//10.1107/S2052252520008672/ti5018sup2.pdf                  #
+##############################################################################
+#    CONTENTS
+#
+#        CATEGORY_GROUP_LIST
+#        SUB_CATEGORY
+#
+#        category  ARRAY_DATA
+#
+#                  _array_data.array_id
+#                  _array_data.binary_id
+#                  _array_data.data
+#                  _array_data.external_data_id
+#                  _array_data.header_contents
+#                  _array_data.header_convention
+#                  _array_data.variant
+#
+#        category  ARRAY_DATA_EXTERNAL_DATA
+#
+#                  _array_data_external_data.archive_format
+#                  _array_data_external_data.archive_path
+#                  _array_data_external_data.format
+#                  _array_data_external_data.frame
+#                  _array_data_external_data.id
+#                  _array_data_external_data.path
+#                  _array_data_external_data.uri
+#                  _array_data_external_data.variant
+#                  _array_data_external_data.version
+#
+#        category  ARRAY_ELEMENT_SIZE
+#
+#                  _array_element_size.array_id
+#                  _array_element_size.index
+#                  _array_element_size.size
+#                  _array_element_size.variant
+#
+#        category  ARRAY_INTENSITIES
+#
+#                  _array_intensities.array_id
+#                  _array_intensities.binary_id
+#                  _array_intensities.details
+#                  _array_intensities.gain
+#                  _array_intensities.gain_esd
+#                  _array_intensities.linearity
+#                  _array_intensities.offset
+#                  _array_intensities.overload
+#                  _array_intensities.pixel_fast_bin_size
+#                  _array_intensities.pixel_slow_bin_size
+#                  _array_intensities.pixel_binning_method
+#                  _array_intensities.scaling
+#                  _array_intensities.undefined_value
+#                  _array_intensities.underload
+#                  _array_intensities.variant
+#
+#        category  ARRAY_STRUCTURE
+#
+#                  _array_structure.byte_order
+#                  _array_structure.compression_type
+#                  _array_structure.compression_type_flag
+#                  _array_structure.encoding_type
+#                  _array_structure.id
+#                  _array_structure.variant
+#
+#        category  ARRAY_STRUCTURE_LIST
+#
+#                  _array_structure_list.axis_set_id
+#                  _array_structure_list.array_id
+#                  _array_structure_list.array_section_id
+#                  _array_structure_list.dimension
+#                  _array_structure_list.direction
+#                  _array_structure_list.index
+#                  _array_structure_list.precedence
+#                  _array_structure_list.variant
+#
+#        category  ARRAY_STRUCTURE_LIST_SECTION
+#
+#                  _array_structure_list_section.array_id
+#                  _array_structure_list_section.end
+#                  _array_structure_list_section.id
+#                  _array_structure_list_section.index
+#                  _array_structure_list_section.start
+#                  _array_structure_list_section.stride
+#                  _array_structure_list_section.variant
+#
+#        category  ARRAY_STRUCTURE_LIST_AXIS
+#
+#                  _array_structure_list_axis.axis_id
+#                  _array_structure_list_axis.axis_set_id
+#                  _array_structure_list_axis.angle
+#                  _array_structure_list_axis.angle_increment
+#                  _array_structure_list_axis.angular_pitch
+#                  _array_structure_list_axis.displacement
+#                  _array_structure_list_axis.displacement_increment
+#                  _array_structure_list_axis.fract_displacement
+#                  _array_structure_list_axis.fract_displacement_increment
+#                  _array_structure_list_axis.radial_pitch
+#                  _array_structure_list_axis.reference_angle
+#                  _array_structure_list_axis.reference_displacement
+#                  _array_structure_list_axis.variant
+#
+#        category  AXIS
+#
+#                  _axis.depends_on
+#                  _axis.equipment
+#                  _axis.equipment_component
+#                  _axis.id
+#                  _axis.offset[1]
+#                  _axis.offset[2]
+#                  _axis.offset[3]
+#                  _axis.rotation
+#                  _axis.rotation_axis
+#                  _axis.type
+#                  _axis.system
+#                  _axis.vector[1]
+#                  _axis.vector[2]
+#                  _axis.vector[3]
+#                  _axis.variant
+#
+#        category  DIFFRN_DATA_FRAME
+#
+#                  _diffrn_data_frame.array_id
+#                  _diffrn_data_frame.array_section_id
+#                  _diffrn_data_frame.binary_id
+#                  _diffrn_data_frame.center_fast
+#                  _diffrn_data_frame.center_slow
+#                  _diffrn_data_frame.center_units
+#                  _diffrn_data_frame.detector_element_id
+#                  _diffrn_data_frame.id
+#                  _diffrn_data_frame.details
+#                  _diffrn_data_frame.variant
+#
+#        category  DIFFRN_DETECTOR
+#
+#                  _diffrn_detector.details
+#                  _diffrn_detector.detector
+#                  _diffrn_detector.diffrn_id
+#                  _diffrn_detector.dtime
+#                  _diffrn_detector.gain_setting
+#                  _diffrn_detector.id
+#                  _diffrn_detector.layer_thickness
+#                  _diffrn_detector.number_of_axes
+#                  _diffrn_detector.type
+#                  _diffrn_detector.variant
+#
+#        category  DIFFRN_DETECTOR_AXIS
+#
+#                  _diffrn_detector_axis.axis_id
+#                  _diffrn_detector_axis.detector_id
+#                  _diffrn_detector_axis.variant
+#
+#        category  DIFFRN_DETECTOR_ELEMENT
+#
+#                  _diffrn_detector_element.id
+#                  _diffrn_detector_element.detector_id
+#                  _diffrn_detector_element.reference_center_fast
+#                  _diffrn_detector_element.reference_center_slow
+#                  _diffrn_detector_element.reference_center_units
+#                  _diffrn_detector_element.variant
+#
+#        category  DIFFRN_MEASUREMENT
+#
+#                  _diffrn_measurement.diffrn_id
+#                  _diffrn_measurement.details
+#                  _diffrn_measurement.device
+#                  _diffrn_measurement.device_details
+#                  _diffrn_measurement.device_type
+#                  _diffrn_measurement.id
+#                  _diffrn_measurement.method
+#                  _diffrn_measurement.number_of_axes
+#                  _diffrn_measurement.sample_detector_distance
+#                  _diffrn_measurement.sample_detector_voffset
+#                  _diffrn_measurement.specimen_support
+#                  _diffrn_measurement.variant
+#
+#        category  DIFFRN_MEASUREMENT_AXIS
+#
+#                  _diffrn_measurement_axis.axis_id
+#                  _diffrn_measurement_axis.measurement_device
+#                  _diffrn_measurement_axis.measurement_id
+#                  _diffrn_measurement_axis.variant
+#
+#        category  DIFFRN_RADIATION
+#
+#                  _diffrn_radiation.beam_width
+#                  _diffrn_radiation.beam_height
+#                  _diffrn_radiation.beam_flux
+#                  _diffrn_radiation.collimation
+#                  _diffrn_radiation.diffrn_id
+#                  _diffrn_radiation.div_x_source
+#                  _diffrn_radiation.div_y_source
+#                  _diffrn_radiation.div_x_y_source
+#                  _diffrn_radiation.filter_edge
+#                  _diffrn_radiation.inhomogeneity
+#                  _diffrn_radiation.monochromator
+#                  _diffrn_radiation.polarisn_norm
+#                  _diffrn_radiation.polarisn_ratio
+#                  _diffrn_radiation.polarisn_norm_esd
+#                  _diffrn_radiation.polarisn_ratio_esd
+#                  _diffrn_radiation.polarizn_source_norm
+#                  _diffrn_radiation.polarizn_source_norm_esd
+#                  _diffrn_radiation.polarizn_source_ratio
+#                  _diffrn_radiation.polarizn_source_ratio_esd
+#                  _diffrn_radiation.polarizn_Stokes_I
+#                  _diffrn_radiation.polarizn_Stokes_Q
+#                  _diffrn_radiation.polarizn_Stokes_U
+#                  _diffrn_radiation.polarizn_Stokes_V
+#                  _diffrn_radiation.polarizn_Stokes_I_esd
+#                  _diffrn_radiation.polarizn_Stokes_Q_esd
+#                  _diffrn_radiation.polarizn_Stokes_U_esd
+#                  _diffrn_radiation.polarizn_Stokes_V_esd
+#                  _diffrn_radiation.probe
+#                  _diffrn_radiation.type
+#                  _diffrn_radiation.variant
+#                  _diffrn_radiation.wavelength_id
+#                  _diffrn_radiation.xray_symbol
+#
+#        category  DIFFRN_REFLN
+#
+#                  _diffrn_refln.frame_id
+#                  _diffrn_refln.variant
+#
+#        category  DIFFRN_SCAN
+#
+#                  _diffrn_scan.id
+#                  _diffrn_scan.date_end
+#                  _diffrn_scan.date_end_estimated
+#                  _diffrn_scan.date_start
+#                  _diffrn_scan.integration_time
+#                  _diffrn_scan.frame_id_start
+#                  _diffrn_scan.frame_id_end
+#                  _diffrn_scan.frames
+#                  _diffrn_scan.time_period
+#                  _diffrn_scan.time_rstrt_incr
+#                  _diffrn_scan.variant
+#
+#        category  DIFFRN_SCAN_AXIS
+#
+#                  _diffrn_scan_axis.axis_id
+#                  _diffrn_scan_axis.angle_start
+#                  _diffrn_scan_axis.angle_range
+#                  _diffrn_scan_axis.angle_increment
+#                  _diffrn_scan_axis.angle_rstrt_incr
+#                  _diffrn_scan_axis.displacement_start
+#                  _diffrn_scan_axis.displacement_range
+#                  _diffrn_scan_axis.displacement_increment
+#                  _diffrn_scan_axis.displacement_rstrt_incr
+#                  _diffrn_scan_axis.reference_angle
+#                  _diffrn_scan_axis.reference_displacement
+#                  _diffrn_scan_axis.scan_id
+#                  _diffrn_scan_axis.variant
+#
+#        category  DIFFRN_SCAN_COLLECTION
+#
+#                  _diffrn_scan_collection.details
+#                  _diffrn_scan_collection.scan_id
+#                  _diffrn_scan_collection.type
+#                  _diffrn_scan_collection.translation_width
+#                  _diffrn_scan_collection.variant
+#
+#        category  DIFFRN_SCAN_FRAME
+#
+#                  _diffrn_scan_frame.date
+#                  _diffrn_scan_frame.frame_id
+#                  _diffrn_scan_frame.frame_number
+#                  _diffrn_scan_frame.integration_time
+#                  _diffrn_scan_frame.polarizn_Stokes_I
+#                  _diffrn_scan_frame.polarizn_Stokes_Q
+#                  _diffrn_scan_frame.polarizn_Stokes_U
+#                  _diffrn_scan_frame.polarizn_Stokes_V
+#                  _diffrn_scan_frame.polarizn_Stokes_I_esd
+#                  _diffrn_scan_frame.polarizn_Stokes_Q_esd
+#                  _diffrn_scan_frame.polarizn_Stokes_U_esd
+#                  _diffrn_scan_frame.polarizn_Stokes_V_esd
+#                  _diffrn_scan_frame.scan_id
+#                  _diffrn_scan_frame.time_period
+#                  _diffrn_scan_frame.time_rstrt_incr
+#                  _diffrn_scan_frame.variant
+#
+#        category  DIFFRN_SCAN_FRAME_AXIS
+#
+#                  _diffrn_scan_frame_axis.axis_id
+#                  _diffrn_scan_frame_axis.angle
+#                  _diffrn_scan_frame_axis.angle_increment
+#                  _diffrn_scan_frame_axis.angle_rstrt_incr
+#                  _diffrn_scan_frame_axis.displacement
+#                  _diffrn_scan_frame_axis.displacement_increment
+#                  _diffrn_scan_frame_axis.displacement_rstrt_incr
+#                  _diffrn_scan_frame_axis.reference_angle
+#                  _diffrn_scan_frame_axis.reference_displacement
+#                  _diffrn_scan_frame_axis.frame_id
+#                  _diffrn_scan_frame_axis.variant
+#
+#        category  DIFFRN_SCAN_FRAME_MONITOR
+#
+#                  _diffrn_scan_frame_monitor.id
+#                  _diffrn_scan_frame_monitor.detector_id
+#                  _diffrn_scan_frame_monitor.frame_id
+#                  _diffrn_scan_frame_monitor.integration_time
+#                  _diffrn_scan_frame_monitor.monitor_value
+#                  _diffrn_scan_frame_monitor.scan_id
+#                  _diffrn_scan_frame_monitor.variant
+#
+#        category  MAP
+#
+#                  _map.details
+#                  _map.diffrn_id
+#                  _map.entry_id
+#                  _map.id
+#                  _map.variant
+#
+#        category  MAP_SEGMENT
+#
+#                  _map_segment.array_id
+#                  _map_segment.array_section_id
+#                  _map_segment.binary_id
+#                  _map_segment.mask_array_id
+#                  _map_segment.mask_array_section_id
+#                  _map_segment.mask_binary_id
+#                  _map_segment.id
+#                  _map_segment.map_id
+#                  _map_segment.details
+#                  _map_segment.variant
+#
+#        category  VARIANT
+#
+#                  _variant.details
+#                  _variant.diffrn_id
+#                  _variant.entry_id
+#                  _variant.role
+#                  _variant.timestamp
+#                  _variant.variant
+#                  _variant.variant_of
+#
+#       ***DEPRECATED*** data items
+#
+#                  _diffrn_detector_axis.id
+#                  _diffrn_detector_element.center[1]
+#                  _diffrn_detector_element.center[2]
+#                  _diffrn_measurement_axis.id
+#                  _diffrn_scan_frame_monitor.value
+#
+#       ***DEPRECATED*** category  DIFFRN_FRAME_DATA
+#
+#                  _diffrn_frame_data.array_id
+#                  _diffrn_frame_data.binary_id
+#                  _diffrn_frame_data.detector_element_id
+#                  _diffrn_frame_data.id
+#                  _diffrn_frame_data.details
+#
+#        ITEM_TYPE_LIST
+#        ITEM_UNITS_LIST
+#        DICTIONARY_HISTORY
+#
+##############################################################################
+
+#Category Group Table:
++--------------------------------------------------------------------------------------------------------------------+
+|ARRAY_DATA_GROUP|Categories that describe array data.                                                               |
+|                |---------------------------------------------------------------------------------------------------|
+|                |+-------------------------------------------------------------------------------------------------+|
+|                || ARRAY_DATA               | Data items in the ARRAY_DATA category are the containers for the     ||
+|                ||                          | array data items described in the category ARRAY_STRUCTURE.          ||
+|                ||                          |                                                                      ||
+|                ||                          | It is recognized that the data in this category need to be used in   ||
+|                ||                          | two distinct ways. During a data collection the lack of ancillary    ||
+|                ||                          | data and timing constraints in processing data may dictate the need  ||
+|                ||                          | to make a 'miniCBF' nothing more than an essential minimum of        ||
+|                ||                          | information to record the results of the data collection. In that    ||
+|                ||                          | case it is proper to use the ARRAY_DATA category as a container for  ||
+|                ||                          | just a single image and a compacted, beam-line dependent list of     ||
+|                ||                          | data collection parameter values. In such a case, only the tags      ||
+|                ||                          | '_array_data.header_convention', '_array_data.header_contents' and   ||
+|                ||                          | '_array_data.data' need be populated.                                ||
+|                ||                          |                                                                      ||
+|                ||                          | For full processing and archiving, most of the tags in this          ||
+|                ||                          | dictionary will need to be populated.                                ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | ARRAY_DATA_EXTERNAL_DATA     | Data items in the ARRAY_DATA_EXTERNAL_DATA category      | ||
+|                || |   |                              | record information needed to refer to data arrays in     | ||
+|                || |   |                              | external datasets.  All necessary metadata must also     | ||
+|                || |   |                              | be copied or linked.                                     | ||
+|                || |   |-----------------------------------------------------------------------------------------| ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                |+-------------------------------------------------------------------------------------------------+|
+|                ||--------------------------+----------------------------------------------------------------------||
+|                || ARRAY_ELEMENT_SIZE       | Data items in the ARRAY_ELEMENT_SIZE category record the physical    ||
+|                ||                          | size of array elements along each array dimension.                   ||
+|                ||--------------------------+----------------------------------------------------------------------||
+|                || ARRAY_INTENSITIES        | Data items in the ARRAY_INTENSITIES category record the information  ||
+|                ||                          | required to recover the intensity data from the set of data values   ||
+|                ||                          | stored in the ARRAY_DATA category.                                   ||
+|                ||                          |                                                                      ||
+|                ||                          | The detector may have a complex relationship between the raw         ||
+|                ||                          | intensity values and the number of incident photons. In most cases,  ||
+|                ||                          | the number stored in the final array will have a simple linear       ||
+|                ||                          | relationship to the actual number of incident photons, given by      ||
+|                ||                          | _array_intensities.gain. If raw, uncorrected values are presented    ||
+|                ||                          | (e.g. for calibration experiments), the value of                     ||
+|                ||                          | _array_intensities.linearity will be 'raw' and                       ||
+|                ||                          | _array_intensities.gain will not be used.                            ||
+|                ||--------------------------+----------------------------------------------------------------------||
+|                || ARRAY_STRUCTURE          | Data items in the ARRAY_STRUCTURE category record the organization   ||
+|                ||                          | and encoding of array data that may be stored in the ARRAY_DATA      ||
+|                ||                          | category.                                                            ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | ARRAY_STRUCTURE_LIST         | Data items in the ARRAY_STRUCTURE_LIST category record   | ||
+|                || |   |                              | the size and organization of each array dimension.       | ||
+|                || |   |                              |                                                          | ||
+|                || |   |                              | The relationship to physical axes may be given.          | ||
+|                || |   |-----------------------------------------------------------------------------------------| ||
+|                || |   | +-------------------------------------------------------------------------------------+ | ||
+|                || |   | |   | ARRAY_STRUCTURE_LIST_SECTION | Data items in the ARRAY_STRUCTURE_LIST_SECTION   | | ||
+|                || |   | |   |                              | category identify the dimension-by-dimension     | | ||
+|                || |   | |   |                              | start, end and stride of each section of an      | | ||
+|                || |   | |   |                              | array that is to be referenced.                  | | ||
+|                || |   | |   |                              |                                                  | | ||
+|                || |   | |   |                              | For any array of array_id, ARRAYID, array        | | ||
+|                || |   | |   |                              | section ids of the form                          | | ||
+|                || |   | |   |                              | ARRAYID(start1:end1:stride1,start2:end2:stride2, | | ||
+|                || |   | |   |                              | ...)                                             | | ||
+|                || |   | |   |                              | are defined by default.                          | | ||
+|                || |   | |   |------------------------------+--------------------------------------------------| | ||
+|                || |   | |   | ARRAY_STRUCTURE_LIST_AXIS    | Data items in the ARRAY_STRUCTURE_LIST_AXIS      | | ||
+|                || |   | |   |                              | category describe the physical settings of sets  | | ||
+|                || |   | |   |                              | of axes for the centres of pixels that           | | ||
+|                || |   | |   |                              | correspond to data points described in the       | | ||
+|                || |   | |   |                              | ARRAY_STRUCTURE_LIST category.                   | | ||
+|                || |   | |   |                              |                                                  | | ||
+|                || |   | |   |                              | In the simplest cases, the physical increments   | | ||
+|                || |   | |   |                              | of a single axis correspond to the increments of | | ||
+|                || |   | |   |                              | a single array index. More complex               | | ||
+|                || |   | |   |                              | organizations, e.g. spiral scans, may require    | | ||
+|                || |   | |   |                              | coupled motions along multiple axes.             | | ||
+|                || |   | |   |                              |                                                  | | ||
+|                || |   | |   |                              | Note that a spiral scan uses two coupled axes:   | | ||
+|                || |   | |   |                              | one for the angular direction and one for the    | | ||
+|                || |   | |   |                              | radial direction. This differs from a            | | ||
+|                || |   | |   |                              | cylindrical scan for which the two axes are not  | | ||
+|                || |   | |   |                              | coupled into one set.                            | | ||
+|                || |   | +-------------------------------------------------------------------------------------+ | ||
+|                || |   |-----------------------------------------------------------------------------------------| ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                |+-------------------------------------------------------------------------------------------------+|
+|----------------+---------------------------------------------------------------------------------------------------|
+|AXIS_GROUP      |Categories that describe axes.                                                                     |
+|                |---------------------------------------------------------------------------------------------------|
+|                |+-------------------------------------------------------------------------------------------------+|
+|                || AXIS | Data items in the AXIS category record the information required to describe the various  ||
+|                ||      | goniometer, detector, source and other axes needed to specify a data collection or the   ||
+|                ||      | axes defining the coordinate system of an image.                                         ||
+|                ||      |                                                                                          ||
+|                ||      | The location of each axis is specified by two vectors: the axis itself, given by a unit  ||
+|                ||      | vector in the direction of the axis, and an offset to the base of the unit vector.       ||
+|                ||      |                                                                                          ||
+|                ||      | The vectors defining an axis are referenced to an appropriate coordinate system. The     ||
+|                ||      | axis vector, itself, is a dimensionless unit vector. Where meaningful, the offset vector ||
+|                ||      | is given in millimetres. In coordinate systems not measured in metres, the offset is not ||
+|                ||      | specified and is taken as zero.                                                          ||
+|                ||      |                                                                                          ||
+|                ||      | The available coordinate systems are:                                                    ||
+|                ||      |                                                                                          ||
+|                ||      | The imgCIF standard laboratory coordinate system                                         ||
+|                ||      | The NeXus/HDF5 McStas laboratory coordinate system                                       ||
+|                ||      | The direct lattice (fractional atomic coordinates)                                       ||
+|                ||      | The orthogonal Cartesian coordinate system (real space)                                  ||
+|                ||      | The reciprocal lattice                                                                   ||
+|                ||      | An abstract orthogonal Cartesian coordinate frame                                        ||
+|                |+-------------------------------------------------------------------------------------------------+|
+|----------------+---------------------------------------------------------------------------------------------------|
+|DIFFRN_GROUP    |Categories that describe details of the diffraction experiment.                                    |
+|                |---------------------------------------------------------------------------------------------------|
+|                |+-------------------------------------------------------------------------------------------------+|
+|                || DIFFRN_DATA_FRAME          | Data items in the DIFFRN_DATA_FRAME category record the details    ||
+|                ||                            | about each frame of data.                                          ||
+|                ||                            |                                                                    ||
+|                ||                            | The items in this category were previously in a DIFFRN_FRAME_DATA  ||
+|                ||                            | category, which is now deprecated. The items from the old category ||
+|                ||                            | are provided as aliases but should not be used for new work.       ||
+|                ||----------------------------+--------------------------------------------------------------------||
+|                || DIFFRN_DETECTOR            | Data items in the DIFFRN_DETECTOR category describe the detector   ||
+|                ||                            | used to measure the scattered radiation, including any analyser    ||
+|                ||                            | and post-sample collimation.                                       ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | DIFFRN_DETECTOR_AXIS | Data items in the DIFFRN_DETECTOR_AXIS category associate axes   | ||
+|                || |   |                      | with detectors.                                                  | ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | DIFFRN_DETECTOR_ELEMENT | Data items in the DIFFRN_DETECTOR_ELEMENT category record the | ||
+|                || |   |                         | details about spatial layout and other characteristics of     | ||
+|                || |   |                         | each element of a detector which may have multiple elements.  | ||
+|                || |   |                         |                                                               | ||
+|                || |   |                         | In most cases, giving more detailed information in            | ||
+|                || |   |                         | ARRAY_STRUCTURE_LIST and ARRAY_STRUCTURE_LIST_AXIS is         | ||
+|                || |   |                         | preferable to simply providing the centre of the detector     | ||
+|                || |   |                         | element.                                                      | ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || DIFFRN_MEASUREMENT         | Data items in the DIFFRN_MEASUREMENT category record details about ||
+|                ||                            | the device used to orient and/or position the crystal during data  ||
+|                ||                            | measurement and the manner in which the diffraction data were      ||
+|                ||                            | measured.                                                          ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | DIFFRN_MEASUREMENT_AXIS | Data items in the DIFFRN_MEASUREMENT_AXIS category associate  | ||
+|                || |   |                         | axes with goniometers.                                        | ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || DIFFRN_RADIATION           | Data items in the DIFFRN_RADIATION category describe the radiation ||
+|                ||                            | used for measuring diffraction intensities, its collimation and    ||
+|                ||                            | monochromatization before the sample.                              ||
+|                ||                            |                                                                    ||
+|                ||                            | Post-sample treatment of the beam is described by data items in    ||
+|                ||                            | the DIFFRN_DETECTOR category.                                      ||
+|                ||----------------------------+--------------------------------------------------------------------||
+|                || DIFFRN_REFLN               | This category redefinition has been added to extend the key of the ||
+|                ||                            | standard DIFFRN_REFLN category.                                    ||
+|                ||                            |                                                                    ||
+|                ||                            | Data items in the DIFFRN_REFLN category record details about the   ||
+|                ||                            | intensities in the diffraction data set identified by              ||
+|                ||                            | _diffrn_refln.diffrn_id.                                           ||
+|                ||                            |                                                                    ||
+|                ||                            | The DIFFRN_REFLN data items refer to individual intensity          ||
+|                ||                            | measurements and must be included in looped lists.                 ||
+|                ||                            |                                                                    ||
+|                ||                            | The DIFFRN_REFLNS data items specify the parameters that apply to  ||
+|                ||                            | all intensity measurements in the particular diffraction data set  ||
+|                ||                            | identified by _diffrn_reflns.diffrn_id and _diffrn_refln.frame_id  ||
+|                ||----------------------------+--------------------------------------------------------------------||
+|                || DIFFRN_SCAN                | Data items in the DIFFRN_SCAN category describe the parameters of  ||
+|                ||                            | one or more scans, relating axis positions to frames.              ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | DIFFRN_SCAN_AXIS | Data items in the DIFFRN_SCAN_AXIS category describe the settings of | ||
+|                || |   |                  | axes for particular scans. Unspecified axes are assumed to be at     | ||
+|                || |   |                  | their zero points.                                                   | ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | DIFFRN_SCAN_COLLECTION | Data items in the DIFFRN_SCAN_COLLECTION category describe the | ||
+|                || |   |                        | type of collection strategy involved in each scan.             | ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | DIFFRN_SCAN_FRAME | Data items in the DIFFRN_SCAN_FRAME category describe the           | ||
+|                || |   |                   | relationships of particular frames to scans.                        | ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | +-------------------------------------------------------------------------------------+ | ||
+|                || |   | |   | DIFFRN_SCAN_FRAME_AXIS | Data items in the DIFFRN_SCAN_FRAME_AXIS category      | | ||
+|                || |   | |   |                        | describe the settings of axes for particular frames.   | | ||
+|                || |   | |   |                        | Unspecified axes are assumed to be at their zero       | | ||
+|                || |   | |   |                        | points. If, for any given frame, nonzero values apply  | | ||
+|                || |   | |   |                        | for any of the data items in this category, those      | | ||
+|                || |   | |   |                        | values should be given explicitly in this category and | | ||
+|                || |   | |   |                        | not simply inferred from values in DIFFRN_SCAN_AXIS.   | | ||
+|                || |   | +-------------------------------------------------------------------------------------+ | ||
+|                || |---+-----------------------------------------------------------------------------------------| ||
+|                || |   | +-------------------------------------------------------------------------------------+ | ||
+|                || |   | |   | DIFFRN_SCAN_FRAME_MONITOR | Data items in the DIFFRN_SCAN_FRAME_MONITOR         | | ||
+|                || |   | |   |                           | category record the values and details about each   | | ||
+|                || |   | |   |                           | monitor for each frame of data during a scan.       | | ||
+|                || |   | |   |                           |                                                     | | ||
+|                || |   | |   |                           | Each monitor value is uniquely identified by the    | | ||
+|                || |   | |   |                           | combination of the scan id given by                 | | ||
+|                || |   | |   |                           | _diffrn_scan_frame.scan_id, the frame id given by   | | ||
+|                || |   | |   |                           | _diffrn_scan_frame_monitor.frame_id, the monitor's  | | ||
+|                || |   | |   |                           | detector id given by                                | | ||
+|                || |   | |   |                           | _diffrn_scan_frame_monitor.detector_id, and a       | | ||
+|                || |   | |   |                           | 1-based ordinal given by                            | | ||
+|                || |   | |   |                           | _diffrn_scan_frame_monitor.id.                      | | ||
+|                || |   | |   |                           |                                                     | | ||
+|                || |   | |   |                           | If there is only one frame for the scan, the value  | | ||
+|                || |   | |   |                           | of _diffrn_scan_frame_monitor.frame_id may be       | | ||
+|                || |   | |   |                           | omitted.                                            | | ||
+|                || |   | |   |                           |                                                     | | ||
+|                || |   | |   |                           | A single frame may have more than one monitor       | | ||
+|                || |   | |   |                           | value, and each monitor value may be the result of  | | ||
+|                || |   | |   |                           | integration over the entire frame integration time  | | ||
+|                || |   | |   |                           | given by the value of                               | | ||
+|                || |   | |   |                           | _diffrn_scan_frame.integration_time, or many        | | ||
+|                || |   | |   |                           | monitor values may be reported over shorter times   | | ||
+|                || |   | |   |                           | given by the value of                               | | ||
+|                || |   | |   |                           | _diffrn_scan_frame_monitor.integration_time. If     | | ||
+|                || |   | |   |                           | only one monitor value for a given monitor is       | | ||
+|                || |   | |   |                           | collected during the integration time of the frame, | | ||
+|                || |   | |   |                           | the value of _diffrn_scan_frame_monitor.id may be   | | ||
+|                || |   | |   |                           | omitted.                                            | | ||
+|                || |   | +-------------------------------------------------------------------------------------+ | ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                |+-------------------------------------------------------------------------------------------------+|
+|----------------+---------------------------------------------------------------------------------------------------|
+|MAP_GROUP       |Categories that describe maps.                                                                     |
+|                |---------------------------------------------------------------------------------------------------|
+|                |+-------------------------------------------------------------------------------------------------+|
+|                || MAP     | Data items in the MAP category record the details of a map. Maps record values of     ||
+|                ||         | parameters, such as density, that are functions of position within a cell or are      ||
+|                ||         | functions of orthogonal coordinates in three space.                                   ||
+|                ||         |                                                                                       ||
+|                ||         | A map may is composed of one or more map segments specified in the MAP_SEGMENT        ||
+|                ||         | category.                                                                             ||
+|                ||         |                                                                                       ||
+|                ||         | Examples are given in the MAP_SEGMENT category.                                       ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | MAP_SEGMENT | Data items in the MAP_SEGMENT category record the details about each      | ||
+|                || |   |             | segment (section or brick) of a map.                                      | ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                |+-------------------------------------------------------------------------------------------------+|
+|----------------+---------------------------------------------------------------------------------------------------|
+|VARIANT_GROUP   |Categories that describe variants                                                                  |
+|                |---------------------------------------------------------------------------------------------------|
+|                |+-------------------------------------------------------------------------------------------------+|
+|                || VARIANT | Data items in the VARIANT category record the details about sets of variants of data  ||
+|                ||         | items.                                                                                ||
+|                ||         |                                                                                       ||
+|                ||         | There is sometimes a need to allow for multiple versions of the same data items in    ||
+|                ||         | order to allow for refinements and corrections to earlier assumptions, observations   ||
+|                ||         | and calculations. In order to allow data sets to contain more than one variant of the ||
+|                ||         | same information, an optional ...variant data item as a pointer to _variant.variant   ||
+|                ||         | has been added to the key of every category, as an implicit data item with a null     ||
+|                ||         | (empty) default value.                                                                ||
+|                ||         |                                                                                       ||
+|                ||         | All rows in a category with the same variant value are considered to be related to    ||
+|                ||         | one another and to all rows in other categories with the same variant value. For a    ||
+|                ||         | given variant, all such rows are also considered to be related to all rows with a     ||
+|                ||         | null variant value, except that a row with a null variant value is for which all      ||
+|                ||         | other components of its key are identical to those entries in another row with a      ||
+|                ||         | non-null variant value is not related the the rows with that non-null variant value.  ||
+|                ||         | This behavior is similar to the convention for identifying alternate conformers in an ||
+|                ||         | atom list.                                                                            ||
+|                ||         |                                                                                       ||
+|                ||         | An optional role may be specified for a variant as the value of _variant.role.        ||
+|                ||         | Possible roles are null, "preferred", "raw data", "unsuccessful trial".               ||
+|                ||         |                                                                                       ||
+|                ||         | variants may carry an optional timestamp as the value of _variant.timestamp.          ||
+|                ||         |                                                                                       ||
+|                ||         | variants may be related to other variants from which they were derived by the value   ||
+|                ||         | of _variant.variant_of                                                                ||
+|                ||         |                                                                                       ||
+|                ||         | Further details about the variant may be specified as the value of _variant.details.  ||
+|                ||         |                                                                                       ||
+|                ||         | In order to allow variant information from multiple datasets to be combined,          ||
+|                ||         | _variant.diffrn_id and/or _variant.entry_id may be used.                              ||
+|                |+-------------------------------------------------------------------------------------------------+|
++--------------------------------------------------------------------------------------------------------------------+
+
+
+;
+    _dictionary.title           cif_img.dic
+    _dictionary.version         1.8.6
+    _dictionary.datablock_id    cif_img.dic
+
+#########################
+## CATEGORY_GROUP_LIST ##
+#########################
+
+     loop_
+    _category_group_list.id
+    _category_group_list.parent_id
+    _category_group_list.description
+             'inclusive_group'  .
+;             Categories that belong to the dictionary extension.
+;
+             'array_data_group'
+             'inclusive_group'
+;             Categories that describe array data.
+;
+             'axis_group'
+             'inclusive_group'
+;             Categories that describe axes.
+;
+             'diffrn_group'
+             'inclusive_group'
+;             Categories that describe details of the diffraction experiment.
+;
+             'map_group'
+             'inclusive_group'
+;             Categories that describe details of map data.
+;
+             'variant_group'
+             'inclusive_group'
+;             Categories that describe details of variants.
+;
+
+
+##################
+## SUB_CATEGORY ##
+##################
+
+     loop_
+    _sub_category.id
+    _sub_category.description
+              'matrix'
+;              The collection of elements of a matrix.
+;
+              'vector'
+;              The collection of elements of a vector.
+;
+
+
+
+
+##############
+# ARRAY_DATA #
+##############
+
+
+save_ARRAY_DATA
+    _category.description
+;   Data items in the ARRAY_DATA  category are the containers for
+    the array data items described in the category ARRAY_STRUCTURE.
+
+    It is recognized that the data in this category need to be used in
+    two distinct ways.  During a data collection the lack of ancillary
+    data and timing constraints in processing data may dictate the
+    need to make a 'miniCBF', nothing more than an essential minimum
+    of information to record the results of the data collection.  In that
+    case it is proper to use the ARRAY_DATA  category as a
+    container for just a single image and a compacted, beamline-dependent
+    list of data collection parameter values.  In such
+    a case, only the tags '_array_data.header_convention',
+    '_array_data.header_contents'  and '_array_data.data' need be
+  populated.
+
+    For full processing and archiving, most of the tags in this
+    dictionary will need to be populated.
+;
+    _category.id                   array_data
+    _category.mandatory_code       no
+    _category.NX_mapping_details
+; in online version
+;
+     loop_
+    _category_key.name             '_array_data.array_id'
+                                   '_array_data.binary_id'
+                                   '_array_data.variant'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'array_data_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+        Example 1.
+
+        This example shows two binary data blocks.  The first one
+        was compressed by the CBF_CANONICAL compression algorithm and is
+        presented as hexadecimal data.  The first character 'H' on the
+        data lines means hexadecimal.  It could have been 'O' for octal
+        or 'D' for decimal.  The second character on the line shows
+        the number of bytes in each word (in this case '4'), which then
+        requires eight hexadecimal digits per word.  The third character
+        gives the order of octets within a word, in this case '<'
+        for the ordering 4321 (i.e. 'big-endian').  Alternatively, the
+        character '>' could have been used for the ordering 1234
+        (i.e. 'little-endian').  The block has a 'message digest'
+        to check the integrity of the data.
+
+        The second block is similar, but uses CBF_PACKED compression
+        and BASE64 encoding.  Note that the size and the digest are
+        different.
+;
+;
+
+         loop_
+        _array_data.array_id
+        _array_data.binary_id
+        _array_data.data
+        image_1 1
+        ;
+        --CIF-BINARY-FORMAT-SECTION--
+        Content-Type: application/octet-stream;
+             conversions="X-CBF_CANONICAL"
+        Content-Transfer-Encoding: X-BASE16
+        X-Binary-Size: 3927126
+        X-Binary-ID: 1
+        Content-MD5: u2sTJEovAHkmkDjPi+gWsg==
+
+        # Hexadecimal encoding, byte 0, byte order ...21
+        #
+        H4< 0050B810 00000000 00000000 00000000 000F423F 00000000 00000000 ...
+        ....
+        --CIF-BINARY-FORMAT-SECTION----
+        ;
+        image_2 2
+        ;
+        --CIF-BINARY-FORMAT-SECTION--
+        Content-Type: application/octet-stream;
+             conversions="X-CBF-PACKED"
+        Content-Transfer-Encoding: BASE64
+        X-Binary-Size: 3745758
+        X-Binary-ID: 2
+        Content-MD5: 1zsJjWPfol2GYl2V+QSXrw==
+
+        ELhQAAAAAAAA...
+        ...
+        --CIF-BINARY-FORMAT-SECTION----
+        ;
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+        Example 2.
+
+        This example shows a single image in a miniCBF, provided by
+        E. Eikenberry.  The entire CBF consists of one data block
+        containing one category and three tags.  The CBFlib
+        program convert_miniCBF and a suitable template file
+        can be used to convert this miniCBF to a full imgCIF
+        file.
+;
+;
+        ###CBF: VERSION 1.5
+        # CBF file written by CBFlib v0.7.8
+
+        data_insulin_pilatus6m
+
+        _array_data.header_convention  SLS_1.0
+        _array_data.header_contents
+        ;
+        # Detector: PILATUS 6M SN: 60-0001
+        # 2007/Jun/17 15:12:36.928
+        # Pixel_size 172e-6 m x 172e-6 m
+        # Silicon sensor, thickness 0.000320 m
+        # Exposure_time 0.995000 s
+        # Exposure_period 1.000000 s
+        # Tau = 194.0e-09 s
+        # Count_cutoff 1048575 counts
+        # Threshold_setting 5000 eV
+        # Wavelength 1.2398 A
+        # Energy_range (0, 0) eV
+        # Detector_distance 0.15500 m
+        # Detector_Voffset -0.01003 m
+        # Beam_xy (1231.00, 1277.00) pixels
+        # Flux 22487563295 ph/s
+        # Filter_transmission 0.0008
+        # Start_angle 13.0000 deg.
+        # Angle_increment 1.0000 deg.
+        # Detector_2theta 0.0000 deg.
+        # Polarization 0.990
+        # Alpha 0.0000 deg.
+        # Kappa 0.0000 deg.
+        # Phi 0.0000 deg.
+        # Chi 0.0000 deg.
+        # Oscillation_axis  X, CW
+        # N_oscillations 1
+        ;
+
+        _array_data.data
+        ;
+        --CIF-BINARY-FORMAT-SECTION--
+        Content-Type: application/octet-stream;
+             conversions="x-CBF_BYTE_OFFSET"
+        Content-Transfer-Encoding: BINARY
+        X-Binary-Size: 6247567
+        X-Binary-ID: 1
+        X-Binary-Element-Type: "signed 32-bit integer"
+        X-Binary-Element-Byte-Order: LITTLE_ENDIAN
+        Content-MD5: 8wO6i2+899lf5iO8QPdgrw==
+        X-Binary-Number-of-Elements: 6224001
+        X-Binary-Size-Fastest-Dimension: 2463
+        X-Binary-Size-Second-Dimension: 2527
+        X-Binary-Size-Padding: 4095
+
+        ...
+
+        --CIF-BINARY-FORMAT-SECTION----
+        ;
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+save_
+
+
+save__array_data.array_id
+    _item_description.description
+;             This item is a pointer to _array_structure.id  in the
+              ARRAY_STRUCTURE  category.
+
+              If not given, it defaults to 1.
+
+;
+    _item.name                  '_array_data.array_id'
+    _item.category_id             array_data
+    _item.mandatory_code          implicit
+    _item_default.value           1
+    _item_type.code               code
+     save_
+
+
+save__array_data.binary_id
+    _item_description.description
+;             This item is an integer identifier which, along with
+              _array_data.array_id, should uniquely identify the
+              particular block of array data.
+
+              If _array_data.binary_id  is not explicitly given,
+              it defaults to 1.
+
+              The value of _array_data.binary_id  distinguishes
+              among multiple sets of data with the same array
+              structure.
+
+              If the MIME header of the data array specifies a
+              value for X-Binary-ID, the value of  _array_data.binary_id
+              should be equal to the value given for X-Binary-ID.
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+             '_array_data.binary_id'            array_data
+                                                                implicit
+             '_diffrn_data_frame.binary_id'     diffrn_data_frame
+                                                                implicit
+             '_array_intensities.binary_id'     array_intensities
+                                                                implicit
+     loop_
+    _item_linked.child_name
+    _item_linked.parent_name
+             '_diffrn_data_frame.binary_id'     '_array_data.binary_id'
+             '_array_intensities.binary_id'     '_array_data.binary_id'
+
+    _item_default.value           1
+    _item_type.code               int
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            1  1
+                            .  1
+     save_
+
+
+save__array_data.data
+    _item_description.description
+;             The value of _array_data.data  contains the array data
+              encapsulated in a STAR string.  The value of this item is
+              required unless a value is given for
+               _array_data.external_data_id  instead, in which
+              case, a null value of '.' should be given here.
+
+              The representation used is a variant on the
+              Multipurpose Internet Mail Extensions (MIME) specified
+              in RFC 2045-2049 by N. Freed et al.  The boundary
+              delimiter used in writing an imgCIF or CBF is
+              \n--CIF-BINARY-FORMAT-SECTION-- (including the
+              required initial \n--, where \n represents the system
+              newline character(s)).
+
+              The Content-Type may be any of the discrete types permitted
+              in RFC 2045; 'application/octet-stream' is recommended
+              for diffraction images in the ARRAY_DATA category.
+              Note:  When appropriate in other categories, e.g. for
+              photographs of crystals, more precise types, such as
+              'image/jpeg', 'image/tiff', 'image/png', etc. should be used.
+
+              If an octet stream was compressed, the compression should
+              be specified by the parameter
+                conversions="X-CBF_PACKED"
+              or the parameter
+                conversions="X-CBF_CANONICAL"
+              or the parameter
+                conversions="X-CBF_BYTE_OFFSET"
+              or the parameter
+                conversions="X-CBF_BACKGROUND_OFFSET_DELTA"
+
+              If the parameter
+                conversions="X-CBF_PACKED"
+              is given it may be further modified with the parameters
+                uncorrelated_sections
+              or
+                flat
+              (e.g. conversions="X-CBF_PACKED flat").
+              In such cases the _array_structure.compression_type_flag
+              should also be present with the corresponding value.
+
+              If the "uncorrelated_sections" parameter is
+              given, each section will be compressed without using
+              the prior section for averaging.
+
+              If the "flat" parameter is given, each
+              image will be treated as one long row.
+
+              Note that X-CBF_CANONICAL and X-CBF_PACKED are
+              slower but more efficient compressions than the others.
+              The X-CBF_BYTE_OFFSET compression is a good compromise
+              between speed and efficiency for ordinary diffraction
+              images.  The X-CBF_BACKGROUND_OFFSET_DELTA compression
+              is oriented towards sparse data, such as masks and
+              tables of replacement pixel values for images with
+              overloaded spots.
+
+              The Content-Transfer-Encoding may be 'BASE64',
+              'Quoted-Printable', 'X-BASE8', 'X-BASE10',
+              'X-BASE16' or 'X-BASE32K', for an imgCIF or 'BINARY'
+              for a CBF.  The octal, decimal and hexadecimal transfer
+              encodings are provided for convenience in debugging and
+              are not recommended for archiving and data interchange.
+
+              In a CIF, one of the parameters 'charset=us-ascii',
+              'charset=utf-8' or 'charset=utf-16' may be used on the
+              Content-Transfer-Encoding to specify the character set
+              used for the external presentation of the encoded data.
+              If no charset parameter is given, the character set of
+              the enclosing CIF is assumed.  In any case, if a BOM
+              flag is detected (FE FF for big-endian UTF-16, FF FE for
+              little-endian UTF-16 or EF BB BF for UTF-8) is detected,
+              the indicated charset will be assumed until the end of the
+              encoded data or the detection of a different BOM.  The
+              charset of the Content-Transfer-Encoding is not the character
+              set of the encoded data, only the character set of the
+              presentation of the encoded data and should be respecified
+              for each distinct STAR string.
+
+              In an imgCIF file, the encoded binary data begin after
+              the empty line terminating the header.  In an imgCIF file,
+              the encoded binary data ends with the terminating boundary
+              delimiter '\n--CIF-BINARY-FORMAT-SECTION----'
+              in the currently effective charset or with the '\n;'
+              that terminates the STAR string.
+
+              In a CBF, the raw binary data begin after an empty line
+              terminating the header and after the sequence:
+
+              Octet   Hex   Decimal  Purpose
+                0     0C       12    Ctrl-L: page break
+                1     1A       26    Ctrl-Z: stop listings, MS-DOS
+                2     04       04    Ctrl-D: stop listings, UNIX
+                3     D5      213    binary section begins
+
+              None of these octets are included in the calculation of
+              the message size or in the calculation of the
+              message digest.
+
+              The X-Binary-Size header specifies the size of the
+              equivalent binary data in octets.  If compression was
+              used, this size is the size after compression, including
+              any book-keeping fields.  An adjustment is made for
+              the deprecated binary formats in which eight bytes of binary
+              header are used for the compression type.  In this case,
+              the eight bytes used for the compression type are subtracted
+              from the size, so that the same size will be reported
+              if the compression type is supplied in the MIME header.
+              Use of the MIME header is the recommended way to
+              supply the compression type.  In general, no portion of
+              the  binary header is included in the calculation of the size.
+
+              The X-Binary-Element-Type header specifies the type of
+              binary data in the octets, using the same descriptive
+              phrases as in _array_structure.encoding_type.  The default
+              value is 'unsigned 32-bit integer'.
+
+              An MD5 message digest may, optionally, be used. The 'RSA Data
+              Security, Inc. MD5 Message-Digest Algorithm' should be used.
+              No portion of the header is included in the calculation of the
+              message digest.
+
+              If the Transfer Encoding is 'X-BASE8', 'X-BASE10' or
+              'X-BASE16', the data are presented as octal, decimal or
+              hexadecimal data organized into lines or words.  Each word
+              is created by composing octets of data in fixed groups of
+              2, 3, 4, 6 or 8 octets, either in the order ...4321 ('big-
+              endian') or 1234... ('little-endian').  If there are fewer
+              than the specified number of octets to fill the last word,
+              then the missing octets are presented as '==' for each
+              missing octet.  Exactly two equal signs are used for each
+              missing octet even for octal and decimal encoding.
+              The format of lines is:
+
+              rnd xxxxxx xxxxxx xxxxxx
+
+              where r is 'H', 'O' or 'D' for hexadecimal, octal or
+              decimal, n is the number of octets per word and d is '<'
+              or '>' for the '...4321' and '1234...' octet orderings,
+              respectively.  The '==' padding for the last word should
+              be on the appropriate side to correspond to the missing
+              octets, e.g.
+
+              H4< FFFFFFFF FFFFFFFF 07FFFFFF ====0000
+
+              or
+
+              H3> FF0700 00====
+
+              For these hexadecimal, octal and decimal formats only,
+              comments beginning with '#' are permitted to improve
+              readability.
+
+              BASE64 encoding follows MIME conventions.  Octets are
+              in groups of three: c1, c2, c3.  The resulting 24 bits
+              are broken into four six-bit quantities, starting with
+              the high-order six bits (c1 >> 2) of the first octet, then
+              the low-order two bits of the first octet followed by the
+              high-order four bits of the second octet [(c1 & 3)<<4 | (c2>>4)],
+              then the bottom four bits of the second octet followed by the
+              high-order two bits of the last octet [(c2 & 15)<<2 | (c3>>6)],
+              then the bottom six bits of the last octet (c3 & 63).  Each
+              of these four quantities is translated into an ASCII character
+              using the mapping:
+
+                        1         2         3         4         5         6
+              0123456789012345678901234567890123456789012345678901234567890123
+              |         |         |         |         |         |         |
+              ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/
+
+              with short groups of octets padded on the right with one '='
+              if c3 is missing, and with '==' if both c2 and c3 are missing.
+
+              X-BASE32K encoding is similar to BASE64 encoding, except that
+              sets of 15 octets are encoded as sets of 8 16-bit Unicode
+              characters, by breaking the 120 bits into 8 15-bit quantities.
+              256 is added to each 15-bit quantity to bring it into a
+              printable Unicode range.  When encoding, zero padding is used
+              to fill out the last 15-bit quantity.  If 8 or more bits of
+              padding are used, a single equals sign (hexadecimal 003D) is
+              appended.  Embedded whitespace and newlines are introduced
+              to produce lines of no more than 80 characters each.  On
+              decoding, all printable ASCII characters and ASCII whitespace
+              characters are ignored except for any trailing equals signs.
+              The number of trailing equals signs indicated the number of
+              trailing octets to be trimmed from the end of the decoded data
+              (see Darakev et al., 2006).
+
+              QUOTED-PRINTABLE encoding also follows MIME conventions, copying
+              octets without translation if their ASCII values are 32...38,
+              42, 48...57, 59, 60, 62, 64...126 and the octet is not a ';'
+              in column 1.  All other characters are translated to =nn, where
+              nn is the hexadecimal encoding of the octet.  All lines are
+              'wrapped' with a terminating '=' (i.e. the MIME conventions
+              for an implicit line terminator are never used).
+
+              The 'X-Binary-Element-Byte-Order' can specify either
+              'BIG_ENDIAN' or 'LITTLE_ENDIAN' byte order of the image
+              data.  Only LITTLE_ENDIAN is recommended.  Processors
+              may treat BIG_ENDIAN as a warning of data that can
+              only be processed by special software.
+
+              The 'X-Binary-Number-of-Elements' specifies the number of
+              elements (not the number of octets) in the decompressed,
+              decoded image.
+
+              The optional 'X-Binary-Size-Fastest-Dimension' specifies the
+              number of elements (not the number of octets) in one row of the
+              fastest changing dimension of the binary data array. This
+              information must be in the MIME header for proper operation of
+              some of the decompression algorithms.
+
+              The optional 'X-Binary-Size-Second-Dimension' specifies the
+              number of elements (not the number of octets) in one column of
+              the second-fastest changing dimension of the binary data array.
+              This information must be in the MIME header for proper operation
+              of some of the decompression algorithms.
+
+              The optional 'X-Binary-Size-Third-Dimension' specifies the
+              number of sections for the third-fastest changing dimension of
+              the binary data array.
+
+              The optional 'X-Binary-Size-Padding' specifies the size in
+              octets of an optional padding after the binary array data and
+              before the closing flags for a binary section.
+
+              Reference:
+
+              Darakev, G., Litchev, V., Mitev, K. Z. & Bernstein, H. J. (2006).
+              'Efficient Support of Binary Data in the XML Implementation of
+              the NeXus File Format', abstract W0165, ACA Summer Meeting,
+              Honolulu, HI, USA, July 2006.
+;
+    _item.name                  '_array_data.data'
+    _item.category_id             array_data
+    _item.mandatory_code          yes
+    _item_type.code               binary
+save_
+
+save__array_data.external_data_id
+    _item_description.description
+;             This item is a pointer to _array_data_external_data.id  in the
+              ARRAY_DATA_EXTERNAL_DATA  category.
+
+              If not given, then the actual array data should be specified as
+              the value of _array_data.data.  If
+              both values are given, the value on _array_data.data  takes
+              precedence, and a warning of a possible conflict should be issued.
+
+;
+    _item.name                  '_array_data.external_data_id'
+    _item.category_id             array_data
+    _item.mandatory_code          implicit
+    _item_default.value           1
+    _item_type.code               code
+     save_
+
+save__array_data.header_contents
+    _item_description.description
+;             This item is a text field for use in minimal CBF files to carry
+              essential header information to be kept with image data
+              in _array_data.data when the tags that normally carry the
+              structured metadata for the image have not been populated.
+
+              Normally this data item should not appear when the full set
+              of tags has been populated and _diffrn_data_frame.details
+              appears.
+;
+    _item.name                  '_array_data.header_contents'
+    _item.category_id            array_data
+    _item.mandatory_code         no
+    _item_type.code              text
+     save_
+
+
+save__array_data.header_convention
+    _item_description.description
+;             This item is an identifier for the convention followed in
+              constructing the contents of _array_data.header_contents
+
+              The permitted values are of an image creator identifier
+              followed by an underscore and a version string.  To avoid
+              confusion about conventions, all creator identifiers
+              should be registered with the IUCr and the conventions
+              for all identifiers and versions should be posted on
+              the MEDSBIO.org web site.
+;
+    _item.name                  '_array_data.header_convention'
+    _item.category_id            array_data
+    _item.mandatory_code         no
+    _item_type.code              code
+     save_
+
+
+save__array_data.variant
+    _item_description.description
+;             The value of _array_data.variant  gives the variant
+              to which the given ARRAY_DATA row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant  in the
+              VARIANT  category.
+;
+    _item.name                  '_array_data.variant'
+    _item.category_id             array_data
+    _item.mandatory_code          implicit
+    _item_default.value          .
+    _item_type.code               code
+     save_
+
+############################
+# ARRAY_DATA_EXTERNAL_DATA #
+############################
+
+
+save_ARRAY_DATA_EXTERNAL_DATA
+    _category.description
+;   Data items in the ARRAY_DATA_EXTERNAL_DATA  category optionally
+    record the location and essential characteristics of arrays of data for use in
+    ARRAY_DATA  that are found external to the cif_img file.
+;
+    _category.id                   array_data_external_data
+    _category.mandatory_code       no
+    _category.NX_mapping_details
+; in online version
+;
+
+    _category_key.name             '_array_data_external_data.id'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'array_data_group'
+     save_
+
+
+save__array_data_external_data.archive_format
+    _item_description.description
+;
+
+    The type of single-file archive in which image data or multi-image
+    inage containers have been encapsulated, if any. The archive is
+    located at _array_data_external_data.uri.
+
+;
+
+    _item.name                 '_array_data_external_data.archive_format'
+    _item.category_id            array_data_external_data
+    _item.type_code              code
+    _item_default.value         .
+
+    loop_
+    _item_enumeration.value
+    _item_enumeration.detail
+    ZIP           'A ZIP archive'
+    TGZ           'A Gzipped tar archive'
+    TBZ           'A Bzip2 tar archive'
+    .             'No compressed archive is present'
+save_
+
+
+save__array_data_external_data.archive_path
+   _item_description.description
+
+;
+
+    The location of the image or multi-image image container,
+    such as HDF5 or CBF, within an archive such as a tarball.
+
+;
+
+    _item.name                 '_array_data_external_data.archive_path'
+    _item.category_id            array_data_external_data
+    _item_type.code              text
+
+    save_
+
+save__array_data_external_data.frame
+    _item_description.description
+;
+
+    The position of the raw data array in what may possibly be a
+    multi-dimensional array of data referenced by
+       _array_data_external_data.uri and _array_data_external_data.path.
+    For many of the formats, data for a single frame is identified by that
+    reference.  If data for multiple frames or data for portions of
+    one or more frames is referenced, the desired portion can be
+    identified dimension by dimension as an array section identifier
+    the form
+       ARRAYID(start1:end1:stride1,start2:end2:stride2, ...)
+    or other valid ARRAY_STRUCTURE_LIST_SECTION
+    identifier.
+
+    Note that the precendence ordering of dimensions varies, even within a
+    single specified format.  For example HDF5 supports both C slowest first
+    and Fortran fastest first, so it is essential to properly populate
+    ARRAY_STRUCTURE_LIST  category.
+
+;
+    _item.name                 '_array_data_external_data.frame'
+    _item.category_id            array_data_external_data
+    _item_type.code              code
+    _item_default.value          1
+    loop_
+    _item_examples.case
+    _item_examples.detail
+    4                           'The fourth frame in the referenced data array'
+
+    save_
+
+
+save__array_data_external_data.format
+    _item_description.description
+;
+    The format in which raw array data referenced by
+    _array_data_external_data.uri  and following archive extraction can be
+    accessed. Items in array_structure and array_structure_list refer
+    to the data after any decompressions and other transformations
+    performed by standard libraries associated with the format as
+    described in the description of each format below.
+
+    Note that, if a single file archive, such as a zip or tarball
+    has been specified at _array_data_external_data.uri
+    then the format of the archive, as contrasted with the format of
+    the image or the multi-image image container such as CBF or
+    HDF5 is specified by _array_data_external_data.archive_format
+    and the particular image is specified by the combination of
+    _array_data_external_data.archive_path,
+    _array_data_external_data.format,
+    _array_data_external_data.path, and
+    _array_data_external_data.frame  while
+    if no single file archive is used, so that a CBF, HDF5, TIFF or SMV is specified
+    at _array_data_external_data.uri, then
+    the particular image is specified by the combination of
+    _array_data_external_data.format,
+    _array_data_external_data.path, and
+    _array_data_external_data.frame  directly.
+
+;
+
+    _item.name                 '_array_data_external_data.format'
+    _item.category_id            array_data_external_data
+    _item.mandatory_code         no
+    _item.type_code              code
+
+    loop_
+    _item_enumeration.value
+    _item_enumeration.detail
+    CBF
+;
+    The contents of _array_data.data in a single-frame imgCBF file. Other
+    datanames in the external file are ignored.
+;
+    SMV
+;
+    An unprocessed sequence of bytes contained in a file conforming to the SMV
+    format as used by ADSC and other CCD manufacturers.
+;
+    HDF5
+;
+    An array of numbers contained in a dataset in an HDF5 file as returned by HDF5
+    library functions.  '_array_data_external_data.path' is the
+    internal HDF5 path.  In an HDF5 file, the path typically identifies a dataset
+    with multiple images.
+;
+    MAR
+;
+    An array of numbers corresponding to a decompressed single frame contained
+    within a MARCCD file (TIFF format).
+;
+    Bruker
+;
+    An array of numbers corresponding to a decompressed single frame from a
+    data file generated by Bruker equipment.
+;
+
+
+    loop_
+      _item_examples.case
+      _item_examples.detail
+;
+    loop_
+    _array_data.array_id
+    _array_data.binary_id
+    _array_data.external_data_id
+    1 1 1
+    1 2 2
+    loop_
+    _array_data_external_data.id
+    _array_data_external_data.format
+    _array_data_external_data.uri
+    _array_data_external_data.path
+    _array_data_external_data.frame
+    1 HDF5 https://zenodo.org/record/12345/files/tartaric.h5 /entry1/detector1/data 1
+    2 HDF5 https://zenodo.org/record/12345/files/tartaric.h5 /entry1/detector1/data 2
+    ...
+;
+;
+    The frames are contained in a single HDF5-format file accessible
+    at https://zenodo.org/record/12345/files/tartaric.h5. An array of 2D
+    images is found at HDF5 location entry1/detector1/data
+;
+
+;
+    loop_
+    _array_data.array_id
+    _array_data.binary_id
+    _array_data.external_data_id
+    1 1 1
+    1 2 2
+    loop_
+    _array_data_external_data.id
+    _array_data_external_data.format
+    _array_data_external_data.version
+    _array_data_external_data.uri
+    1 Bruker Smart6000 https://uni_repo.edu/5341/run1/tartaric.001
+    2 Bruker Smart6000 https://uni_repo.edu/5341/run1/tartaric.002
+    ...
+;
+;
+    Frames are contained in individual Smart6000 Bruker-format files
+    accessible using https://uni_repo.edu/5341 in subdirectory run1.
+;
+
+;
+    loop_
+    _array_data.array_id
+    _array_data.binary_id
+    _array_data.external_data_id
+    1 1 1
+    1 2 2
+    loop_
+    _array_data_external_data.id
+    _array_data_external_data.format
+    _array_data_external_data.uri
+    _array_data_external_data.archive_format
+    _array_data_external_data.archive_path
+    1 SMV
+        https://data.proteindiffraction.org/ssgcid/MyulA_01062_a_B12-sddc0001574_7k69.tar.bz2
+        TBZ
+        MyulA_01062_a_B12-sddc0001574_7k69/data/317895h4_y_0001.img
+    2 SMV
+        https://data.proteindiffraction.org/ssgcid/MyulA_01062_a_B12-sddc0001574_7k69.tar.bz2
+        TBZ
+        MyulA_01062_a_B12-sddc0001574_7k69/data/317895h4_y_0002.img
+;
+;
+    Frames with SMV format are contained at data.proteindiffraction.org in a tarred
+    archive compressed with bzip2.
+;
+    save_
+
+save__array_data_external_data.id
+    _item_description.description
+;             The value of _array_data_external_data.id  must uniquely identify
+              each item of array_data_external_data.
+
+              This item has been made implicit and given a default value of 1
+              as a convenience in writing miniCBF files.  Normally an
+              explicit name with useful content should be used.
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+             '_array_data_external_data.id'    array_data_external_data      implicit
+             '_array_data.external_data_id'    array_data                    implicit
+
+
+    _item_default.value           1
+    _item_type.code               code
+     loop_
+    _item_linked.child_name    _item_linked.parent_name
+             '_array_data.external_data_id'
+                      '_array_data_external_data.id'
+     save_
+
+save__array_data_external_data.path
+   _item_description.description
+
+;
+
+    An optional format-dependent path that is used to locate the
+    external image or images within the object referenced by the combination of
+    _array_data_external_data.uri,
+    _array_data_external_data.archive_path
+    in the case that _array_data_external_data.archive_format
+    specifies a non-null single-file archive format, such as zip or a
+    tarball.  When a single-file archive format is not used, then
+    _array_data_external_data.path
+    locates the external image or images  within the object referenced by
+    _array_data_external_data.uri.
+    In both cases, the specific image within an array of multiple images is
+    identified by _array_data_external_data.frame.
+
+
+;
+
+    _item.name                 '_array_data_external_data.path'
+    _item.category_id            array_data_external_data
+    _item_type.code              text
+
+    save_
+
+save__array_data_external_data.uri
+    _item_description.description
+;
+    A URI describing the location of an image external to the current data block
+;
+    _item.name                '_array_data_external_data.uri'
+    _item.category_id           array_data_external_data
+    _item_type.code             code
+
+    save_
+
+save__array_data_external_data.variant
+    _item_description.description
+;             The value of _array_data_external_data.variant  gives the variant
+              to which the given ARRAY_DATA_EXTERNAL_DATA row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant  in the
+              VARIANT  category.
+;
+    _item.name                  '_array_data_external_data.variant'
+    _item.category_id             array_data_external_data
+    _item.mandatory_code          implicit
+    _item_default.value          .
+    _item_type.code               code
+     save_
+
+save__array_data_external_data.version
+    _item_description.description
+;
+    An identifier for the version of the file format described by '_array_data_external_data.format'.
+;
+
+    _item.name              '_array_data_external_data.version'
+    _item.category_id         array_data_external_data
+    _item_type.code           code
+
+    save_
+
+
+######################
+# ARRAY_ELEMENT_SIZE #
+######################
+
+
+save_ARRAY_ELEMENT_SIZE
+    _category.description
+;   Data items in the ARRAY_ELEMENT_SIZE  category record the physical
+    size of array elements along each array dimension.
+;
+    _category.id                   array_element_size
+    _category.mandatory_code       no
+    _category.NX_mapping_details
+; in online version
+;
+
+  loop_
+    _category_key.name             '_array_element_size.array_id'
+                                   '_array_element_size.index'
+                                   '_array_element_size.variant'
+  loop_
+    _category_group.id             'inclusive_group'
+                                   'array_data_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;      Example 1. A regular 2D array with a uniform element dimension
+                    of 1220 nanometres.
+;
+;
+        loop_
+       _array_element_size.array_id
+       _array_element_size.index
+       _array_element_size.size
+        image_1   1    1.22e-6
+        image_1   2    1.22e-6
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save__array_element_size.array_id
+    _item_description.description
+;             This item is a pointer to _array_structure.id  in the
+              ARRAY_STRUCTURE  category.
+;
+    _item.name                  '_array_element_size.array_id'
+    _item.category_id             array_element_size
+    _item.mandatory_code          implicit
+    _item_type.code               code
+     save_
+
+
+save__array_element_size.index
+    _item_description.description
+;             This item is a pointer to _array_structure_list.index  in
+              the ARRAY_STRUCTURE_LIST category.
+;
+    _item.name                  '_array_element_size.index'
+    _item.category_id             array_element_size
+    _item.mandatory_code          yes
+    _item_type.code               int
+     save_
+
+
+save__array_element_size.size
+    _item_description.description
+;             The size in metres of an image element in this
+              dimension. This supposes that the elements are arranged
+              on a regular grid.
+;
+    _item.name               '_array_element_size.size'
+    _item.category_id          array_element_size
+    _item.mandatory_code       yes
+    _item_type.code            float
+    _item_units.code           'metres'
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0.0
+     save_
+
+
+save__array_element_size.variant
+    _item_description.description
+;             The value of _array_element_size.variant  gives the variant
+              to which the given ARRAY_ELEMENT_SIZE row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant  in the
+              VARIANT  category.
+;
+    _item.name                  '_array_element_size.variant'
+    _item.category_id             array_element_size
+    _item.mandatory_code          implicit
+    _item_default.value          .
+    _item_type.code               code
+     save_
+
+
+#####################
+# ARRAY_INTENSITIES #
+#####################
+
+
+save_ARRAY_INTENSITIES
+    _category.description
+;   Data items in the ARRAY_INTENSITIES  category record the
+    information required to recover the intensity data from
+    the set of data values stored in the ARRAY_DATA  category.
+
+    The detector may have a complex relationship
+    between the raw intensity values and the number of
+    incident photons.  In most cases, the number stored
+    in the final array will have a simple linear relationship
+    to the actual number of incident photons, given by
+    _array_intensities.gain.  If raw, uncorrected values
+    are presented (e.g. for calibration experiments), the
+    value of _array_intensities.linearity  will be 'raw'
+    and _array_intensities.gain will not be used.
+;
+    _category.id                   array_intensities
+    _category.mandatory_code       no
+    _category.NX_mapping_details
+; in online version
+;
+
+     loop_
+    _category_key.name             '_array_intensities.array_id'
+                                   '_array_intensities.binary_id'
+                                   '_array_intensities.variant'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'array_data_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+        Example 1
+;
+;
+        loop_
+        _array_intensities.array_id
+        _array_intensities.linearity
+        _array_intensities.gain
+        _array_intensities.overload
+        _array_intensities.undefined_value
+        _array_intensities.pixel_fast_bin_size
+        _array_intensities.pixel_slow_bin_size
+        _array_intensities.pixel_binning_method
+        image_1   linear  1.2    655535   0   2   2    hardware
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save__array_intensities.array_id
+    _item_description.description
+;             This item is a pointer to _array_structure.id  in the
+              ARRAY_STRUCTURE  category.
+;
+    _item.name                  '_array_intensities.array_id'
+    _item.category_id             array_intensities
+    _item.mandatory_code          implicit
+    _item_type.code               code
+     save_
+
+
+save__array_intensities.binary_id
+    _item_description.description
+;             This item is a pointer to _array_data.binary_id  in the
+              ARRAY_DATA  category.
+;
+    _item.name                  '_array_intensities.binary_id'
+    _item.category_id             array_intensities
+    _item.mandatory_code          implicit
+    _item_type.code               int
+     save_
+
+
+save__array_intensities.details
+    _item_description.description
+;             A description of special aspects of the calculation of array
+              intensities.
+;
+    _item.name                  '_array_intensities.details'
+    _item.category_id             array_intensities
+    _item.mandatory_code          no
+    _item_type.code                   text
+    _item_examples.case         'Gain_setting: low gain (vrf = -0.300)'
+     save_
+
+
+save__array_intensities.gain
+    _item_description.description
+;             Detector 'gain'. The factor by which linearized
+              intensity count values should be divided to produce
+              true photon counts.
+;
+    _item.name              '_array_intensities.gain'
+    _item.category_id          array_intensities
+    _item.mandatory_code       yes
+    _item_type.code            float
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0.0
+    _item_units.code           'counts_per_photon'
+     loop_
+    _item_related.related_name
+    _item_related.function_code  '_array_intensities.gain_esd'
+                                 'associated_value'
+     save_
+
+
+save__array_intensities.gain_esd
+    _item_description.description
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of detector 'gain'.
+;
+    _item.name              '_array_intensities.gain_esd'
+    _item.category_id          array_intensities
+    _item.mandatory_code       yes
+    _item_type.code            float
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0.0
+
+    _item_units.code          'counts_per_photon'
+     loop_
+    _item_related.related_name
+    _item_related.function_code  '_array_intensities.gain'
+                                 'associated_esd'
+     save_
+
+
+save__array_intensities.linearity
+    _item_description.description
+;             The intensity linearity scaling method used to convert
+              from the raw intensity to the stored element value:
+
+             'linear' is linear.
+
+             'offset'  means that the value defined by
+             _array_intensities.offset  should be added to each
+             element value.
+
+             'scaling' means that the value defined by
+             _array_intensities.scaling  should be multiplied with each
+             element value.
+
+             'scaling_offset' is the combination of the two previous cases,
+             with the scale factor applied before the offset value.
+
+             'sqrt_scaled' means that the square root of raw
+             intensities multiplied by _array_intensities.scaling  is
+             calculated and stored, perhaps rounded to the nearest
+             integer. Thus, linearization involves dividing the stored
+             values by _array_intensities.scaling  and squaring the
+             result.
+
+             'logarithmic_scaled' means that the logarithm base 10 of
+             raw intensities multiplied by _array_intensities.scaling
+             is calculated and stored, perhaps rounded to the nearest
+             integer. Thus, linearization involves dividing the stored
+             values by _array_intensities.scaling  and calculating 10
+             to the power of this number.
+
+             'raw' means that the data are a set of raw values straight
+             from the detector.
+;
+
+    _item.name               '_array_intensities.linearity'
+    _item.category_id          array_intensities
+    _item.mandatory_code       yes
+    _item_type.code            code
+     loop_
+    _item_enumeration.value
+    _item_enumeration.detail
+                              'linear' .
+                              'offset'
+;            The value defined by  _array_intensities.offset  should
+             be added to each element value.
+;
+                              'scaling'
+;            The value defined by _array_intensities.scaling  should be
+             multiplied with each element value.
+;
+                              'scaling_offset'
+;            The combination of the scaling and offset
+             with the scale factor applied before the offset value.
+;
+                              'sqrt_scaled'
+;            The square root of raw intensities multiplied by
+             _array_intensities.scaling  is calculated and stored,
+             perhaps rounded to the nearest integer. Thus,
+             linearization involves dividing the stored
+             values by _array_intensities.scaling  and squaring the
+             result.
+;
+                              'logarithmic_scaled'
+;            The logarithm base 10 of raw intensities multiplied by
+             _array_intensities.scaling   is calculated and stored,
+             perhaps rounded to the nearest integer. Thus,
+             linearization involves dividing the stored values by
+             _array_intensities.scaling  and calculating 10 to the
+             power of this number.
+;
+                              'raw'
+;            The array consists of raw values to which no corrections have
+             been applied.  While the handling of the data is similar to
+             that given for 'linear' data with no offset, the meaning of
+             the data differs in that the number of incident photons is
+             not necessarily linearly related to the number of counts
+             reported.  This value is intended for use either in
+             calibration experiments or to allow for handling more
+             complex data-fitting algorithms than are allowed for by
+             this data item.
+;
+
+     save_
+
+
+save__array_intensities.offset
+    _item_description.description
+;             Offset value to add to array element values in the manner
+              described by the item _array_intensities.linearity.
+;
+    _item.name                 '_array_intensities.offset'
+    _item.category_id          array_intensities
+    _item.mandatory_code       no
+    _item_type.code            float
+     save_
+
+
+save__array_intensities.overload
+    _item_description.description
+;             The saturation intensity level for this data array, i.e. the
+              value above which correct intensities may not be recorded.
+
+              The valid pixel values are those less than
+              _array_intensities.overload  and greater than or equal to
+              _array_intensities.underload
+;
+    _item.name                 '_array_intensities.overload'
+    _item.category_id          array_intensities
+    _item.mandatory_code       no
+    _item_type.code            float
+    _item_units.code          'counts'
+     save_
+
+
+save__array_intensities.pixel_fast_bin_size
+    _item_description.description
+;             The value of _array_intensities.pixel_fast_bin_size  specifies
+              the number of pixels that compose one element in the direction
+              of the most rapidly varying array dimension.
+
+              Typical values are 1, 2, 4 or 8.  When there is 1 pixel per
+              array element in both directions, the value given for
+              _array_intensities.pixel_binning_method  normally should be
+              'none'.
+
+              It is specified as a float to allow for binning algorithms that
+              create array elements that are not integer multiples of the
+              detector pixel size.
+;
+    _item.name              '_array_intensities.pixel_fast_bin_size'
+    _item.category_id          array_intensities
+    _item.mandatory_code       implicit
+    _item_type.code            float
+    _item_default.value        1.
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0.0
+    _item_units.code           'pixels_per_element'
+     save_
+
+
+save__array_intensities.pixel_slow_bin_size
+    _item_description.description
+;             The value of _array_intensities.pixel_slow_bin_size  specifies
+              the number of pixels that compose one element in the direction
+              of the second most rapidly varying array dimension.
+
+              Typical values are 1, 2, 4 or 8.  When there is 1 pixel per
+              array element in both directions, the value given for
+              _array_intensities.pixel_binning_method  normally should be
+              'none'.
+
+              It is specified as a float to allow for binning algorithms that
+              create array elements that are not integer multiples of the
+              detector pixel size.
+;
+    _item.name              '_array_intensities.pixel_slow_bin_size'
+    _item.category_id          array_intensities
+    _item.mandatory_code       implicit
+    _item_type.code            float
+    _item_default.value        1.
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0.0
+    _item_units.code           'pixels_per_element'
+     save_
+
+
+save__array_intensities.pixel_binning_method
+    _item_description.description
+;             The value of _array_intensities.pixel_binning_method  specifies
+              the method used to derive array elements from multiple pixels.
+;
+    _item.name              '_array_intensities.pixel_binning_method'
+    _item.category_id          array_intensities
+    _item.mandatory_code       implicit
+    _item_type.code            code
+     loop_
+    _item_enumeration.value
+    _item_enumeration.detail
+                               'hardware'
+;              The element intensities were derived from the raw data of one
+               or more pixels by use of hardware in the detector, e.g. by use
+               of shift registers in a CCD to combine pixels into super-pixels.
+;
+                               'software'
+;              The element intensities were derived from the raw data of more
+               than one pixel by use of software.
+;
+                               'combined'
+;              The element intensities were derived from the raw data of more
+               than one pixel by use of both hardware and software, as when
+               hardware binning is used in one direction and software in the
+               other.
+;
+                               'none'
+;              In both directions, the data have not been binned.  The
+               number of pixels is equal to the number of elements.
+
+               When the value of _array_intensities.pixel_binning_method  is
+               'none' the values of _array_intensities.pixel_fast_bin_size
+               and _array_intensities.pixel_slow_bin_size  both must be 1.
+;
+                               'unspecified'
+;              The method used to derive element intensities is not specified.
+;
+    _item_default.value        'unspecified'
+     save_
+
+
+save__array_intensities.scaling
+    _item_description.description
+;             Multiplicative scaling value to be applied to array data
+              in the manner described by the item
+              _array_intensities.linearity.
+;
+    _item.name                 '_array_intensities.scaling'
+    _item.category_id          array_intensities
+    _item.mandatory_code       no
+    _item_type.code            float
+     save_
+
+
+save__array_intensities.undefined_value
+    _item_description.description
+;             A value to be substituted for undefined values in
+              the data array.
+;
+    _item.name                 '_array_intensities.undefined_value'
+    _item.category_id          array_intensities
+    _item.mandatory_code       no
+    _item_type.code            float
+     save_
+
+
+save__array_intensities.underload
+    _item_description.description
+;             The lowest value at which pixels for this detector are
+              measured.
+
+              The valid pixel values are those less than
+              _array_intensities.overload  and greater than or equal to
+              _array_intensities.underload
+
+;
+    _item.name                 '_array_intensities.underload'
+    _item.category_id          array_intensities
+    _item.mandatory_code       no
+    _item_type.code            float
+    _item_units.code          'counts'
+     save_
+
+
+save__array_intensities.variant
+    _item_description.description
+;             The value of _array_intensities.variant  gives the variant
+              to which the given ARRAY_INTENSITIES row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant  in the
+              VARIANT  category.
+;
+    _item.name                  '_array_intensities.variant'
+    _item.category_id             array_intensities
+    _item.mandatory_code          implicit
+    _item_default.value          .
+    _item_type.code               code
+     save_
+
+
+###################
+# ARRAY_STRUCTURE #
+###################
+
+
+save_ARRAY_STRUCTURE
+    _category.description
+;   Data items in the ARRAY_STRUCTURE  category record the organization and
+    encoding of array data that may be stored in the ARRAY_DATA  category.
+;
+    _category.id                   array_structure
+    _category.mandatory_code       no
+    _category.NX_mapping_details
+; in online version
+;
+     loop_
+    _category_key.name             '_array_structure.id'
+                                   '_array_structure.variant'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'array_data_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;   Example 1.
+;
+;
+     loop_
+    _array_structure.id
+    _array_structure.encoding_type
+    _array_structure.compression_type
+    _array_structure.byte_order
+     image_1       "unsigned 16-bit integer"  none  little_endian
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save__array_structure.byte_order
+    _item_description.description
+;             The order of bytes for integer values which require more
+              than 1 byte.
+
+              (IBM-PCs and compatibles, and DEC VAXs use low-byte-first
+              ordered integers, whereas Hewlett Packard 700
+              series, Sun-4 and Silicon Graphics use high-byte-first
+              ordered integers.  DEC Alphas can produce/use either
+              depending on a compiler switch.)
+;
+
+    _item.name                     '_array_structure.byte_order'
+    _item.category_id               array_structure
+    _item.mandatory_code            yes
+    _item_type.code                 ucode
+     loop_
+    _item_enumeration.value
+    _item_enumeration.detail
+                                   'big_endian'
+;       The first byte in the byte stream of the bytes which make up an
+        integer value is the most significant byte of an integer.
+;
+                                   'little_endian'
+;       The last byte in the byte stream of the bytes which make up an
+        integer value is the most significant byte of an integer.
+;
+     save_
+
+
+save__array_structure.compression_type
+    _item_description.description
+;             Type of data-compression method used to compress the array
+              data.
+;
+    _item.name                   '_array_structure.compression_type'
+    _item.category_id             array_structure
+    _item.mandatory_code          no
+    _item_type.code               ucode
+    _item_default.value           'none'
+     loop_
+    _item_enumeration.value
+    _item_enumeration.detail
+                                  'byte_offset'
+;       Using the 'byte_offset' compression scheme as per A. Hammersley
+        and the CBFlib manual, section 3.3.3
+;
+                                  'canonical'
+;       Using the 'canonical' compression scheme (International Tables
+        for Crystallography Volume G, Section 5.6.3.1) and CBFlib
+        manual section 3.3.1
+;
+                                  'nibble_offset'
+;       Using the 'nibble_offset' compression scheme as per H. Bernstein
+        and the CBFlib manual, section 3.3.4
+;
+                                  'none'
+;       Data are stored in normal format as defined by
+        _array_structure.encoding_type  and
+        _array_structure.byte_order.
+;
+                                  'packed'
+;       Using the 'packed' compression scheme, a CCP4-style packing
+        as per J. P. Abrahams pack_c.c and CBFlib manual, section 3.3.2.
+;
+                                  'packed_v2'
+;       Using the 'packed' compression scheme, version 2, as per
+        J. P. Abrahams pack_c.c and CBFlib manual, section 3.3.2.
+;
+     save_
+
+
+save__array_structure.compression_type_flag
+    _item_description.description
+;             Flags modifying the type of data-compression method used to
+              compress the arraydata.
+;
+    _item.name                   '_array_structure.compression_type_flag'
+    _item.category_id             array_structure
+    _item.mandatory_code          no
+    _item_type.code               ucode
+     loop_
+    _item_enumeration.value
+    _item_enumeration.detail
+                                  'uncorrelated_sections'
+;       When applying packed or packed_v2 compression on an array with
+        uncorrelated sections, do not average in points from the prior
+        section.
+;
+                                  'flat'
+;       When applying packed or packed_v2 compression on an array that
+        treats the entire image as a single line set the maximum number
+        of bits for an offset to 65 bits.
+
+        The flag is included for compatibility with software prior to
+        CBFlib_0.7.7, and should not be used for new data sets.
+;
+     save_
+
+
+save__array_structure.encoding_type
+    _item_description.description
+;             Data encoding of a single element of array data.
+
+              The type 'unsigned 1-bit integer' is used for
+              packed Boolean arrays for masks.  Each element
+              of the array corresponds to a single bit
+              packed in unsigned 8-bit data.
+
+              In several cases, the IEEE format is referenced.
+              See IEEE Standard 754-1985 (IEEE, 1985).
+
+              Reference: IEEE (1985). IEEE Standard for Binary Floating-Point
+              Arithmetic. ANSI/IEEE Std 754-1985. New York: Institute of
+              Electrical and Electronics Engineers.
+;
+
+    _item.name                '_array_structure.encoding_type'
+    _item.category_id          array_structure
+    _item.mandatory_code       yes
+    _item_type.code            uline
+     loop_
+    _item_enumeration.value
+                              'unsigned 1-bit integer'
+                              'unsigned 8-bit integer'
+                              'signed 8-bit integer'
+                              'unsigned 16-bit integer'
+                              'signed 16-bit integer'
+                              'unsigned 32-bit integer'
+                              'signed 32-bit integer'
+                              'signed 32-bit real IEEE'
+                              'signed 64-bit real IEEE'
+                              'signed 32-bit complex IEEE'
+     save_
+
+
+save__array_structure.id
+    _item_description.description
+;             The value of _array_structure.id  must uniquely identify
+              each item of array data.
+
+              This item has been made implicit and given a default value of 1
+              as a convenience in writing miniCBF files.  Normally an
+              explicit name with useful content should be used.
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+             '_array_structure.id'              array_structure      implicit
+             '_array_data.array_id'             array_data           implicit
+             '_array_structure_list.array_id'   array_structure_list implicit
+             '_array_structure_list_section.array_id'
+                                        array_structure_list_section implicit
+             '_array_intensities.array_id'      array_intensities    implicit
+             '_diffrn_data_frame.array_id'      diffrn_data_frame    implicit
+
+
+    _item_default.value           1
+    _item_type.code               code
+     loop_
+    _item_linked.child_name
+    _item_linked.parent_name
+             '_array_data.array_id'
+                      '_array_structure.id'
+             '_array_structure_list.array_id'
+                      '_array_structure.id'
+             '_array_structure_list_section.array_id'
+                      '_array_structure.id'
+             '_array_intensities.array_id'
+                      '_array_structure.id'
+             '_diffrn_data_frame.array_id'
+                      '_array_structure.id'
+
+     save_
+
+
+save__array_structure.variant
+    _item_description.description
+;             The value of _array_structure.variant  gives the variant
+              to which the given ARRAY_STRUCTURE row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant  in the
+              VARIANT  category.
+;
+    _item.name                  '_array_structure.variant'
+    _item.category_id             array_structure
+    _item.mandatory_code          implicit
+    _item_default.value          .
+    _item_type.code               code
+     save_
+
+
+########################
+# ARRAY_STRUCTURE_LIST #
+########################
+
+
+save_ARRAY_STRUCTURE_LIST
+    _category.description
+;    Data items in the ARRAY_STRUCTURE_LIST  category record the size
+     and organization of each array dimension.
+
+     The relationship to physical axes may be given.
+;
+    _category.id                   array_structure_list
+    _category.mandatory_code       no
+    _category.NX_mapping_details
+; in online version
+;
+
+     loop_
+    _category_key.name             '_array_structure_list.array_id'
+                                   '_array_structure_list.index'
+                                   '_array_structure_list.variant'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'array_data_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;       Example 1. An image array of 1300 x 1200 elements.  The raster
+                    order of the image is left to right (increasing) in the
+                    first dimension and bottom to top (decreasing) in
+                    the second dimension.
+;
+;
+        loop_
+       _array_structure_list.array_id
+       _array_structure_list.index
+       _array_structure_list.dimension
+       _array_structure_list.precedence
+       _array_structure_list.direction
+       _array_structure_list.axis_set_id
+        image_1   1    1300    1     increasing  ELEMENT_X
+        image_1   2    1200    2     decreasing  ELEMENY_Y
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save__array_structure_list.array_id
+    _item_description.description
+;             This item is a pointer to _array_structure.id  in the
+              ARRAY_STRUCTURE  category.
+;
+    _item.name                  '_array_structure_list.array_id'
+    _item.category_id             array_structure_list
+    _item.mandatory_code          implicit
+    _item_type.code               code
+save_
+
+save__array_structure_list.array_section_id
+    _item_description.description
+;             This item is a pointer to _array_structure_list_section.id  in the
+              ARRAY_STRUCTURE_LIST_SECTION  category.
+;
+    _item.name                  '_array_structure_list.array_section_id'
+    _item.category_id             array_structure_list
+    _item.mandatory_code          implicit
+    _item_type.code               code
+save_
+
+
+save__array_structure_list.axis_set_id
+    _item_description.description
+;             This is a descriptor for the physical axis or set of axes
+              corresponding to an array index.
+
+              This data item is related to the axes of the detector
+              itself given in DIFFRN_DETECTOR_AXIS, but usually differs
+              in that the axes in this category are the axes of the
+              coordinate system of reported data points, while the axes in
+              DIFFRN_DETECTOR_AXIS  are the physical axes
+              of the detector describing the 'poise' of the detector as an
+              overall physical object.
+
+              If there is only one axis in the set, the identifier of
+              that axis should be used as the identifier of the set.
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+           '_array_structure_list.axis_set_id'
+                                  array_structure_list            yes
+           '_array_structure_list_axis.axis_set_id'
+                                  array_structure_list_axis       implicit
+    _item_type.code               code
+     loop_
+    _item_linked.child_name
+    _item_linked.parent_name
+           '_array_structure_list_axis.axis_set_id'
+                               '_array_structure_list.axis_set_id'
+     save_
+
+
+save__array_structure_list.dimension
+    _item_description.description
+;             The number of elements stored in the array structure in
+              this dimension.
+;
+    _item.name                '_array_structure_list.dimension'
+    _item.category_id          array_structure_list
+    _item.mandatory_code       yes
+    _item_type.code            int
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            1  1
+                            .  1
+     save_
+
+
+save__array_structure_list.direction
+    _item_description.description
+;             Identifies the direction in which this array index changes.
+;
+    _item.name                '_array_structure_list.direction'
+    _item.category_id          array_structure_list
+    _item.mandatory_code       yes
+    _item_type.code            code
+     loop_
+    _item_enumeration.value
+    _item_enumeration.detail
+
+                              'increasing'
+;       Indicates the index changes from 1 to the maximum dimension.
+;
+                              'decreasing'
+;       Indicates the index changes from the maximum dimension to 1.
+;
+     save_
+
+
+save__array_structure_list.index
+    _item_description.description
+;             Identifies the one-based index of the row or column in the
+              array structure.
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+           '_array_structure_list.index'        array_structure_list   yes
+           '_array_structure_list.precedence'   array_structure_list   yes
+           '_array_element_size.index'          array_element_size     yes
+
+    _item_type.code            int
+
+     loop_
+    _item_linked.child_name
+    _item_linked.parent_name
+          '_array_structure_list_section.index'
+                        '_array_structure_list.index'
+          '_array_element_size.index'
+                        '_array_structure_list.index'
+
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            1  1
+                            .  1
+     save_
+
+
+save__array_structure_list.precedence
+    _item_description.description
+;             Identifies the rank order in which this array index changes
+              with respect to other array indices.  The precedence of 1
+              indicates the index which changes fastest.
+;
+    _item.name                '_array_structure_list.precedence'
+    _item.category_id          array_structure_list
+    _item.mandatory_code       yes
+    _item_type.code            int
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            1  1
+                            .  1
+     save_
+
+
+save__array_structure_list.variant
+    _item_description.description
+;             The value of _array_structure_list.variant  gives the variant
+              to which the given ARRAY_STRUCTURE_LIST row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant  in the
+              VARIANT  category.
+;
+    _item.name                  '_array_structure_list.variant'
+    _item.category_id             array_structure_list
+    _item.mandatory_code          implicit
+    _item_default.value          .
+    _item_type.code               code
+     save_
+
+
+################################
+# ARRAY_STRUCTURE_LIST_SECTION #
+################################
+
+
+save_ARRAY_STRUCTURE_LIST_SECTION
+    _category.description
+;   Data items in the ARRAY_STRUCTURE_LIST_SECTION  category identify
+    the dimension-by-dimension start, end and stride of each section of an
+    array that is to be referenced.
+
+    For any array with identifier ARRAYID, array section ids of the form
+    ARRAYID(start1:end1:stride1,start2:end2:stride2, ...) are defined
+    by default.
+
+    For the given index, the elements in the section are of indices:
+    _array_structure_list_section.start,
+    _array_structure_list_section.start + _array_structure_list_section.stride,
+    _array_structure_list_section.start + 2*_array_structure_list_section.stride,
+    ...
+
+    stopping either when the indices leave the limits of the indices
+    of that dimension or
+    [min(_array_structure_list_section.start, _array_structure_list_section.end),
+     max(_array_structure_list_section.start, _array_structure_list_section.end)].
+
+
+    The ordering of these elements is determined by the overall ordering of
+    _array_structure_list_section.array_id  and not by the ordering implied
+    by the stride.
+;
+    _category.id                   array_structure_list_section
+    _category.mandatory_code       no
+    _category.NX_mapping_details
+; in online version
+;
+
+     loop_
+    _category_key.name             '_array_structure_list_section.id'
+                                   '_array_structure_list_section.array_id'
+                                   '_array_structure_list_section.index'
+                                   '_array_structure_list_section.variant'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'array_data_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;       Example 1. An image array, myarray, of 1300 x 1200 elements, and
+                    700 frames is defined in ARRAY_STRUCTURE_LIST, and
+                    the array section identifier
+
+                    "myarray(101:1200,101:1100,1:700:10)"
+
+                    is explicitly defined taking every 10th frame and
+                    removing a 100 pixel border.  Note that even though
+                    the slow index high is 700, the last frame that
+                    will actually be included is only 691.
+;
+;
+
+     loop_
+    _array_structure_list.array_id
+    _array_structure_list.index
+    _array_structure_list.dimension
+    _array_structure_list.precedence
+    _array_structure_list.direction
+    _array_structure_list.axis_set_id
+    myarray   1    1300    1     increasing  ELEMENT_X
+    myarray   2    1200    2     increasing  ELEMENT_Y
+    myarray   3    700     3     increasing  FRAME_NO
+
+     loop_
+    _array_structure_list_section.id
+    _array_structure_list_section.array_id
+    _array_structure_list_section.index
+    _array_structure_list_section.start
+    _array_structure_list_section.end
+    _array_structure_list_section.stride
+    "myarray(101:1200,101:1100,1:700:10)"  myarray 1 101 1200  .
+    "myarray(101:1200,101:1100,1:700:10)"  myarray 2 101 1100  .
+    "myarray(101:1200,101:1100,1:700:10)"  myarray 3   1  700  10
+
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save__array_structure_list_section.array_id
+    _item_description.description
+;             This item is a pointer to _array_structure.id  in the
+              ARRAY_STRUCTURE  category.
+;
+    _item.name                  '_array_structure_list_section.array_id'
+    _item.category_id             array_structure_list_section
+    _item.mandatory_code          implicit
+    _item_type.code               code
+save_
+
+
+save__array_structure_list_section.end
+    _item_description.description
+;             Identifies the ending ordinal, numbered from 1, for an array
+              element of index _array_structure_list_section.index  in the
+              section.
+
+              The value defaults to the dimension for index
+              _array_structure_list_section.index
+              of the array.
+
+              Note that this agrees with the Fortran convention, rather than
+              the Python convention in that, if compatible with the stride,
+              the end element is included in the section as in Fortran, rather
+              than being one beyond the section as in Python.
+;
+
+    _item.name               '_array_structure_list_section.end'
+    _item.category_id          array_structure_list_section
+    _item.mandatory_code       implicit
+    _item_type.code            int
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            1  1
+                            .  1
+     save_
+
+
+save__array_structure_list_section.id
+    _item_description.description
+;             Uniquely identifies the array section chosen.
+
+              To avoid confusion array section IDs that contain parentheses
+              should conform to the default syntax
+
+              ARRAYID(start1:end1:stride1,start2:end2:stride2, ...)
+;
+    _item.name                  '_array_structure_list_section.id'
+    _item.category_id             array_structure_list_section
+    _item.mandatory_code          yes
+    _item_type.code               code
+
+     loop_
+    _item_linked.child_name
+    _item_linked.parent_name
+                            '_diffrn_data_frame.array_section_id'
+                              '_array_structure_list_section.id'
+                            '_map_segment.array_section_id'
+                              '_array_structure_list_section.id'
+
+save_
+
+
+save__array_structure_list_section.index
+    _item_description.description
+;             This item is a pointer to _array_structure_list.index
+              in the ARRAY_STRUCTURE_LIST  category.
+
+              Identifies the one-based index of the row, column, sheet ...
+              the ARRAY_STRUCTURE_LIST  category.
+
+              For a multidimensional array, a value must be explicitly given.
+
+              If an index is omitted from a section then all elements for that
+              index are assumed to be included in the section.
+;
+    _item.name                 '_array_structure_list_section.index'
+    _item.category_id          array_structure_list_section
+    _item.mandatory_code       implicit
+    _item_type.code            int
+     save_
+
+
+save__array_structure_list_section.start
+    _item_description.description
+;             Identifies the starting ordinal, numbered from 1,
+              for an array element of index _array_structure_list_section.index
+              in the section.
+
+              The value defaults to 1.   For the given index, the elements in
+              the section are of indices:
+              _array_structure_list_section.start,
+              _array_structure_list_section.start
+                 + _array_structure_list_section.stride,
+              _array_structure_list_section.start
+                 + 2*_array_structure_list_section.stride,
+                  ...
+
+              stopping either when the indices leave the limits of the indices
+              of that dimension or
+              [min(_array_structure_list_section.start,
+                  _array_structure_list_section.end ),
+               max(_array_structure_list_section.start,
+                  _array_structure_list_section.end )].
+
+
+              The ordering of these elements is determined by the overall
+              ordering of _array_structure_list_section.array_id  and not by
+              the ordering implied by the stride.
+;
+    _item.name                 '_array_structure_list_section.start'
+    _item.category_id          array_structure_list_section
+    _item.mandatory_code       implicit
+    _item_type.code            int
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            1  1
+                            .  1
+     save_
+
+
+save__array_structure_list_section.stride
+    _item_description.description
+;             Identifies the incremental steps to be taken when moving
+              element to element in the section in that particular
+              dimension.  The value of _array_structure_list_section.stride
+              may be positive or negative.  If the stride is zero, the section
+              is just defined by _array_structure_list_section.start.
+;
+    _item.name                '_array_structure_list_section.stride'
+    _item.category_id          array_structure_list_section
+    _item.mandatory_code       no
+    _item_default.value        1
+    _item_type.code            int
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            1  1
+                            .  1
+     save_
+
+
+save__array_structure_list_section.variant
+    _item_description.description
+;             The value of _array_structure_list_section.variant  gives the
+              variant to which the given ARRAY_STRUCTURE_LIST_SECTION row
+              is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant  in the
+              VARIANT  category.
+;
+    _item.name                  '_array_structure_list_section.variant'
+    _item.category_id             array_structure_list_section
+    _item.mandatory_code          implicit
+    _item_default.value          .
+    _item_type.code               code
+     save_
+
+
+#############################
+# ARRAY_STRUCTURE_LIST_AXIS #
+#############################
+
+save_ARRAY_STRUCTURE_LIST_AXIS
+    _category.description
+;   Data items in the ARRAY_STRUCTURE_LIST_AXIS  category describe
+    the physical settings of sets of axes for the centres of pixels that
+    correspond to data points described in the
+    ARRAY_STRUCTURE_LIST  category.
+
+    In the simplest cases, the physical increments of a single axis correspond
+    to the increments of a single array index.  More complex organizations,
+    e.g. spiral scans, may require coupled motions along multiple axes.
+
+    Note that a spiral scan uses two coupled axes: one for the angular
+    direction and one for the radial direction.  This differs from a
+    cylindrical scan for which the two axes are not coupled into one
+    set.
+
+    Axes may be specified either for an entire array or for just a section
+    of an array.
+;
+    _category.id                   array_structure_list_axis
+    _category.mandatory_code       no
+    _category.NX_mapping_details
+; in online version
+;
+
+     loop_
+    _category_key.name
+                                  '_array_structure_list_axis.axis_set_id'
+                                  '_array_structure_list_axis.axis_id'
+                                  '_array_structure_list_axis.variant'
+     loop_
+    _category_group.id           'inclusive_group'
+                                 'array_data_group'
+     save_
+
+
+save__array_structure_list_axis.axis_id
+    _item_description.description
+;             The value of this data item is the identifier of one of
+              the axes in the set of axes for which settings are being
+              specified.
+
+              Multiple axes may be specified for the same value of
+              _array_structure_list_axis.axis_set_id.
+
+              This item is a pointer to _axis.id  in the
+              AXIS  category.
+;
+    _item.name                 '_array_structure_list_axis.axis_id'
+    _item.category_id          array_structure_list_axis
+    _item.mandatory_code       yes
+    _item_type.code            code
+     save_
+
+
+save__array_structure_list_axis.axis_set_id
+    _item_description.description
+;             The value of this data item is the identifier of the
+               set of axes for which axis settings are being specified.
+
+               Multiple axes may be specified for the same value of
+               _array_structure_list_axis.axis_set_id.
+
+               This item is a pointer to
+               _array_structure_list.axis_set_id
+               in the ARRAY_STRUCTURE_LIST  category.
+
+               If this item is not specified, it defaults to the corresponding
+               axis identifier.
+;
+    _item.name                 '_array_structure_list_axis.axis_set_id'
+    _item.category_id          array_structure_list_axis
+    _item.mandatory_code       implicit
+    _item_type.code            code
+     save_
+
+
+save__array_structure_list_axis.angle
+    _item_description.description
+;             The setting of the specified axis in degrees for the first
+               data point of the array index with the corresponding value
+               of _array_structure_list.axis_set_id.  If the index is
+               specified as 'increasing', this will be the centre of the
+               pixel with index value 1.  If the index is specified as
+             'decreasing', this will be the centre of the pixel with
+               maximum index value.
+;
+    _item.name                 '_array_structure_list_axis.angle'
+    _item.category_id          array_structure_list_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'degrees'
+     save_
+
+
+save__array_structure_list_axis.angle_increment
+    _item_description.description
+;             The pixel-centre-to-pixel-centre increment in the angular
+               setting of the specified axis in degrees.  This is not
+               meaningful in the case of 'constant velocity' spiral scans
+               and should not be specified for this case.
+
+               See _array_structure_list_axis.angular_pitch.
+
+;
+    _item.name                 '_array_structure_list_axis.angle_increment'
+    _item.category_id          array_structure_list_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'degrees'
+     save_
+
+
+save__array_structure_list_axis.displacement
+    _item_description.description
+;             The setting of the specified axis in millimetres for the first
+               data point of the array index with the corresponding value
+               of _array_structure_list.axis_set_id.  If the index is
+               specified as 'increasing', this will be the centre of the
+               pixel with index value 1.  If the index is specified as
+             'decreasing', this will be the centre of the pixel with
+               maximum index value.
+;
+    _item.name               '_array_structure_list_axis.displacement'
+    _item.category_id          array_structure_list_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save__array_structure_list_axis.fract_displacement
+    _item_description.description
+;             The setting of the specified axis as a decimal fraction of
+               the axis unit vector for the first data point of the array
+               index with the corresponding value of
+               _array_structure_list.axis_set_id.
+
+               If the index is specified as 'increasing', this will be the
+               centre of the pixel with index value 1.  If the index is
+               specified as 'decreasing', this will be the centre of the
+               pixel with maximum index value.
+;
+    _item.name               '_array_structure_list_axis.fract_displacement'
+    _item.category_id          array_structure_list_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+     save_
+
+
+save__array_structure_list_axis.displacement_increment
+    _item_description.description
+;             The pixel-centre-to-pixel-centre increment for the displacement
+               setting of the specified axis in millimetres.
+;
+    _item.name
+        '_array_structure_list_axis.displacement_increment'
+    _item.category_id          array_structure_list_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save__array_structure_list_axis.fract_displacement_increment
+    _item_description.description
+;             The pixel-centre-to-pixel-centre increment for the displacement
+               setting of the specified axis as a decimal fraction of the
+               axis unit vector.
+;
+    _item.name
+        '_array_structure_list_axis.fract_displacement_increment'
+    _item.category_id          array_structure_list_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save__array_structure_list_axis.angular_pitch
+    _item_description.description
+;             The pixel-centre-to-pixel-centre distance for a one-step
+               change in the setting of the specified axis in millimetres.
+
+               This is meaningful only for 'constant velocity' spiral scans
+               or for uncoupled angular scans at a constant radius
+               (cylindrical scans) and should not be specified for cases
+               in which the angle between pixels (rather than the distance
+               between pixels) is uniform.
+
+               See _array_structure_list_axis.angle_increment.
+;
+    _item.name               '_array_structure_list_axis.angular_pitch'
+    _item.category_id          array_structure_list_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save__array_structure_list_axis.radial_pitch
+    _item_description.description
+;             The radial distance from one 'cylinder' of pixels to the
+               next in millimetres.  If the scan is a 'constant velocity'
+               scan with differing angular displacements between pixels,
+               the value of this item may differ significantly from the
+               value of _array_structure_list_axis.displacement_increment.
+;
+    _item.name               '_array_structure_list_axis.radial_pitch'
+    _item.category_id          array_structure_list_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save__array_structure_list_axis.reference_angle
+    _item_description.description
+;             The value of _array_structure_list_axis.reference_angle
+               specifies the setting of the angle of this axis used for
+               determining a reference beam centre and a reference detector
+               distance.  It is normally expected to be identical to the
+               value of _array_structure_list_axis.angle.
+
+;
+    _item.name '_array_structure_list_axis.reference_angle'
+    _item.category_id          array_structure_list_axis
+    _item.mandatory_code       implicit
+    _item_type.code            float
+    _item_units.code           'degrees'
+     save_
+
+
+save__array_structure_list_axis.reference_displacement
+    _item_description.description
+;             The value of _array_structure_list_axis.reference_displacement
+               specifies the setting of the displacement of this axis used
+               for determining a reference beam centre and a reference detector
+               distance.  It is normally expected to be identical to the value
+               of _array_structure_list_axis.displacement.
+
+;
+    _item.name '_array_structure_list_axis.reference_displacement'
+    _item.category_id          array_structure_list_axis
+    _item.mandatory_code       implicit
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save__array_structure_list_axis.variant
+    _item_description.description
+;            The value of _array_structure_list_axis.variant  gives the variant
+              to which the given ARRAY_STRUCTURE_LIST_AXIS row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant  in the
+              VARIANT  category.
+;
+    _item.name                  '_array_structure_list_axis.variant'
+    _item.category_id             array_structure_list_axis
+    _item.mandatory_code          implicit
+    _item_default.value          .
+    _item_type.code               code
+     save_
+
+
+########
+# AXIS #
+########
+
+save_AXIS
+    _category.description
+;   Data items in the AXIS  category record the information required
+     to describe the various goniometer, detector, source and other
+     axes needed to specify a data collection or the axes defining the
+     coordinate system of an image.
+
+     The location of each axis is specified by two vectors: the axis
+     itself, given by a unit vector in the direction of the axis, and
+     an offset to the base of the unit vector.
+
+     The vectors defining an axis are referenced to an appropriate
+     coordinate system, given in _axis.system.  The axis vector itself,
+       [_axis.vector[1], _axis.vector[2], _axis.vector[3]],
+     is a dimensionless unit vector.  Where meaningful, an offset vector
+       [_axis.offset[1], _axis.offset[2], _axis.offset[3]]
+     supplies the offsets to the base of a rotation or translation axis in
+     X, Y and Z.  This is appropriate for the imgCIF standard laboratory
+     coordinate system, the NeXus/HDF5 McStas laboratory coordinate system
+     and the last two Cartesian coordinate systems, but for the direct lattice,
+     X corresponds to a, Y to b and Z to c, while for the reciprocal lattice,
+     X corresponds to a*, Y to b* and Z to c*.
+
+     For purposes of visualization, all the coordinate systems are
+     taken as right-handed, i.e. using the convention that the extended
+     thumb of a right hand could point along the first (X) axis, the
+     straightened pointer finger could point along the second (Y) axis
+     and the middle finger folded inward could point along the third (Z)
+     axis.  For a right-handed rotation axis, if the right hand is wrapped
+     around the axis with the thumb pointed in the direction of the axis,
+     the fingers point in the positive rotation direction, i.e. clockwise.
+
+     THE IMGCIF STANDARD LABORATORY COORDINATE SYSTEM
+
+
+     The imgCIF standard laboratory coordinate system is a right-handed
+     orthogonal coordinate system similar to that used by MOSFLM,
+     but imgCIF puts Z along the X-ray beam, rather than putting X along the
+     X-ray beam as in MOSFLM.
+
+     The vectors for the imgCIF standard laboratory coordinate system
+     form a right-handed Cartesian coordinate system with its origin
+     in the sample or specimen.  The origin of the axis system should,
+     if possible, be defined in terms of mechanically stable axes to be
+     both in the sample and in the beam.  If the sample goniometer or other
+     sample positioner has two axes the intersection of which defines a
+     unique point at which the sample should be mounted to be bathed
+     by the beam, that will be the origin of the axis system.  If no such
+     point is defined, then the midpoint of the line of intersection
+     between the sample and the centre of the beam will define the origin.
+     For this definition the sample positioning system will be set at
+     its initial reference position for the experiment.
+
+
+                             | Y (to complete right-handed system)
+                             |
+                             |
+                             |
+                             |
+                             |
+                             |________________X
+                            /       principal goniometer axis
+                           /
+                          /
+                         /
+                        /
+                       /Z (to source)
+
+
+
+
+     Axis 1 (X): The X-axis is aligned to the mechanical axis pointing from
+     the sample or specimen along the  principal axis of the goniometer or
+     sample positioning system if the sample positioning system has an axis
+     that intersects the origin and which forms an angle of more than 22.5
+     degrees with the beam axis.
+
+     Axis 2 (Y): The Y-axis completes an orthogonal right-handed system
+     defined by the X-axis and the Z-axis (see below).
+
+     Axis 3 (Z): The Z-axis is derived from the source axis which goes from
+     the sample to the source.  The Z-axis is the component of the source axis
+     in the direction of the source orthogonal to the X-axis in the plane
+     defined by the X-axis and the source axis.
+
+     If the conditions for the X-axis can be met, the coordinate system
+     will be based on the goniometer or other sample positioning system
+     and the beam and not on the orientation of the detector, gravity etc.
+     The vectors necessary to specify all other axes are given by sets of
+     three components in the order (X, Y, Z).
+     If the axis involved is a rotation axis, it is right-handed, i.e. as
+     one views the object to be rotated from the origin (the tail) of the
+     unit vector, the rotation is clockwise.  If a translation axis is
+     specified, the direction of the unit vector specifies the sense of
+     positive translation.
+
+     In some experimental techniques, there is no goniometer or the principal
+     axis of the goniometer is at a small acute angle with respect to
+     the source axis.  In such cases, other reference axes are needed
+     to define a useful coordinate system.  The order of priority in
+     defining directions in such cases is to use the detector, then
+     gravity, then north.
+
+     If the X-axis cannot be defined as above, then the
+     direction (not the origin) of the X-axis should be parallel to the axis
+     of the primary detector element corresponding to the most rapidly
+     varying dimension of that detector element's data array, with its
+     positive sense corresponding to increasing values of the index for
+     that dimension.  If the detector is such that such a direction cannot
+     be defined (as with a point detector) or that the direction forms an
+     angle of less than 22.5 degrees with respect to the source axis, then
+     the X-axis should be chosen so that if the Y-axis is chosen
+     in the direction of gravity, and the Z-axis is chosen to be along
+     the source axis, a right-handed orthogonal coordinate system is chosen.
+     In the case of a vertical source axis, as a last resort, the
+     X-axis should be chosen to point north.
+
+     All rotations are given in degrees and all translations are given in mm.
+
+     Axes may be dependent on one another.  The X-axis is the only goniometer
+     axis the direction of which is strictly connected to the hardware.  All
+     other axes are specified by the positions they would assume when the
+     axes upon which they depend are at their zero points.
+
+     When specifying detector axes, the axis is given to the beam centre.
+     The location of the beam centre on the detector should be given in the
+     DIFFRN_DETECTOR  category in distortion-corrected millimetres from
+     the (0,0) corner of the detector.
+
+     For convenience when describing detector element (module) placement,
+     an optional mounting rotation axis and rotation angle may be
+     specified.  In such cases, the mounting rotation axis and angle
+     of rotation around the mounting rotation axis are applied after
+     applying the transformations upon which the given axis depends.
+
+     It should be noted that many different origins arise in the definition
+     of an experiment.  In particular, as noted above, it is necessary to
+     specify the location of the beam centre on the detector in terms
+     of the origin of the detector, which is, of course, not coincident
+     with the centre of the sample.
+
+     THE NEXUS/HDF5 MCSTAS LABORATORY COORDINATE SYSTEM
+
+
+     The standard coordinate frame in NeXus is the McStas coordinate frame,
+     in which the Z-axis points in the direction of the incident beam, the
+     X-axis is orthogonal to the Z-axis in the horizontal plane and pointing
+     left as seen from the source and the Y-axis points upwards.  The
+     origin is in the sample.
+
+     Differences in Coordinate Frames
+
+     The standard coordinate frame in imgCIF/CBF aligns the X-axis to the
+     principal goniometer axis, and chooses the Z-axis to point from the sample
+     into the beam.  If the beam is not orthogonal to the X-axis, the Z-axis
+     is the component of the vector that points into the beam orthogonal to the
+     X-axis.  The Y-axis is chosen to complete a right-handed axis system.
+
+     Let us call the NeXus coordinate axes, X_nx, Y_nx and Z_nx, the
+     imgCIF/CBF coordinate axes, X_cbf, Y_cbf and Z_cbf and the direction
+     of gravity, Gravity.  In order to translate a vector v_nx = ( x, y, z)
+     from the NeXus coordinate system to the imgCIF coordinate system, we
+     also need two additional axes, as unit vectors, Gravity_cbf the downwards
+     direction, and  Beam_cbf, the direction of the beam, e.g. ( 0, 0, -1).
+
+     In practice, the beam is not necessarily perfectly horizontal, so Y_nx
+     is not necessarily perfectly vertical. Therefore, in order to generate
+     X_nx, Y_nx and Z_nx some care is needed.  The cross product between two
+     vectors a and b is a new vector c orthogonal to both a and b,
+     chosen so that a, b, c is a right-handed system.  If a and b are
+     orthogonal unit vectors, this right-handed system is an orthonormal
+     coordinate system.
+
+     In the CBF coordinate frame, Z_nx is aligned to Beam_cbf:
+
+        Z_nx = Beam_cbf.
+
+     X_nx is defined as being horizontal at right angles to the beam,
+     pointing to the left when seen from the source.  Assuming the beam is
+     not vertical, we can compute X_nx as the normalized cross product of
+     the  beam and gravity:
+
+        X_nx = (Beam_cbf x Gravity_cbf)/||Beam_cbf x Gravity_cbf||.
+
+     To see that this satisfies the constraint of being horizontal and
+     pointing to the left, consider the case of Beam = ( 0, 0, -1 )
+     and Gravity = ( 0, 0, 1 ); then we would have X_nx = ( 1, 0, 0 )
+     from the cross product above.  The normalization is only necessary
+     if the beam is not horizontal.
+
+     Finally Y_nx is computed as the cross product of the beam and X_nx,
+     completing an orthonormal right-handed system with Y_nx pointing upwards
+
+        Y_nx = Beam_cbf x X_nx.
+
+     Then we know that in the imgCIF/CBF coordinate frame
+
+        v_nx = X.X_nx + Y.Y_nx + Z.Z_nx.
+
+     Thus, given the imgCIF/CBF vectors for the true direction of the beam
+     and the true direction of gravity, we have a linear transformation from
+     the NeXus coordinate frame to the imgCIF/CBF coordinate frame.   The
+     origins of the two frames agree.   The inverse linear transformation will
+     transform a vector in the imgCIF/CBF coordinate frame into the NeXus
+     coordinate frame.
+
+     In the common case in which the beam is orthogonal to the principal
+     goniometer axis so that Beam_cbf = ( 0, 0, -1 ) and the imgCIF/CBF
+     Y-axis points upwards, the transformation inverts the X and Z axes.
+     In the other common case in which the beam is orthogonal to the
+     principal goniometer axis and the imgCIF/CBF Y-axis points
+     downwards, the transformation inverts the Y and Z axes.
+
+     Mapping axes
+
+     There are two transformations needed:  coord_xform(v) which takes a vector,
+     v, in the CBF imgCIF Standard Laboratory Coordinate System and returns the
+     equivalent McStas coordinate vector, and offset_xform(o) which takes an
+     offset, o, in the CBF imgCIF Standard Laboratory Coordinate System and
+     returns the equivalent NeXus offset.
+
+     In imgCIF/CBF all the information about all axes other than their
+     settings are gathered in one AXIS category.  The closest equivalent
+     container in NeXus is the NXinstrument class.  We put the information
+     about detector axes into a
+     detector:NXdetector/transformations:NXtransformations NeXus class instance,
+     information about the goniometer into a
+     goniometer:NXgoniometer/transformations:NXtransformations NeXus
+     class instance, etc.  Additionally, in view of the general nature of
+     some axes, such as the coordinate frame axes and gravity, we add a
+     transformations:NXtransformation NeXus class instance under NXentry with
+     axis__gravity, axis__beam and other axes not tied to specific equipment.
+
+     We have applied the coordinate frame transformation changing
+     the CBF laboratory coordinates into McStas coordinates.  Notice that X and
+     Z have changed direction, but Y has not.   In other experimental setups,
+     other transformations may occur.   The offsets for dependent axes are
+     given relative to the total offset of axes on which that axis is dependent.
+     Note that the axis settings do not enter into this calculation, because the
+     offsets of dependent axes are given with all axes at their zero settings.
+
+
+     The cbf_location attribute gives a mapping back into the CBF AXIS category
+     in dotted notation.  The first component is the data block.  The second
+     component is "axis".  The third component is either "vector" or
+     "offset"  for information drawn from the AXIS.VECTOR[...] or
+     AXIS.OFFSET[...] respectively.  The last component is the CBF row number
+     to facilitate recovering the original CBF layout.
+
+
+     THE DIRECT LATTICE (FRACTIONAL COORDINATES)
+
+
+     The unit cell, reciprocal cell and crystallographic orthogonal
+     Cartesian coordinate system are defined by the CELL and the matrices
+     in the ATOM_SITES category.
+
+     The direct lattice coordinate system is a system of fractional
+     coordinates aligned to the crystal, rather than to the laboratory.
+     This is a natural coordinate system for maps and atomic coordinates.
+     It is the simplest coordinate system in which to apply symmetry.
+     The axes are determined by the cell edges, and are not necessarily
+     orthogonal.  This coordinate system is not uniquely defined and
+     depends on the cell parameters in the CELL category and the
+     settings chosen to index the crystal.
+
+     Molecules in a crystal studied by X-ray diffraction are organized
+     into a repeating regular array of unit cells.  Each unit cell is defined
+     by three vectors, a, b and c.  To quote from Drenth (2001),
+
+
+     "The choice of the unit cell is not unique and therefore, guidelines
+     have been established for selecting the standard basis vectors and
+     the origin.  They are based on symmetry and metric considerations:
+
+      "(1)  The axial system should be right-handed.
+       (2)  The basis vectors should coincide as much as possible with
+       directions of highest symmetry.
+       (3)  The cell taken should be the smallest one that satisfies
+       condition (2)
+       (4)  Of all the lattice vectors, none is shorter than a.
+       (5)  Of those not directed along a, none is shorter than b.
+       (6)  Of those not lying in the ab plane, none is shorter than c.
+       (7)  The three angles between the basis vectors a, b and c are
+       either all acute (< 90 degrees) or all obtuse ( >= 90 degrees)."
+
+     These rules do not produce a unique result that is stable under
+     the assumption of experimental errors, and the resulting cell
+     may not be primitive.
+
+     In this coordinate system, the vector (.5, .5, .5) is in the middle
+     of the given unit cell.
+
+     Grid coordinates are an important variation on fractional coordinates
+     used when working with maps.  In imgCIF, the conversion from
+     fractional to grid coordinates is implicit in the array indexing
+     specified by _array_structure_list.dimension.  Note that this
+     implicit grid-coordinate scheme is 1-based, not zero-based, i.e.
+     the origin of the cell for axes along the cell edges with no
+     specified _array_structure_list_axis.displacement will have
+     grid coordinates of (1,1,1), i.e. array indices of (1,1,1).
+
+     THE ORTHOGONAL CARTESIAN COORDINATE SYSTEM (REAL SPACE)
+
+
+     The orthogonal Cartesian coordinate system is a transformation of
+     the direct lattice to the actual physical coordinates of atoms in
+     space.  It is similar to the laboratory coordinate system, but
+     is anchored to and moves with the crystal, rather than being
+     anchored to the laboratory.  The transformation from fractional
+     to orthogonal Cartesian coordinates is given by the
+              _atom_sites.Cartn_transf_matrix[i][j]  and
+              _atom_sites.Cartn_transf_vector[i]
+     tags.  A common choice for the matrix of the transformation is
+     given in Protein Data Bank (1992):
+
+              | a      b cos \g   c cos \b                            |
+              | 0      b sin \g   c (cos \a - cos \b cos \g)/sin \g   |
+              | 0      0          V/(a b sin \g)                      |
+
+     This is a convenient coordinate system in which to do fitting
+     of models to maps and in which to understand the chemistry of
+     a molecule.
+
+     THE RECIPROCAL LATTICE
+
+
+     The reciprocal lattice coordinate system is used for diffraction
+     intensities.  It is based on the reciprocal cell, the dual of the cell,
+     in which reciprocal cell edges are derived from direct cell faces:
+
+        a* = bc sin \a /V  b* = ac sin \b /V  c* = ab sin \g /V
+        cos \a* = (cos \b  cos \g  - cos \a )/(sin \b sin \g )
+        cos \b* = (cos \a  cos \g  - cos \b )/(sin \a sin \g )
+        cos \g* = (cos \a  cos \b  - cos \g )/(sin \a sin \b )
+        V = abc (1 - cos^2^ \a
+                       - cos^2^ \b
+                       - cos^2^ \g
+                       + 2 cos \a cos \b cos \g )^1/2^
+
+     In this form the dimensions of the reciprocal lattice are in reciprocal
+     \%angstr\"oms (\%A^-1^).  A dimensionless form can be obtained by
+     multiplying by the wavelength.  Reflections are commonly indexed against
+     this coordinate system as (h, k, l) triples.
+
+
+
+     References:
+
+     Drenth, J. (2001). Introduction to basic crystallography.
+     International tables for crystallography, Vol. F, Crystallography of
+     biological macromolecules, edited by M. G. Rossmann & E. Arnold,
+     1st ed., ch. 2.1, pp. 44--63. Dordrecht: Kluwer Academic Publishers.
+
+     Leslie, A. G. W. & Powell, H. (2004). MOSFLM v6.11.
+     MRC Laboratory of Molecular Biology, Hills Road, Cambridge, England.
+     http://www.CCP4.ac.uk/dist/X-windows/Mosflm/.
+
+     Stout, G. H. & Jensen, L. H. (1989). X-ray structure determination,
+     2nd ed., 453 pp. New York: Wiley.
+
+     Protein Data Bank (1992). Atomic Coordinate and Bibliographic
+     Entry Format Description. Report, February 1992. Brookhaven, NY, USA:
+     Brookhaven National Laboratory.
+;
+    _category.id                   axis
+    _category.mandatory_code       no
+  _category.NX_mapping_details
+; in online version
+;
+
+     loop_
+    _category_key.name          '_axis.id'
+                                '_axis.equipment'
+                                '_axis.variant'
+     loop_
+    _category_group.id           'inclusive_group'
+                                 'axis_group'
+                                 'diffrn_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;      Example 1.
+
+        This example shows the axis specification of the axes of a
+        kappa-geometry goniometer [see Stout, G. H. & Jensen, L. H.
+        (1989). X-ray structure determination. A practical
+        guide, 2nd ed. p. 134. New York: Wiley Interscience].
+
+        There are three axes specified, and no offsets.  The outermost axis,
+        omega, is pointed along the X axis.  The next innermost axis, kappa,
+        is at a 50 degree angle to the X axis, pointed away from the source.
+        The innermost axis, phi, aligns with the X axis when omega and
+        phi are at their zero points.  If T-omega, T-kappa and T-phi
+        are the transformation matrices derived from the axis settings,
+        the complete transformation would be:
+            X' = (T-omega) (T-kappa) (T-phi) X
+;
+;
+         loop_
+        _axis.id
+        _axis.type
+        _axis.equipment
+        _axis.depends_on
+        _axis.vector[1] _axis.vector[2] _axis.vector[3]
+        omega rotation goniometer     .    1        0        0
+        kappa rotation goniometer omega    -.64279  0       -.76604
+        phi   rotation goniometer kappa    1        0        0
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;      Example 2.
+
+        This example shows the axis specification of the axes of a
+        detector, source and gravity.  The order has been changed as a
+        reminder that the ordering of presentation of tokens is not
+        significant.  The centre of rotation of the detector has been taken
+        to be 68 mm in the direction away from the source.
+;
+;
+        loop_
+        _axis.id
+        _axis.type
+        _axis.equipment
+        _axis.depends_on
+        _axis.vector[1] _axis.vector[2] _axis.vector[3]
+        _axis.offset[1] _axis.offset[2] _axis.offset[3]
+        source       .        source     .       0     0     1   . . .
+        gravity      .        gravity    .       0    -1     0   . . .
+        tranz     translation detector rotz      0     0     1   0 0 -68
+        twotheta  rotation    detector   .       1     0     0   . . .
+        roty      rotation    detector twotheta  0     1     0   0 0 -68
+        rotz      rotation    detector roty      0     0     1   0 0 -68
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;      Example 3.
+
+        This example shows the axis specification of the axes for a map,
+        using fractional coordinates.  Each cell edge has been divided
+        into a grid of 50 divisions in the ARRAY_STRUCTURE_LIST_AXIS
+        category.  The map is using only the first octant of the grid
+        in the ARRAY_STRUCTURE_LIST category.
+
+        The fastest changing axis is along A, then along B,
+        and the slowest is along C.
+
+        The map sampling is being done in the middle of each grid
+        division.
+
+;
+;
+        loop_
+        _axis.id
+        _axis.system
+        _axis.vector[1] _axis.vector[2] _axis.vector[3]
+        CELL_A_AXIS    fractional       1 0 0
+        CELL_B_AXIS    fractional       0 1 0
+        CELL_C_AXIS    fractional       0 0 1
+
+        loop_
+        _array_structure_list.array_id
+        _array_structure_list.index
+        _array_structure_list.dimension
+        _array_structure_list.precedence
+        _array_structure_list.direction
+        _array_structure_list.axis_set_id
+        map 1 25 1 increasing CELL_A_AXIS
+        map 1 25 2 increasing CELL_B_AXIS
+        map 1 25 3 increasing CELL_C_AXIS
+
+        loop_
+        _array_structure_list_axis.axis_id
+        _array_structure_list_axis.fract_displacement
+        _array_structure_list_axis.fract_displacement_increment
+        CELL_A_AXIS 0.01 0.02
+        CELL_B_AXIS 0.01 0.02
+        CELL_C_AXIS 0.01 0.02
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;      Example 4.
+
+        This example shows the axis specification of the axes for a map,
+        this time as orthogonal \%angstr\"oms, using the same coordinate system
+        as for the atomic coordinates.  The map is sampling every 1.5
+        \%A (1.5e-7 mm) in a map segment 37.5 \%A on a side.
+;
+;
+        loop_
+        _axis.id
+        _axis.system
+        _axis.vector[1] _axis.vector[2] _axis.vector[3]
+        X    orthogonal       1 0 0
+        Y    orthogonal       0 1 0
+        Z    orthogonal       0 0 1
+
+                loop_
+        _array_structure_list.array_id
+        _array_structure_list.index
+        _array_structure_list.dimension
+        _array_structure_list.precedence
+        _array_structure_list.direction
+        _array_structure_list.axis_set_id
+        map 1 25 1 increasing X
+        map 2 25 2 increasing Y
+        map 3 25 3 increasing Z
+
+        loop_
+        _array_structure_list_axis.axis_id
+        _array_structure_list_axis.displacement
+        _array_structure_list_axis.displacement_increment
+        X 7.5e-8 1.5e-7
+        Y 7.5e-8 1.5e-7
+        Z 7.5e-8 1.5e-7
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;       Example 5.
+
+    This example shows an excerpt from the axis specification of an FEL detector
+    provided by N. Sauter and A. Brewster.
+
+    The detector is divided into 4 quadrants, each quadrant contains 8 sensors
+    and each sensor contains 2 ASICs.  We want to be able to refine the
+    placement of each of these elements, so we maintain the set of vectors
+    that places them.
+;
+;
+     loop_
+    _diffrn_detector_axis.detector_id
+    _diffrn_detector_axis.axis_id
+    CSPAD_FRONT AXIS_D0_X
+    CSPAD_FRONT AXIS_D0_Y
+    CSPAD_FRONT AXIS_D0_Z
+    CSPAD_FRONT AXIS_D0_R
+    CSPAD_FRONT FS_D0Q0
+    CSPAD_FRONT FS_D0Q0S0
+    CSPAD_FRONT FS_D0Q0S0A0
+    CSPAD_FRONT FS_D0Q0S0A1
+    CSPAD_FRONT FS_D0Q0S1
+    CSPAD_FRONT FS_D0Q0S1A0
+    CSPAD_FRONT FS_D0Q0S1A1
+    CSPAD_FRONT FS_D0Q0S2
+    CSPAD_FRONT FS_D0Q0S2A0
+    CSPAD_FRONT FS_D0Q0S2A1
+    CSPAD_FRONT FS_D0Q0S3
+    CSPAD_FRONT FS_D0Q0S3A0
+    CSPAD_FRONT FS_D0Q0S3A1
+    CSPAD_FRONT FS_D0Q0S4
+    CSPAD_FRONT FS_D0Q0S4A0
+    CSPAD_FRONT FS_D0Q0S4A1
+    CSPAD_FRONT FS_D0Q0S5
+    CSPAD_FRONT FS_D0Q0S5A0
+    CSPAD_FRONT FS_D0Q0S5A1
+    CSPAD_FRONT FS_D0Q0S6
+    CSPAD_FRONT FS_D0Q0S6A0
+    CSPAD_FRONT FS_D0Q0S6A1
+    CSPAD_FRONT FS_D0Q0S7
+    CSPAD_FRONT FS_D0Q0S7A0
+    CSPAD_FRONT FS_D0Q0S7A1
+    CSPAD_FRONT FS_D0Q1
+    CSPAD_FRONT FS_D0Q1S0
+    CSPAD_FRONT FS_D0Q1S0A0
+    CSPAD_FRONT FS_D0Q1S0A1
+    CSPAD_FRONT FS_D0Q1S1
+    CSPAD_FRONT FS_D0Q1S1A0
+    CSPAD_FRONT FS_D0Q1S1A1
+    CSPAD_FRONT FS_D0Q1S2
+    CSPAD_FRONT FS_D0Q1S2A0
+    CSPAD_FRONT FS_D0Q1S2A1
+    CSPAD_FRONT FS_D0Q1S3
+    CSPAD_FRONT FS_D0Q1S3A0
+    CSPAD_FRONT FS_D0Q1S3A1
+    CSPAD_FRONT FS_D0Q1S4
+    CSPAD_FRONT FS_D0Q1S4A0
+    CSPAD_FRONT FS_D0Q1S4A1
+    CSPAD_FRONT FS_D0Q1S5
+    CSPAD_FRONT FS_D0Q1S5A0
+    CSPAD_FRONT FS_D0Q1S5A1
+    CSPAD_FRONT FS_D0Q1S6
+    CSPAD_FRONT FS_D0Q1S6A0
+    CSPAD_FRONT FS_D0Q1S6A1
+    CSPAD_FRONT FS_D0Q1S7
+    CSPAD_FRONT FS_D0Q1S7A0
+    CSPAD_FRONT FS_D0Q1S7A1
+    CSPAD_FRONT FS_D0Q2
+    CSPAD_FRONT FS_D0Q2S0
+    CSPAD_FRONT FS_D0Q2S0A0
+    CSPAD_FRONT FS_D0Q2S0A1
+    CSPAD_FRONT FS_D0Q2S1
+    CSPAD_FRONT FS_D0Q2S1A0
+    CSPAD_FRONT FS_D0Q2S1A1
+    CSPAD_FRONT FS_D0Q2S2
+    CSPAD_FRONT FS_D0Q2S2A0
+    CSPAD_FRONT FS_D0Q2S2A1
+    CSPAD_FRONT FS_D0Q2S3
+    CSPAD_FRONT FS_D0Q2S3A0
+    CSPAD_FRONT FS_D0Q2S3A1
+    CSPAD_FRONT FS_D0Q2S4
+    CSPAD_FRONT FS_D0Q2S4A0
+    CSPAD_FRONT FS_D0Q2S4A1
+    CSPAD_FRONT FS_D0Q2S5
+    CSPAD_FRONT FS_D0Q2S5A0
+    CSPAD_FRONT FS_D0Q2S5A1
+    CSPAD_FRONT FS_D0Q2S6
+    CSPAD_FRONT FS_D0Q2S6A0
+    CSPAD_FRONT FS_D0Q2S6A1
+    CSPAD_FRONT FS_D0Q2S7
+    CSPAD_FRONT FS_D0Q2S7A0
+    CSPAD_FRONT FS_D0Q2S7A1
+    CSPAD_FRONT FS_D0Q3
+    CSPAD_FRONT FS_D0Q3S0
+    CSPAD_FRONT FS_D0Q3S0A0
+    CSPAD_FRONT FS_D0Q3S0A1
+    CSPAD_FRONT FS_D0Q3S1
+    CSPAD_FRONT FS_D0Q3S1A0
+    CSPAD_FRONT FS_D0Q3S1A1
+    CSPAD_FRONT FS_D0Q3S2
+    CSPAD_FRONT FS_D0Q3S2A0
+    CSPAD_FRONT FS_D0Q3S2A1
+    CSPAD_FRONT FS_D0Q3S3
+    CSPAD_FRONT FS_D0Q3S3A0
+    CSPAD_FRONT FS_D0Q3S3A1
+    CSPAD_FRONT FS_D0Q3S4
+    CSPAD_FRONT FS_D0Q3S4A0
+    CSPAD_FRONT FS_D0Q3S4A1
+    CSPAD_FRONT FS_D0Q3S5
+    CSPAD_FRONT FS_D0Q3S5A0
+    CSPAD_FRONT FS_D0Q3S5A1
+    CSPAD_FRONT FS_D0Q3S6
+    CSPAD_FRONT FS_D0Q3S6A0
+    CSPAD_FRONT FS_D0Q3S6A1
+    CSPAD_FRONT FS_D0Q3S7
+    CSPAD_FRONT FS_D0Q3S7A0
+    CSPAD_FRONT FS_D0Q3S7A1
+
+     loop_
+    _diffrn_detector_element.id
+    _diffrn_detector_element.detector_id
+    ELE_D0Q0S0A0 CSPAD_FRONT
+    ELE_D0Q0S0A1 CSPAD_FRONT
+    ELE_D0Q0S1A0 CSPAD_FRONT
+    ELE_D0Q0S1A1 CSPAD_FRONT
+    ELE_D0Q0S2A0 CSPAD_FRONT
+    ELE_D0Q0S2A1 CSPAD_FRONT
+    ELE_D0Q0S3A0 CSPAD_FRONT
+    ELE_D0Q0S3A1 CSPAD_FRONT
+    ELE_D0Q0S4A0 CSPAD_FRONT
+    ELE_D0Q0S4A1 CSPAD_FRONT
+    ELE_D0Q0S5A0 CSPAD_FRONT
+    ELE_D0Q0S5A1 CSPAD_FRONT
+    ELE_D0Q0S6A0 CSPAD_FRONT
+    ELE_D0Q0S6A1 CSPAD_FRONT
+    ELE_D0Q0S7A0 CSPAD_FRONT
+    ELE_D0Q0S7A1 CSPAD_FRONT
+    ELE_D0Q1S0A0 CSPAD_FRONT
+    ELE_D0Q1S0A1 CSPAD_FRONT
+    ELE_D0Q1S1A0 CSPAD_FRONT
+    ELE_D0Q1S1A1 CSPAD_FRONT
+    ELE_D0Q1S2A0 CSPAD_FRONT
+    ELE_D0Q1S2A1 CSPAD_FRONT
+    ELE_D0Q1S3A0 CSPAD_FRONT
+    ELE_D0Q1S3A1 CSPAD_FRONT
+    ELE_D0Q1S4A0 CSPAD_FRONT
+    ELE_D0Q1S4A1 CSPAD_FRONT
+    ELE_D0Q1S5A0 CSPAD_FRONT
+    ELE_D0Q1S5A1 CSPAD_FRONT
+    ELE_D0Q1S6A0 CSPAD_FRONT
+    ELE_D0Q1S6A1 CSPAD_FRONT
+    ELE_D0Q1S7A0 CSPAD_FRONT
+    ELE_D0Q1S7A1 CSPAD_FRONT
+    ELE_D0Q2S0A0 CSPAD_FRONT
+    ELE_D0Q2S0A1 CSPAD_FRONT
+    ELE_D0Q2S1A0 CSPAD_FRONT
+    ELE_D0Q2S1A1 CSPAD_FRONT
+    ELE_D0Q2S2A0 CSPAD_FRONT
+    ELE_D0Q2S2A1 CSPAD_FRONT
+    ELE_D0Q2S3A0 CSPAD_FRONT
+    ELE_D0Q2S3A1 CSPAD_FRONT
+    ELE_D0Q2S4A0 CSPAD_FRONT
+    ELE_D0Q2S4A1 CSPAD_FRONT
+    ELE_D0Q2S5A0 CSPAD_FRONT
+    ELE_D0Q2S5A1 CSPAD_FRONT
+    ELE_D0Q2S6A0 CSPAD_FRONT
+    ELE_D0Q2S6A1 CSPAD_FRONT
+    ELE_D0Q2S7A0 CSPAD_FRONT
+    ELE_D0Q2S7A1 CSPAD_FRONT
+    ELE_D0Q3S0A0 CSPAD_FRONT
+    ELE_D0Q3S0A1 CSPAD_FRONT
+    ELE_D0Q3S1A0 CSPAD_FRONT
+    ELE_D0Q3S1A1 CSPAD_FRONT
+    ELE_D0Q3S2A0 CSPAD_FRONT
+    ELE_D0Q3S2A1 CSPAD_FRONT
+    ELE_D0Q3S3A0 CSPAD_FRONT
+    ELE_D0Q3S3A1 CSPAD_FRONT
+    ELE_D0Q3S4A0 CSPAD_FRONT
+    ELE_D0Q3S4A1 CSPAD_FRONT
+    ELE_D0Q3S5A0 CSPAD_FRONT
+    ELE_D0Q3S5A1 CSPAD_FRONT
+    ELE_D0Q3S6A0 CSPAD_FRONT
+    ELE_D0Q3S6A1 CSPAD_FRONT
+    ELE_D0Q3S7A0 CSPAD_FRONT
+    ELE_D0Q3S7A1 CSPAD_FRONT
+
+
+     loop_
+    _axis.id
+    _axis.type
+    _axis.equipment
+    _axis.depends_on
+    _axis.vector[1]
+    _axis.vector[2]
+    _axis.vector[3]
+    _axis.offset[1]
+    _axis.offset[2]
+    _axis.offset[3]
+    _axis.equipment_component
+    _axis.rotation
+    _axis.rotation_axis
+    AXIS_SOURCE general source . 0 0 1 . . . . . .
+    AXIS_GRAVITY general gravity . 0 -1 0 . . . . . .
+    AXIS_D0_Z translation detector . 0 0 1 . . . detector_arm . .
+    AXIS_D0_Y translation detector AXIS_D0_Z 0 1 0 . . . detector_arm . .
+    AXIS_D0_X translation detector AXIS_D0_Y 1 0 0 . . . detector_arm . .
+    AXIS_D0_R rotation detector AXIS_D0_X 0 0 1 0.0 0.0 0.0 detector_arm . .
+    FS_D0Q0 rotation detector AXIS_D0_R 0 0 1 -49.860765625 41.643353125 0.0 detector_quadrant . .
+    FS_D0Q0S0 rotation detector FS_D0Q0 0.0 0.0 1.0 11.3696 -23.189925 0.0 detector_sensor . .
+    FS_D0Q0S0A0 rotation detector FS_D0Q0S0 0 0 1 -10.835 0.0 0.0 detector_asic 89.66181 FS_D0Q0S0
+    AXIS_D0Q0S0A0_F translation detector FS_D0Q0S0A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S0A0_S translation detector AXIS_D0Q0S0A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S0A1 rotation detector FS_D0Q0S0 0 0 1 10.835 0.0 0.0 detector_asic 89.66181 FS_D0Q0S0
+    AXIS_D0Q0S0A1_F translation detector FS_D0Q0S0A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S0A1_S translation detector AXIS_D0Q0S0A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S1 rotation detector FS_D0Q0 0.0 0.0 1.0 34.815 -23.309825 0.0 detector_sensor . .
+    FS_D0Q0S1A0 rotation detector FS_D0Q0S1 0 0 1 -10.835 0.0 0.0 detector_asic 90.00132 FS_D0Q0S1
+    AXIS_D0Q0S1A0_F translation detector FS_D0Q0S1A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S1A0_S translation detector AXIS_D0Q0S1A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S1A1 rotation detector FS_D0Q0S1 0 0 1 10.835 0.0 0.0 detector_asic 90.00132 FS_D0Q0S1
+    AXIS_D0Q0S1A1_F translation detector FS_D0Q0S1A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S1A1_S translation detector AXIS_D0Q0S1A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S2 rotation detector FS_D0Q0 -0.0 -0.0 -1.0 -23.5389 -10.921625 0.0 detector_sensor . .
+    FS_D0Q0S2A0 rotation detector FS_D0Q0S2 0 0 1 -10.835 0.0 0.0 detector_asic 359.68548 FS_D0Q0S2
+    AXIS_D0Q0S2A0_F translation detector FS_D0Q0S2A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S2A0_S translation detector AXIS_D0Q0S2A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S2A1 rotation detector FS_D0Q0S2 0 0 1 10.835 0.0 0.0 detector_asic 359.68548 FS_D0Q0S2
+    AXIS_D0Q0S2A1_F translation detector FS_D0Q0S2A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S2A1_S translation detector AXIS_D0Q0S2A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S3 rotation detector FS_D0Q0 0.0 0.0 1.0 -23.5499 -34.181125 0.0 detector_sensor . .
+    FS_D0Q0S3A0 rotation detector FS_D0Q0S3 0 0 1 -10.835 0.0 0.0 detector_asic 359.96513 FS_D0Q0S3
+    AXIS_D0Q0S3A0_F translation detector FS_D0Q0S3A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S3A0_S translation detector AXIS_D0Q0S3A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S3A1 rotation detector FS_D0Q0S3 0 0 1 10.835 0.0 0.0 detector_asic 359.96513 FS_D0Q0S3
+    AXIS_D0Q0S3A1_F translation detector FS_D0Q0S3A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S3A1_S translation detector AXIS_D0Q0S3A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S4 rotation detector FS_D0Q0 0.0 0.0 1.0 -11.2651 24.282775 0.0 detector_sensor . .
+    FS_D0Q0S4A0 rotation detector FS_D0Q0S4 0 0 1 -10.835 0.0 0.0 detector_asic 270.14738 FS_D0Q0S4
+    AXIS_D0Q0S4A0_F translation detector FS_D0Q0S4A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S4A0_S translation detector AXIS_D0Q0S4A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S4A1 rotation detector FS_D0Q0S4 0 0 1 10.835 0.0 0.0 detector_asic 270.14738 FS_D0Q0S4
+    AXIS_D0Q0S4A1_F translation detector FS_D0Q0S4A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S4A1_S translation detector AXIS_D0Q0S4A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S5 rotation detector FS_D0Q0 0.0 0.0 1.0 -34.7336 24.169475 0.0 detector_sensor . .
+    FS_D0Q0S5A0 rotation detector FS_D0Q0S5 0 0 1 -10.835 0.0 0.0 detector_asic 270.07896 FS_D0Q0S5
+    AXIS_D0Q0S5A0_F translation detector FS_D0Q0S5A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S5A0_S translation detector AXIS_D0Q0S5A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S5A1 rotation detector FS_D0Q0S5 0 0 1 10.835 0.0 0.0 detector_asic 270.07896 FS_D0Q0S5
+    AXIS_D0Q0S5A1_F translation detector FS_D0Q0S5A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S5A1_S translation detector AXIS_D0Q0S5A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S6 rotation detector FS_D0Q0 0.0 0.0 1.0 23.5488 33.320375 0.0 detector_sensor . .
+    FS_D0Q0S6A0 rotation detector FS_D0Q0S6 0 0 1 -10.835 0.0 0.0 detector_asic 359.78222 FS_D0Q0S6
+    AXIS_D0Q0S6A0_F translation detector FS_D0Q0S6A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S6A0_S translation detector AXIS_D0Q0S6A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S6A1 rotation detector FS_D0Q0S6 0 0 1 10.835 0.0 0.0 detector_asic 359.78222 FS_D0Q0S6
+    AXIS_D0Q0S6A1_F translation detector FS_D0Q0S6A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S6A1_S translation detector AXIS_D0Q0S6A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S7 rotation detector FS_D0Q0 0.0 0.0 1.0 23.3541 9.829875 0.0 detector_sensor . .
+    FS_D0Q0S7A0 rotation detector FS_D0Q0S7 0 0 1 -10.835 0.0 0.0 detector_asic 359.89604 FS_D0Q0S7
+    AXIS_D0Q0S7A0_F translation detector FS_D0Q0S7A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S7A0_S translation detector AXIS_D0Q0S7A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S7A1 rotation detector FS_D0Q0S7 0 0 1 10.835 0.0 0.0 detector_asic 359.89604 FS_D0Q0S7
+    AXIS_D0Q0S7A1_F translation detector FS_D0Q0S7A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S7A1_S translation detector AXIS_D0Q0S7A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1 rotation detector AXIS_D0_R 0 0 1 41.512521875 50.149653125 0.0 detector_quadrant . .
+    FS_D0Q1S0 rotation detector FS_D0Q1 -0.0 -0.0 -1.0 -23.1589875 -11.451825 0.0 detector_sensor . .
+    FS_D0Q1S0A0 rotation detector FS_D0Q1S0 0 0 1 -10.835 0.0 0.0 detector_asic 0.27238 FS_D0Q1S0
+    AXIS_D0Q1S0A0_F translation detector FS_D0Q1S0A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S0A0_S translation detector AXIS_D0Q1S0A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S0A1 rotation detector FS_D0Q1S0 0 0 1 10.835 0.0 0.0 detector_asic 0.27238 FS_D0Q1S0
+    AXIS_D0Q1S0A1_F translation detector FS_D0Q1S0A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S0A1_S translation detector AXIS_D0Q1S0A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S1 rotation detector FS_D0Q1 -0.0 -0.0 -1.0 -23.2073875 -34.782825 0.0 detector_sensor . .
+    FS_D0Q1S1A0 rotation detector FS_D0Q1S1 0 0 1 -10.835 0.0 0.0 detector_asic 0.00525999986641 FS_D0Q1S1
+    AXIS_D0Q1S1A0_F translation detector FS_D0Q1S1A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S1A0_S translation detector AXIS_D0Q1S1A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S1A1 rotation detector FS_D0Q1S1 0 0 1 10.835 0.0 0.0 detector_asic 0.00525999986641 FS_D0Q1S1
+    AXIS_D0Q1S1A1_F translation detector FS_D0Q1S1A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S1A1_S translation detector AXIS_D0Q1S1A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S2 rotation detector FS_D0Q1 0.0 0.0 1.0 -10.7311875 23.286175 0.0 detector_sensor . .
+    FS_D0Q1S2A0 rotation detector FS_D0Q1S2 0 0 1 -10.835 0.0 0.0 detector_asic 270.02545 FS_D0Q1S2
+    AXIS_D0Q1S2A0_F translation detector FS_D0Q1S2A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S2A0_S translation detector AXIS_D0Q1S2A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S2A1 rotation detector FS_D0Q1S2 0 0 1 10.835 0.0 0.0 detector_asic 270.02545 FS_D0Q1S2
+    AXIS_D0Q1S2A1_F translation detector FS_D0Q1S2A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S2A1_S translation detector AXIS_D0Q1S2A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S3 rotation detector FS_D0Q1 0.0 0.0 1.0 -34.1402875 23.344475 0.0 detector_sensor . .
+    FS_D0Q1S3A0 rotation detector FS_D0Q1S3 0 0 1 -10.835 0.0 0.0 detector_asic 270.03066 FS_D0Q1S3
+    AXIS_D0Q1S3A0_F translation detector FS_D0Q1S3A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S3A0_S translation detector AXIS_D0Q1S3A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S3A1 rotation detector FS_D0Q1S3 0 0 1 10.835 0.0 0.0 detector_asic 270.03066 FS_D0Q1S3
+    AXIS_D0Q1S3A1_F translation detector FS_D0Q1S3A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S3A1_S translation detector AXIS_D0Q1S3A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S4 rotation detector FS_D0Q1 0.0 0.0 1.0 24.0035125 11.407275 0.0 detector_sensor . .
+    FS_D0Q1S4A0 rotation detector FS_D0Q1S4 0 0 1 -10.835 0.0 0.0 detector_asic 179.96381 FS_D0Q1S4
+    AXIS_D0Q1S4A0_F translation detector FS_D0Q1S4A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S4A0_S translation detector AXIS_D0Q1S4A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S4A1 rotation detector FS_D0Q1S4 0 0 1 10.835 0.0 0.0 detector_asic 179.96381 FS_D0Q1S4
+    AXIS_D0Q1S4A1_F translation detector FS_D0Q1S4A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S4A1_S translation detector AXIS_D0Q1S4A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S5 rotation detector FS_D0Q1 0.0 0.0 1.0 24.0035125 34.876875 0.0 detector_sensor . .
+    FS_D0Q1S5A0 rotation detector FS_D0Q1S5 0 0 1 -10.835 0.0 0.0 detector_asic 180.02434 FS_D0Q1S5
+    AXIS_D0Q1S5A0_F translation detector FS_D0Q1S5A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S5A0_S translation detector AXIS_D0Q1S5A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S5A1 rotation detector FS_D0Q1S5 0 0 1 10.835 0.0 0.0 detector_asic 180.02434 FS_D0Q1S5
+    AXIS_D0Q1S5A1_F translation detector FS_D0Q1S5A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S5A1_S translation detector AXIS_D0Q1S5A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S6 rotation detector FS_D0Q1 0.0 0.0 1.0 33.2523125 -23.321925 0.0 detector_sensor . .
+    FS_D0Q1S6A0 rotation detector FS_D0Q1S6 0 0 1 -10.835 0.0 0.0 detector_asic 270.08027 FS_D0Q1S6
+    AXIS_D0Q1S6A0_F translation detector FS_D0Q1S6A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S6A0_S translation detector AXIS_D0Q1S6A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S6A1 rotation detector FS_D0Q1S6 0 0 1 10.835 0.0 0.0 detector_asic 270.08027 FS_D0Q1S6
+    AXIS_D0Q1S6A1_F translation detector FS_D0Q1S6A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S6A1_S translation detector AXIS_D0Q1S6A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S7 rotation detector FS_D0Q1 0.0 0.0 1.0 9.9785125 -23.358225 0.0 detector_sensor . .
+    FS_D0Q1S7A0 rotation detector FS_D0Q1S7 0 0 1 -10.835 0.0 0.0 detector_asic 270.15067 FS_D0Q1S7
+    AXIS_D0Q1S7A0_F translation detector FS_D0Q1S7A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S7A0_S translation detector AXIS_D0Q1S7A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S7A1 rotation detector FS_D0Q1S7 0 0 1 10.835 0.0 0.0 detector_asic 270.15067 FS_D0Q1S7
+    AXIS_D0Q1S7A1_F translation detector FS_D0Q1S7A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S7A1_S translation detector AXIS_D0Q1S7A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2 rotation detector AXIS_D0_R 0 0 1 49.596146875 -41.351371875 0.0 detector_quadrant . .
+    FS_D0Q2S0 rotation detector FS_D0Q2 -0.0 -0.0 -1.0 -11.3150125 23.1242 0.0 detector_sensor . .
+    FS_D0Q2S0A0 rotation detector FS_D0Q2S0 0 0 1 -10.835 0.0 0.0 detector_asic 90.04803 FS_D0Q2S0
+    AXIS_D0Q2S0A0_F translation detector FS_D0Q2S0A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S0A0_S translation detector AXIS_D0Q2S0A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S0A1 rotation detector FS_D0Q2S0 0 0 1 10.835 0.0 0.0 detector_asic 90.04803 FS_D0Q2S0
+    AXIS_D0Q2S0A1_F translation detector FS_D0Q2S0A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S0A1_S translation detector AXIS_D0Q2S0A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S1 rotation detector FS_D0Q2 -0.0 -0.0 -1.0 -34.6999125 23.155 0.0 detector_sensor . .
+    FS_D0Q2S1A0 rotation detector FS_D0Q2S1 0 0 1 -10.835 0.0 0.0 detector_asic 90.00592 FS_D0Q2S1
+    AXIS_D0Q2S1A0_F translation detector FS_D0Q2S1A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S1A0_S translation detector AXIS_D0Q2S1A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S1A1 rotation detector FS_D0Q2S1 0 0 1 10.835 0.0 0.0 detector_asic 90.00592 FS_D0Q2S1
+    AXIS_D0Q2S1A1_F translation detector FS_D0Q2S1A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S1A1_S translation detector AXIS_D0Q2S1A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S2 rotation detector FS_D0Q2 0.0 0.0 1.0 23.4746875 10.7811 0.0 detector_sensor . .
+    FS_D0Q2S2A0 rotation detector FS_D0Q2S2 0 0 1 -10.835 0.0 0.0 detector_asic 180.11318 FS_D0Q2S2
+    AXIS_D0Q2S2A0_F translation detector FS_D0Q2S2A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S2A0_S translation detector AXIS_D0Q2S2A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S2A1 rotation detector FS_D0Q2S2 0 0 1 10.835 0.0 0.0 detector_asic 180.11318 FS_D0Q2S2
+    AXIS_D0Q2S2A1_F translation detector FS_D0Q2S2A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S2A1_S translation detector AXIS_D0Q2S2A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S3 rotation detector FS_D0Q2 0.0 0.0 1.0 23.6220875 34.2221 0.0 detector_sensor . .
+    FS_D0Q2S3A0 rotation detector FS_D0Q2S3 0 0 1 -10.835 0.0 0.0 detector_asic 179.92104 FS_D0Q2S3
+    AXIS_D0Q2S3A0_F translation detector FS_D0Q2S3A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S3A0_S translation detector AXIS_D0Q2S3A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S3A1 rotation detector FS_D0Q2S3 0 0 1 10.835 0.0 0.0 detector_asic 179.92104 FS_D0Q2S3
+    AXIS_D0Q2S3A1_F translation detector FS_D0Q2S3A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S3A1_S translation detector AXIS_D0Q2S3A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S4 rotation detector FS_D0Q2 0.0 0.0 1.0 11.1953875 -23.9954 0.0 detector_sensor . .
+    FS_D0Q2S4A0 rotation detector FS_D0Q2S4 0 0 1 -10.835 0.0 0.0 detector_asic 89.63875 FS_D0Q2S4
+    AXIS_D0Q2S4A0_F translation detector FS_D0Q2S4A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S4A0_S translation detector AXIS_D0Q2S4A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S4A1 rotation detector FS_D0Q2S4 0 0 1 10.835 0.0 0.0 detector_asic 89.63875 FS_D0Q2S4
+    AXIS_D0Q2S4A1_F translation detector FS_D0Q2S4A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S4A1_S translation detector AXIS_D0Q2S4A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S5 rotation detector FS_D0Q2 0.0 0.0 1.0 34.5494875 -24.1901 0.0 detector_sensor . .
+    FS_D0Q2S5A0 rotation detector FS_D0Q2S5 0 0 1 -10.835 0.0 0.0 detector_asic 89.68154 FS_D0Q2S5
+    AXIS_D0Q2S5A0_F translation detector FS_D0Q2S5A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S5A0_S translation detector AXIS_D0Q2S5A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S5A1 rotation detector FS_D0Q2S5 0 0 1 10.835 0.0 0.0 detector_asic 89.68154 FS_D0Q2S5
+    AXIS_D0Q2S5A1_F translation detector FS_D0Q2S5A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S5A1_S translation detector AXIS_D0Q2S5A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S6 rotation detector FS_D0Q2 0.0 0.0 1.0 -23.4854125 -33.2552 0.0 detector_sensor . .
+    FS_D0Q2S6A0 rotation detector FS_D0Q2S6 0 0 1 -10.835 0.0 0.0 detector_asic 179.83473 FS_D0Q2S6
+    AXIS_D0Q2S6A0_F translation detector FS_D0Q2S6A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S6A0_S translation detector AXIS_D0Q2S6A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S6A1 rotation detector FS_D0Q2S6 0 0 1 10.835 0.0 0.0 detector_asic 179.83473 FS_D0Q2S6
+    AXIS_D0Q2S6A1_F translation detector FS_D0Q2S6A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S6A1_S translation detector AXIS_D0Q2S6A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S7 rotation detector FS_D0Q2 0.0 0.0 1.0 -23.3413125 -9.8417 0.0 detector_sensor . .
+    FS_D0Q2S7A0 rotation detector FS_D0Q2S7 0 0 1 -10.835 0.0 0.0 detector_asic 180.092 FS_D0Q2S7
+    AXIS_D0Q2S7A0_F translation detector FS_D0Q2S7A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S7A0_S translation detector AXIS_D0Q2S7A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S7A1 rotation detector FS_D0Q2S7 0 0 1 10.835 0.0 0.0 detector_asic 180.092 FS_D0Q2S7
+    AXIS_D0Q2S7A1_F translation detector FS_D0Q2S7A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S7A1_S translation detector AXIS_D0Q2S7A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3 rotation detector AXIS_D0_R 0 0 1 -41.247903125 -50.441634375 0.0 detector_quadrant . .
+    FS_D0Q3S0 rotation detector FS_D0Q3 0.0 0.0 1.0 23.1056375 11.6367625 0.0 detector_sensor . .
+    FS_D0Q3S0A0 rotation detector FS_D0Q3S0 0 0 1 -10.835 0.0 0.0 detector_asic 180.12436 FS_D0Q3S0
+    AXIS_D0Q3S0A0_F translation detector FS_D0Q3S0A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S0A0_S translation detector AXIS_D0Q3S0A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S0A1 rotation detector FS_D0Q3S0 0 0 1 10.835 0.0 0.0 detector_asic 180.12436 FS_D0Q3S0
+    AXIS_D0Q3S0A1_F translation detector FS_D0Q3S0A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S0A1_S translation detector AXIS_D0Q3S0A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S1 rotation detector FS_D0Q3 0.0 0.0 1.0 23.1298375 34.9864625 0.0 detector_sensor . .
+    FS_D0Q3S1A0 rotation detector FS_D0Q3S1 0 0 1 -10.835 0.0 0.0 detector_asic 180.00263 FS_D0Q3S1
+    AXIS_D0Q3S1A0_F translation detector FS_D0Q3S1A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S1A0_S translation detector AXIS_D0Q3S1A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S1A1 rotation detector FS_D0Q3S1 0 0 1 10.835 0.0 0.0 detector_asic 180.00263 FS_D0Q3S1
+    AXIS_D0Q3S1A1_F translation detector FS_D0Q3S1A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S1A1_S translation detector AXIS_D0Q3S1A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S2 rotation detector FS_D0Q3 -0.0 -0.0 -1.0 10.9572375 -23.5830375 0.0 detector_sensor . .
+    FS_D0Q3S2A0 rotation detector FS_D0Q3S2 0 0 1 -10.835 0.0 0.0 detector_asic 269.55191 FS_D0Q3S2
+    AXIS_D0Q3S2A0_F translation detector FS_D0Q3S2A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S2A0_S translation detector AXIS_D0Q3S2A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S2A1 rotation detector FS_D0Q3S2 0 0 1 10.835 0.0 0.0 detector_asic 269.55191 FS_D0Q3S2
+    AXIS_D0Q3S2A1_F translation detector FS_D0Q3S2A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S2A1_S translation detector AXIS_D0Q3S2A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S3 rotation detector FS_D0Q3 -0.0 -0.0 -1.0 34.4180375 -23.4818375 0.0 detector_sensor . .
+    FS_D0Q3S3A0 rotation detector FS_D0Q3S3 0 0 1 -10.835 0.0 0.0 detector_asic 269.74206 FS_D0Q3S3
+    AXIS_D0Q3S3A0_F translation detector FS_D0Q3S3A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S3A0_S translation detector AXIS_D0Q3S3A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S3A1 rotation detector FS_D0Q3S3 0 0 1 10.835 0.0 0.0 detector_asic 269.74206 FS_D0Q3S3
+    AXIS_D0Q3S3A1_F translation detector FS_D0Q3S3A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S3A1_S translation detector AXIS_D0Q3S3A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S4 rotation detector FS_D0Q3 0.0 0.0 1.0 -24.1283625 -11.5336375 0.0 detector_sensor . .
+    FS_D0Q3S4A0 rotation detector FS_D0Q3S4 0 0 1 -10.835 0.0 0.0 detector_asic 359.81971 FS_D0Q3S4
+    AXIS_D0Q3S4A0_F translation detector FS_D0Q3S4A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S4A0_S translation detector AXIS_D0Q3S4A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S4A1 rotation detector FS_D0Q3S4 0 0 1 10.835 0.0 0.0 detector_asic 359.81971 FS_D0Q3S4
+    AXIS_D0Q3S4A1_F translation detector FS_D0Q3S4A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S4A1_S translation detector AXIS_D0Q3S4A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S5 rotation detector FS_D0Q3 0.0 0.0 1.0 -24.1701625 -34.9548375 0.0 detector_sensor . .
+    FS_D0Q3S5A0 rotation detector FS_D0Q3S5 0 0 1 -10.835 0.0 0.0 detector_asic 359.99883 FS_D0Q3S5
+    AXIS_D0Q3S5A0_F translation detector FS_D0Q3S5A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S5A0_S translation detector AXIS_D0Q3S5A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S5A1 rotation detector FS_D0Q3S5 0 0 1 10.835 0.0 0.0 detector_asic 359.99883 FS_D0Q3S5
+    AXIS_D0Q3S5A1_F translation detector FS_D0Q3S5A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S5A1_S translation detector AXIS_D0Q3S5A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S6 rotation detector FS_D0Q3 -0.0 -0.0 -1.0 -33.3089625 23.4474625 0.0 detector_sensor . .
+    FS_D0Q3S6A0 rotation detector FS_D0Q3S6 0 0 1 -10.835 0.0 0.0 detector_asic 269.67299 FS_D0Q3S6
+    AXIS_D0Q3S6A0_F translation detector FS_D0Q3S6A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S6A0_S translation detector AXIS_D0Q3S6A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S6A1 rotation detector FS_D0Q3S6 0 0 1 10.835 0.0 0.0 detector_asic 269.67299 FS_D0Q3S6
+    AXIS_D0Q3S6A1_F translation detector FS_D0Q3S6A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S6A1_S translation detector AXIS_D0Q3S6A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S7 rotation detector FS_D0Q3 -0.0 -0.0 -1.0 -10.0032625 23.4826625 0.0 detector_sensor . .
+    FS_D0Q3S7A0 rotation detector FS_D0Q3S7 0 0 1 -10.835 0.0 0.0 detector_asic 269.67561 FS_D0Q3S7
+    AXIS_D0Q3S7A0_F translation detector FS_D0Q3S7A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S7A0_S translation detector AXIS_D0Q3S7A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S7A1 rotation detector FS_D0Q3S7 0 0 1 10.835 0.0 0.0 detector_asic 269.67561 FS_D0Q3S7
+    AXIS_D0Q3S7A1_F translation detector FS_D0Q3S7A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S7A1_S translation detector AXIS_D0Q3S7A1_F 0 -1 0 0 0 0.0 detector_asic . .
+
+
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;       Example 6.
+
+    This example shows an excerpt from the axis specification of an FEL detector
+    provided by N. Sauter and A. Brewster, using _axis.rotation_axis and
+    _axis.rotation to organize the positional dependencies.  The approach
+    in Example 5 is now preferred.
+
+    The detector is divided into 4 quadrants, each quadrant contains 8 sensors
+    and each sensor contains 2 ASICs.  We want to be able to refine the
+    placement of each of these elements, so we maintain the set of vectors
+    that places them.
+
+    To do this, the first vector of importance is an initial placement axis
+    that moves from the origin along the Z axis a distance equal to the
+    detector distance.  This is the origin for the rest of the axes and is
+    called AXIS_D0_ORIGIN.
+
+    Each subsequent movement involves a frame shift.  This is done by using
+    two imgCIF axes: a rotation axis and a translation axis.  The rotation
+    axis is listed first, and includes no offset or angle.  The actual frame
+    shift is done by using a translation axis.  An offset is used first in
+    the parent's frame, and then an angle is listed to rotate around the
+    rotation axis.
+
+    Example, sensor five of quadrant 2.  First a rotation axis is listed:
+
+    AXIS_D0Q2S5_ROT rotation detector AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    This defines a rotation axis around the z axis in the frame of quadrant 2.
+
+    Next a translation axis is listed:
+    AXIS_D0Q2S5 translation detector
+        AXIS_D0Q2 . . . 34.5494875 -24.1901 0.0 89.68154 AXIS_D0Q2S5_ROT
+    Here, in the frame of quadrant 2, we shift X by 34 and Y by -24 mm,
+    then rotate 89 degrees around the axis named AXIS_D0Q2S5_ROT.
+
+    And so forth.
+;
+;
+
+     loop_
+    _diffrn_detector_axis.detector_id
+    _diffrn_detector_axis.axis_id
+    CSPAD_FRONT AXIS_DETECTOR_X
+    CSPAD_FRONT AXIS_DETECTOR_Y
+    CSPAD_FRONT AXIS_DETECTOR_Z
+    CSPAD_FRONT AXIS_DETECTOR_PITCH
+
+     loop_
+    _diffrn_detector_element.id
+    _diffrn_detector_element.detector_id
+    ELE_D0Q0S0A0 CSPAD_FRONT
+    ELE_D0Q0S0A1 CSPAD_FRONT
+    ELE_D0Q0S1A0 CSPAD_FRONT
+    ELE_D0Q0S1A1 CSPAD_FRONT
+    ELE_D0Q0S2A0 CSPAD_FRONT
+    ELE_D0Q0S2A1 CSPAD_FRONT
+    ELE_D0Q0S3A0 CSPAD_FRONT
+    ELE_D0Q0S3A1 CSPAD_FRONT
+    ELE_D0Q0S4A0 CSPAD_FRONT
+    ELE_D0Q0S4A1 CSPAD_FRONT
+    ELE_D0Q0S5A0 CSPAD_FRONT
+    ELE_D0Q0S5A1 CSPAD_FRONT
+    ELE_D0Q0S6A0 CSPAD_FRONT
+    ELE_D0Q0S6A1 CSPAD_FRONT
+    ELE_D0Q0S7A0 CSPAD_FRONT
+    ELE_D0Q0S7A1 CSPAD_FRONT
+    ELE_D0Q1S0A0 CSPAD_FRONT
+    ELE_D0Q1S0A1 CSPAD_FRONT
+    ELE_D0Q1S1A0 CSPAD_FRONT
+    ELE_D0Q1S1A1 CSPAD_FRONT
+    ELE_D0Q1S2A0 CSPAD_FRONT
+    ELE_D0Q1S2A1 CSPAD_FRONT
+    ELE_D0Q1S3A0 CSPAD_FRONT
+    ELE_D0Q1S3A1 CSPAD_FRONT
+    ELE_D0Q1S4A0 CSPAD_FRONT
+    ELE_D0Q1S4A1 CSPAD_FRONT
+    ELE_D0Q1S5A0 CSPAD_FRONT
+    ELE_D0Q1S5A1 CSPAD_FRONT
+    ELE_D0Q1S6A0 CSPAD_FRONT
+    ELE_D0Q1S6A1 CSPAD_FRONT
+    ELE_D0Q1S7A0 CSPAD_FRONT
+    ELE_D0Q1S7A1 CSPAD_FRONT
+    ELE_D0Q2S0A0 CSPAD_FRONT
+    ELE_D0Q2S0A1 CSPAD_FRONT
+    ELE_D0Q2S1A0 CSPAD_FRONT
+    ELE_D0Q2S1A1 CSPAD_FRONT
+    ELE_D0Q2S2A0 CSPAD_FRONT
+    ELE_D0Q2S2A1 CSPAD_FRONT
+    ELE_D0Q2S3A0 CSPAD_FRONT
+    ELE_D0Q2S3A1 CSPAD_FRONT
+    ELE_D0Q2S4A0 CSPAD_FRONT
+    ELE_D0Q2S4A1 CSPAD_FRONT
+    ELE_D0Q2S5A0 CSPAD_FRONT
+    ELE_D0Q2S5A1 CSPAD_FRONT
+    ELE_D0Q2S6A0 CSPAD_FRONT
+    ELE_D0Q2S6A1 CSPAD_FRONT
+    ELE_D0Q2S7A0 CSPAD_FRONT
+    ELE_D0Q2S7A1 CSPAD_FRONT
+    ELE_D0Q3S0A0 CSPAD_FRONT
+    ELE_D0Q3S0A1 CSPAD_FRONT
+    ELE_D0Q3S1A0 CSPAD_FRONT
+    ELE_D0Q3S1A1 CSPAD_FRONT
+    ELE_D0Q3S2A0 CSPAD_FRONT
+    ELE_D0Q3S2A1 CSPAD_FRONT
+    ELE_D0Q3S3A0 CSPAD_FRONT
+    ELE_D0Q3S3A1 CSPAD_FRONT
+    ELE_D0Q3S4A0 CSPAD_FRONT
+    ELE_D0Q3S4A1 CSPAD_FRONT
+    ELE_D0Q3S5A0 CSPAD_FRONT
+    ELE_D0Q3S5A1 CSPAD_FRONT
+    ELE_D0Q3S6A0 CSPAD_FRONT
+    ELE_D0Q3S6A1 CSPAD_FRONT
+    ELE_D0Q3S7A0 CSPAD_FRONT
+    ELE_D0Q3S7A1 CSPAD_FRONT
+
+
+     loop_
+    _axis.id
+    _axis.type
+    _axis.equipment
+    _axis.depends_on
+    _axis.vector[1]
+    _axis.vector[2]
+    _axis.vector[3]
+    _axis.offset[1]
+    _axis.offset[2]
+    _axis.offset[3]
+    _axis.rotation
+    _axis.rotation_axis
+    AXIS_SOURCE general source   . 0 0 1 . . . . .
+    AXIS_GRAVITY general gravity . 0 -1 0 . . . . .
+    AXIS_DETECTOR_Z translation detector
+                                 . 0 0 1 0 0 0 . .
+    AXIS_DETECTOR_Y translation detector
+                   AXIS_DETECTOR_Z 0 1 0 0 0 0 . .
+    AXIS_DETECTOR_X translation detector
+                   AXIS_DETECTOR_Y 1 0 0 0 0 0 . .
+    AXIS_DETECTOR_PITCH rotation detector
+                   AXIS_DETECTOR_X 0 1 0 0 0 0 . .
+    AXIS_DETECTOR_ROT rotation detector
+               AXIS_DETECTOR_PITCH 0 0 1 0 0 0 . .
+    AXIS_D0_ORIGIN translation detector
+               AXIS_DETECTOR_PITCH 0 0 1 0 0 171.0104 . .
+    AXIS_D0_ROT rotation detector
+                    AXIS_D0_ORIGIN 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0 translation detector
+                    AXIS_D0_ORIGIN . . . 0.0 0.0 0.0 0.0 AXIS_D0_ROT
+    AXIS_D0Q0_ROT rotation detector
+                           AXIS_D0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0 translation detector
+                           AXIS_D0 . . . -49.860765625 41.643353125 0.0
+                                      0.0 AXIS_D0Q0_ROT
+    AXIS_D0Q0S0_ROT rotation detector
+                          AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S0 translation detector
+                          AXIS_D0Q0 . . . 11.3696 -23.189925 0.0
+                                      89.66181 AXIS_D0Q0S0_ROT
+    AXIS_D0Q0S0A0_ROT rotation detector
+                        AXIS_D0Q0S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S0A0 translation detector
+                        AXIS_D0Q0S0 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S0A0_ROT
+    AXIS_D0Q0S0A0_F translation detector
+                      AXIS_D0Q0S0A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S0A0_S translation detector
+                      AXIS_D0Q0S0A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S0A1_ROT rotation detector
+                        AXIS_D0Q0S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S0A1 translation detector
+                        AXIS_D0Q0S0 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S0A1_ROT
+    AXIS_D0Q0S0A1_F translation detector
+                      AXIS_D0Q0S0A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S0A1_S translation detector
+                      AXIS_D0Q0S0A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S1_ROT rotation detector
+                          AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S1 translation detector
+                          AXIS_D0Q0 . . . 34.815 -23.309825 0.0
+                                      90.00132 AXIS_D0Q0S1_ROT
+    AXIS_D0Q0S1A0_ROT rotation detector
+                        AXIS_D0Q0S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S1A0 translation detector
+                        AXIS_D0Q0S1 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S1A0_ROT
+    AXIS_D0Q0S1A0_F translation detector
+                      AXIS_D0Q0S1A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S1A0_S translation detector
+                      AXIS_D0Q0S1A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S1A1_ROT rotation detector
+                        AXIS_D0Q0S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S1A1 translation detector
+                        AXIS_D0Q0S1 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S1A1_ROT
+    AXIS_D0Q0S1A1_F translation detector
+                      AXIS_D0Q0S1A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S1A1_S translation detector
+                      AXIS_D0Q0S1A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S2_ROT rotation detector
+                          AXIS_D0Q0 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q0S2 translation detector
+                          AXIS_D0Q0 . . . -23.5389 -10.921625 0.0
+                                     359.68548 AXIS_D0Q0S2_ROT
+    AXIS_D0Q0S2A0_ROT rotation detector
+                        AXIS_D0Q0S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S2A0 translation detector
+                        AXIS_D0Q0S2 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S2A0_ROT
+    AXIS_D0Q0S2A0_F translation detector
+                        AXIS_D0Q0S2A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S2A0_S translation detector
+                        AXIS_D0Q0S2A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S2A1_ROT rotation detector
+                        AXIS_D0Q0S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S2A1 translation detector
+                        AXIS_D0Q0S2 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S2A1_ROT
+    AXIS_D0Q0S2A1_F translation detector
+                        AXIS_D0Q0S2A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S2A1_S translation detector
+                        AXIS_D0Q0S2A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S3_ROT rotation detector
+                        AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S3 translation detector
+                        AXIS_D0Q0 . . . -23.5499 -34.181125 0.0
+                                   359.96513 AXIS_D0Q0S3_ROT
+    AXIS_D0Q0S3A0_ROT rotation detector
+                        AXIS_D0Q0S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S3A0 translation detector
+                        AXIS_D0Q0S3 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S3A0_ROT
+    AXIS_D0Q0S3A0_F translation detector
+                        AXIS_D0Q0S3A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S3A0_S translation detector
+                        AXIS_D0Q0S3A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S3A1_ROT rotation detector
+                        AXIS_D0Q0S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S3A1 translation detector
+                        AXIS_D0Q0S3 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S3A1_ROT
+    AXIS_D0Q0S3A1_F translation detector
+                        AXIS_D0Q0S3A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S3A1_S translation detector
+                        AXIS_D0Q0S3A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S4_ROT rotation detector
+                        AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S4 translation detector
+                        AXIS_D0Q0 . . . -11.2651 24.282775 0.0
+                                   270.14738 AXIS_D0Q0S4_ROT
+    AXIS_D0Q0S4A0_ROT rotation detector
+                        AXIS_D0Q0S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S4A0 translation detector
+                        AXIS_D0Q0S4 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S4A0_ROT
+    AXIS_D0Q0S4A0_F translation detector
+                        AXIS_D0Q0S4A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S4A0_S translation detector
+                        AXIS_D0Q0S4A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S4A1_ROT rotation detector
+                        AXIS_D0Q0S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S4A1 translation detector
+                        AXIS_D0Q0S4 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S4A1_ROT
+    AXIS_D0Q0S4A1_F translation detector
+                        AXIS_D0Q0S4A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S4A1_S translation detector
+                        AXIS_D0Q0S4A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S5_ROT rotation detector
+                        AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S5 translation detector
+                        AXIS_D0Q0 . . . -34.7336 24.169475 0.0
+                                   270.07896 AXIS_D0Q0S5_ROT
+    AXIS_D0Q0S5A0_ROT rotation detector
+                        AXIS_D0Q0S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S5A0 translation detector
+                        AXIS_D0Q0S5 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S5A0_ROT
+    AXIS_D0Q0S5A0_F translation detector
+                        AXIS_D0Q0S5A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S5A0_S translation detector
+                        AXIS_D0Q0S5A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S5A1_ROT rotation detector
+                        AXIS_D0Q0S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S5A1 translation detector
+                        AXIS_D0Q0S5 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S5A1_ROT
+    AXIS_D0Q0S5A1_F translation detector
+                        AXIS_D0Q0S5A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S5A1_S translation detector
+                        AXIS_D0Q0S5A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S6_ROT rotation detector
+                        AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S6 translation detector
+                        AXIS_D0Q0 . . . 23.5488 33.320375 0.0
+                                   359.78222 AXIS_D0Q0S6_ROT
+    AXIS_D0Q0S6A0_ROT rotation detector
+                        AXIS_D0Q0S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S6A0 translation detector
+                        AXIS_D0Q0S6 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S6A0_ROT
+    AXIS_D0Q0S6A0_F translation detector
+                        AXIS_D0Q0S6A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S6A0_S translation detector
+                        AXIS_D0Q0S6A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S6A1_ROT rotation detector
+                        AXIS_D0Q0S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S6A1 translation detector
+                        AXIS_D0Q0S6 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S6A1_ROT
+    AXIS_D0Q0S6A1_F translation detector
+                        AXIS_D0Q0S6A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S6A1_S translation detector
+                        AXIS_D0Q0S6A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S7_ROT rotation detector
+                        AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S7 translation detector
+                        AXIS_D0Q0 . . . 23.3541 9.829875 0.0
+                                   359.89604 AXIS_D0Q0S7_ROT
+    AXIS_D0Q0S7A0_ROT rotation detector
+                        AXIS_D0Q0S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S7A0 translation detector
+                        AXIS_D0Q0S7 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S7A0_ROT
+    AXIS_D0Q0S7A0_F translation detector
+                        AXIS_D0Q0S7A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S7A0_S translation detector
+                        AXIS_D0Q0S7A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S7A1_ROT rotation detector
+                        AXIS_D0Q0S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S7A1 translation detector
+                        AXIS_D0Q0S7 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S7A1_ROT
+    AXIS_D0Q0S7A1_F translation detector
+                        AXIS_D0Q0S7A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S7A1_S translation detector
+                        AXIS_D0Q0S7A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1_ROT rotation detector
+                        AXIS_D0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1 translation detector
+                        AXIS_D0 . . . 41.512521875 50.149653125 0.0
+                                   0.0 AXIS_D0Q1_ROT
+    AXIS_D0Q1S0_ROT rotation detector
+                        AXIS_D0Q1 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q1S0 translation detector
+                        AXIS_D0Q1 . . . -23.1589875 -11.451825 0.0
+                                     0.27238 AXIS_D0Q1S0_ROT
+    AXIS_D0Q1S0A0_ROT rotation detector
+                        AXIS_D0Q1S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S0A0 translation detector
+                        AXIS_D0Q1S0 . . . -10.835 0.0 0.0
+                                       0.0 AXIS_D0Q1S0A0_ROT
+    AXIS_D0Q1S0A0_F translation detector
+                        AXIS_D0Q1S0A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S0A0_S translation detector
+                        AXIS_D0Q1S0A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S0A1_ROT rotation detector
+                        AXIS_D0Q1S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S0A1 translation detector
+                        AXIS_D0Q1S0 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S0A1_ROT
+    AXIS_D0Q1S0A1_F translation detector
+                        AXIS_D0Q1S0A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S0A1_S translation detector
+                        AXIS_D0Q1S0A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S1_ROT rotation detector
+                        AXIS_D0Q1 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q1S1 translation detector
+                        AXIS_D0Q1 . . . -23.2073875 -34.782825 0.0
+                                     0.00525999986641 AXIS_D0Q1S1_ROT
+    AXIS_D0Q1S1A0_ROT rotation detector
+                        AXIS_D0Q1S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S1A0 translation detector
+                        AXIS_D0Q1S1 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S1A0_ROT
+    AXIS_D0Q1S1A0_F translation detector
+                        AXIS_D0Q1S1A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S1A0_S translation detector
+                        AXIS_D0Q1S1A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S1A1_ROT rotation detector
+                        AXIS_D0Q1S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S1A1 translation detector
+                        AXIS_D0Q1S1 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S1A1_ROT
+    AXIS_D0Q1S1A1_F translation detector
+                        AXIS_D0Q1S1A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S1A1_S translation detector
+                        AXIS_D0Q1S1A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S2_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S2 translation detector
+                        AXIS_D0Q1 . . . -10.7311875 23.286175 0.0
+                                   270.02545 AXIS_D0Q1S2_ROT
+    AXIS_D0Q1S2A0_ROT rotation detector
+                        AXIS_D0Q1S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S2A0 translation detector
+                        AXIS_D0Q1S2 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S2A0_ROT
+    AXIS_D0Q1S2A0_F translation detector
+                        AXIS_D0Q1S2A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S2A0_S translation detector
+                        AXIS_D0Q1S2A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S2A1_ROT rotation detector
+                        AXIS_D0Q1S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S2A1 translation detector
+                        AXIS_D0Q1S2 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S2A1_ROT
+    AXIS_D0Q1S2A1_F translation detector
+                        AXIS_D0Q1S2A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S2A1_S translation detector
+                        AXIS_D0Q1S2A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S3_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S3 translation detector
+                        AXIS_D0Q1 . . . -34.1402875 23.344475 0.0
+                                   270.03066 AXIS_D0Q1S3_ROT
+    AXIS_D0Q1S3A0_ROT rotation detector
+                        AXIS_D0Q1S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S3A0 translation detector
+                        AXIS_D0Q1S3 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S3A0_ROT
+    AXIS_D0Q1S3A0_F translation detector
+                        AXIS_D0Q1S3A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S3A0_S translation detector
+                        AXIS_D0Q1S3A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S3A1_ROT rotation detector
+                        AXIS_D0Q1S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S3A1 translation detector
+                        AXIS_D0Q1S3 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S3A1_ROT
+    AXIS_D0Q1S3A1_F translation detector
+                        AXIS_D0Q1S3A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S3A1_S translation detector
+                        AXIS_D0Q1S3A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S4_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S4 translation detector
+                        AXIS_D0Q1 . . . 24.0035125 11.407275 0.0
+                                    179.96381 AXIS_D0Q1S4_ROT
+    AXIS_D0Q1S4A0_ROT rotation detector
+                        AXIS_D0Q1S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S4A0 translation detector
+                        AXIS_D0Q1S4 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S4A0_ROT
+    AXIS_D0Q1S4A0_F translation detector
+                        AXIS_D0Q1S4A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S4A0_S translation detector
+                        AXIS_D0Q1S4A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S4A1_ROT rotation detector
+                        AXIS_D0Q1S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S4A1 translation detector
+                        AXIS_D0Q1S4 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S4A1_ROT
+    AXIS_D0Q1S4A1_F translation detector
+                        AXIS_D0Q1S4A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S4A1_S translation detector
+                        AXIS_D0Q1S4A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S5_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S5 translation detector
+                        AXIS_D0Q1 . . . 24.0035125 34.876875 0.0
+                                   180.02434 AXIS_D0Q1S5_ROT
+    AXIS_D0Q1S5A0_ROT rotation detector
+                        AXIS_D0Q1S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S5A0 translation detector
+                        AXIS_D0Q1S5 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S5A0_ROT
+    AXIS_D0Q1S5A0_F translation detector
+                        AXIS_D0Q1S5A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S5A0_S translation detector
+                        AXIS_D0Q1S5A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S5A1_ROT rotation detector
+                        AXIS_D0Q1S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S5A1 translation detector
+                        AXIS_D0Q1S5 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S5A1_ROT
+    AXIS_D0Q1S5A1_F translation detector
+                        AXIS_D0Q1S5A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S5A1_S translation detector
+                        AXIS_D0Q1S5A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S6_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S6 translation detector
+                        AXIS_D0Q1 . . . 33.2523125 -23.321925 0.0
+                                   270.08027 AXIS_D0Q1S6_ROT
+    AXIS_D0Q1S6A0_ROT rotation detector
+                        AXIS_D0Q1S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S6A0 translation detector
+                        AXIS_D0Q1S6 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S6A0_ROT
+    AXIS_D0Q1S6A0_F translation detector
+                        AXIS_D0Q1S6A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S6A0_S translation detector
+                        AXIS_D0Q1S6A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S6A1_ROT rotation detector
+                        AXIS_D0Q1S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S6A1 translation detector
+                        AXIS_D0Q1S6 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S6A1_ROT
+    AXIS_D0Q1S6A1_F translation detector
+                        AXIS_D0Q1S6A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S6A1_S translation detector
+                        AXIS_D0Q1S6A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S7_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S7 translation detector
+                        AXIS_D0Q1 . . . 9.9785125 -23.358225 0.0
+                                   270.15067 AXIS_D0Q1S7_ROT
+    AXIS_D0Q1S7A0_ROT rotation detector
+                        AXIS_D0Q1S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S7A0 translation detector
+                        AXIS_D0Q1S7 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S7A0_ROT
+    AXIS_D0Q1S7A0_F translation detector
+                        AXIS_D0Q1S7A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S7A0_S translation detector
+                        AXIS_D0Q1S7A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S7A1_ROT rotation detector
+                        AXIS_D0Q1S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S7A1 translation detector
+                        AXIS_D0Q1S7 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S7A1_ROT
+    AXIS_D0Q1S7A1_F translation detector
+                        AXIS_D0Q1S7A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S7A1_S translation detector
+                        AXIS_D0Q1S7A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2_ROT rotation detector
+                        AXIS_D0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2 translation detector
+                        AXIS_D0 . . . 49.596146875 -41.351371875 0.0
+                                   0.0 AXIS_D0Q2_ROT
+    AXIS_D0Q2S0_ROT rotation detector
+                        AXIS_D0Q2 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q2S0 translation detector
+                        AXIS_D0Q2 . . . -11.3150125 23.1242 0.0
+                                    90.04803 AXIS_D0Q2S0_ROT
+    AXIS_D0Q2S0A0_ROT rotation detector
+                        AXIS_D0Q2S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S0A0 translation detector
+                        AXIS_D0Q2S0 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q2S0A0_ROT
+    AXIS_D0Q2S0A0_F translation detector
+                        AXIS_D0Q2S0A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S0A0_S translation detector
+                        AXIS_D0Q2S0A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S0A1_ROT rotation detector
+                        AXIS_D0Q2S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S0A1 translation detector
+                        AXIS_D0Q2S0 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S0A1_ROT
+    AXIS_D0Q2S0A1_F translation detector
+                        AXIS_D0Q2S0A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S0A1_S translation detector
+                        AXIS_D0Q2S0A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S1_ROT rotation detector
+                        AXIS_D0Q2 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q2S1 translation detector
+                        AXIS_D0Q2 . . . -34.6999125 23.155 0.0
+                                    90.00592 AXIS_D0Q2S1_ROT
+    AXIS_D0Q2S1A0_ROT rotation detector
+                        AXIS_D0Q2S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S1A0 translation detector
+                        AXIS_D0Q2S1 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q2S1A0_ROT
+    AXIS_D0Q2S1A0_F translation detector
+                        AXIS_D0Q2S1A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S1A0_S translation detector
+                        AXIS_D0Q2S1A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S1A1_ROT rotation detector
+                        AXIS_D0Q2S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S1A1 translation detector
+                        AXIS_D0Q2S1 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S1A1_ROT
+    AXIS_D0Q2S1A1_F translation detector
+                        AXIS_D0Q2S1A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S1A1_S translation detector
+                        AXIS_D0Q2S1A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S2_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S2 translation detector
+                        AXIS_D0Q2 . . . 23.4746875 10.7811 0.0
+                                    180.11318 AXIS_D0Q2S2_ROT
+    AXIS_D0Q2S2A0_ROT rotation detector
+                        AXIS_D0Q2S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S2A0 translation detector
+                        AXIS_D0Q2S2 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q2S2A0_ROT
+    AXIS_D0Q2S2A0_F translation detector
+                        AXIS_D0Q2S2A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S2A0_S translation detector
+                        AXIS_D0Q2S2A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S2A1_ROT rotation detector
+                        AXIS_D0Q2S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S2A1 translation detector
+                        AXIS_D0Q2S2 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S2A1_ROT
+    AXIS_D0Q2S2A1_F translation detector
+                        AXIS_D0Q2S2A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S2A1_S translation detector
+                        AXIS_D0Q2S2A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S3_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S3 translation detector
+                        AXIS_D0Q2 . . . 23.6220875 34.2221 0.0
+                                   179.92104 AXIS_D0Q2S3_ROT
+    AXIS_D0Q2S3A0_ROT rotation detector
+                        AXIS_D0Q2S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S3A0 translation detector
+                        AXIS_D0Q2S3 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q2S3A0_ROT
+    AXIS_D0Q2S3A0_F translation detector
+                        AXIS_D0Q2S3A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S3A0_S translation detector
+                        AXIS_D0Q2S3A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S3A1_ROT rotation detector
+                        AXIS_D0Q2S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S3A1 translation detector
+                        AXIS_D0Q2S3 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S3A1_ROT
+    AXIS_D0Q2S3A1_F translation detector
+                        AXIS_D0Q2S3A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S3A1_S translation detector
+                        AXIS_D0Q2S3A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S4_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S4 translation detector
+                        AXIS_D0Q2 . . . 11.1953875 -23.9954 0.0
+                                      89.63875 AXIS_D0Q2S4_ROT
+    AXIS_D0Q2S4A0_ROT rotation detector
+                        AXIS_D0Q2S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S4A0 translation detector
+                        AXIS_D0Q2S4 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q2S4A0_ROT
+    AXIS_D0Q2S4A0_F translation detector
+                        AXIS_D0Q2S4A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S4A0_S translation detector
+                        AXIS_D0Q2S4A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S4A1_ROT rotation detector
+                        AXIS_D0Q2S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S4A1 translation detector
+                        AXIS_D0Q2S4 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S4A1_ROT
+    AXIS_D0Q2S4A1_F translation detector
+                        AXIS_D0Q2S4A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S4A1_S translation detector
+                        AXIS_D0Q2S4A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S5_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S5 translation detector
+                        AXIS_D0Q2 . . . 34.5494875 -24.1901 0.0
+                                    89.68154 AXIS_D0Q2S5_ROT
+    AXIS_D0Q2S5A0_ROT rotation detector
+                        AXIS_D0Q2S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S5A0 translation detector
+                        AXIS_D0Q2S5 . . . -10.835 0.0 0.0
+                                       0.0 AXIS_D0Q2S5A0_ROT
+    AXIS_D0Q2S5A0_F translation detector
+                        AXIS_D0Q2S5A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S5A0_S translation detector
+                        AXIS_D0Q2S5A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S5A1_ROT rotation detector
+                        AXIS_D0Q2S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S5A1 translation detector
+                        AXIS_D0Q2S5 . . . 10.835 0.0 0.0
+                                       0.0 AXIS_D0Q2S5A1_ROT
+    AXIS_D0Q2S5A1_F translation detector
+                        AXIS_D0Q2S5A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S5A1_S translation detector
+                        AXIS_D0Q2S5A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S6_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S6 translation detector
+                        AXIS_D0Q2 . . . -23.4854125 -33.2552 0.0
+                                   179.83473 AXIS_D0Q2S6_ROT
+    AXIS_D0Q2S6A0_ROT rotation detector
+                        AXIS_D0Q2S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S6A0 translation detector
+                        AXIS_D0Q2S6 . . . -10.835 0.0 0.0
+                                       0.0 AXIS_D0Q2S6A0_ROT
+    AXIS_D0Q2S6A0_F translation detector
+                        AXIS_D0Q2S6A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S6A0_S translation detector
+                        AXIS_D0Q2S6A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S6A1_ROT rotation detector
+                        AXIS_D0Q2S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S6A1 translation detector
+                        AXIS_D0Q2S6 . . . 10.835 0.0 0.0
+                                       0.0 AXIS_D0Q2S6A1_ROT
+    AXIS_D0Q2S6A1_F translation detector
+                        AXIS_D0Q2S6A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S6A1_S translation detector
+                        AXIS_D0Q2S6A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S7_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S7 translation detector
+                        AXIS_D0Q2 . . . -23.3413125 -9.8417 0.0
+                                   180.092 AXIS_D0Q2S7_ROT
+    AXIS_D0Q2S7A0_ROT rotation detector
+                        AXIS_D0Q2S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S7A0 translation detector
+                        AXIS_D0Q2S7 . . . -10.835 0.0 0.0
+                                       0.0 AXIS_D0Q2S7A0_ROT
+    AXIS_D0Q2S7A0_F translation detector
+                        AXIS_D0Q2S7A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S7A0_S translation detector
+                        AXIS_D0Q2S7A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S7A1_ROT rotation detector
+                        AXIS_D0Q2S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S7A1 translation detector
+                        AXIS_D0Q2S7 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S7A1_ROT
+    AXIS_D0Q2S7A1_F translation detector
+                        AXIS_D0Q2S7A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S7A1_S translation detector
+                        AXIS_D0Q2S7A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3_ROT rotation detector
+                        AXIS_D0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3 translation detector
+                        AXIS_D0 . . . -41.247903125 -50.441634375 0.0
+                                   0.0 AXIS_D0Q3_ROT
+    AXIS_D0Q3S0_ROT rotation detector
+                        AXIS_D0Q3 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q3S0 translation detector
+                        AXIS_D0Q3 . . . 23.1056375 11.6367625 0.0
+                                   180.12436 AXIS_D0Q3S0_ROT
+    AXIS_D0Q3S0A0_ROT rotation detector
+                        AXIS_D0Q3S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S0A0 translation detector
+                        AXIS_D0Q3S0 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S0A0_ROT
+    AXIS_D0Q3S0A0_F translation detector
+                        AXIS_D0Q3S0A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S0A0_S translation detector
+                        AXIS_D0Q3S0A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S0A1_ROT rotation detector
+                        AXIS_D0Q3S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S0A1 translation detector
+                        AXIS_D0Q3S0 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S0A1_ROT
+    AXIS_D0Q3S0A1_F translation detector
+                        AXIS_D0Q3S0A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S0A1_S translation detector
+                        AXIS_D0Q3S0A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S1_ROT rotation detector
+                        AXIS_D0Q3 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q3S1 translation detector
+                        AXIS_D0Q3 . . . 23.1298375 34.9864625 0.0
+                                   180.00263 AXIS_D0Q3S1_ROT
+    AXIS_D0Q3S1A0_ROT rotation detector
+                        AXIS_D0Q3S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S1A0 translation detector
+                        AXIS_D0Q3S1 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S1A0_ROT
+    AXIS_D0Q3S1A0_F translation detector
+                        AXIS_D0Q3S1A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S1A0_S translation detector
+                        AXIS_D0Q3S1A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S1A1_ROT rotation detector
+                        AXIS_D0Q3S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S1A1 translation detector
+                        AXIS_D0Q3S1 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S1A1_ROT
+    AXIS_D0Q3S1A1_F translation detector
+                        AXIS_D0Q3S1A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S1A1_S translation detector
+                        AXIS_D0Q3S1A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S2_ROT rotation detector
+                        AXIS_D0Q3 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q3S2 translation detector
+                        AXIS_D0Q3 . . . 10.9572375 -23.5830375 0.0
+                                   269.55191 AXIS_D0Q3S2_ROT
+    AXIS_D0Q3S2A0_ROT rotation detector
+                        AXIS_D0Q3S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S2A0 translation detector
+                        AXIS_D0Q3S2 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S2A0_ROT
+    AXIS_D0Q3S2A0_F translation detector
+                        AXIS_D0Q3S2A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S2A0_S translation detector
+                        AXIS_D0Q3S2A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S2A1_ROT rotation detector
+                        AXIS_D0Q3S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S2A1 translation detector
+                        AXIS_D0Q3S2 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S2A1_ROT
+    AXIS_D0Q3S2A1_F translation detector
+                        AXIS_D0Q3S2A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S2A1_S translation detector
+                        AXIS_D0Q3S2A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S3_ROT rotation detector
+                        AXIS_D0Q3 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q3S3 translation detector
+                        AXIS_D0Q3 . . . 34.4180375 -23.4818375 0.0
+                                   269.74206 AXIS_D0Q3S3_ROT
+    AXIS_D0Q3S3A0_ROT rotation detector
+                        AXIS_D0Q3S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S3A0 translation detector
+                        AXIS_D0Q3S3 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S3A0_ROT
+    AXIS_D0Q3S3A0_F translation detector
+                        AXIS_D0Q3S3A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S3A0_S translation detector
+                        AXIS_D0Q3S3A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S3A1_ROT rotation detector
+                        AXIS_D0Q3S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S3A1 translation detector
+                        AXIS_D0Q3S3 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S3A1_ROT
+    AXIS_D0Q3S3A1_F translation detector
+                        AXIS_D0Q3S3A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S3A1_S translation detector
+                        AXIS_D0Q3S3A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S4_ROT rotation detector
+                        AXIS_D0Q3 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q3S4 translation detector
+                        AXIS_D0Q3 . . . -24.1283625 -11.5336375 0.0
+                                   359.81971 AXIS_D0Q3S4_ROT
+    AXIS_D0Q3S4A0_ROT rotation detector
+                        AXIS_D0Q3S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S4A0 translation detector
+                        AXIS_D0Q3S4 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S4A0_ROT
+    AXIS_D0Q3S4A0_F translation detector
+                        AXIS_D0Q3S4A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S4A0_S translation detector
+                        AXIS_D0Q3S4A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S4A1_ROT rotation detector
+                        AXIS_D0Q3S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S4A1 translation detector
+                        AXIS_D0Q3S4 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S4A1_ROT
+    AXIS_D0Q3S4A1_F translation detector
+                        AXIS_D0Q3S4A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S4A1_S translation detector
+                        AXIS_D0Q3S4A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S5_ROT rotation detector
+                        AXIS_D0Q3 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q3S5 translation detector
+                        AXIS_D0Q3 . . . -24.1701625 -34.9548375 0.0
+                                   359.99883 AXIS_D0Q3S5_ROT
+    AXIS_D0Q3S5A0_ROT rotation detector
+                        AXIS_D0Q3S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S5A0 translation detector
+                        AXIS_D0Q3S5 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S5A0_ROT
+    AXIS_D0Q3S5A0_F translation detector
+                        AXIS_D0Q3S5A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S5A0_S translation detector
+                        AXIS_D0Q3S5A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S5A1_ROT rotation detector
+                        AXIS_D0Q3S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S5A1 translation detector
+                        AXIS_D0Q3S5 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S5A1_ROT
+    AXIS_D0Q3S5A1_F translation detector
+                        AXIS_D0Q3S5A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S5A1_S translation detector
+                        AXIS_D0Q3S5A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S6_ROT rotation detector
+                        AXIS_D0Q3 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q3S6 translation detector
+                        AXIS_D0Q3 . . . -33.3089625 23.4474625 0.0
+                                   269.67299 AXIS_D0Q3S6_ROT
+    AXIS_D0Q3S6A0_ROT rotation detector
+                        AXIS_D0Q3S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S6A0 translation detector
+                        AXIS_D0Q3S6 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S6A0_ROT
+    AXIS_D0Q3S6A0_F translation detector
+                        AXIS_D0Q3S6A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S6A0_S translation detector
+                        AXIS_D0Q3S6A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S6A1_ROT rotation detector
+                        AXIS_D0Q3S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S6A1 translation detector
+                        AXIS_D0Q3S6 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S6A1_ROT
+    AXIS_D0Q3S6A1_F translation detector
+                        AXIS_D0Q3S6A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S6A1_S translation detector
+                        AXIS_D0Q3S6A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S7_ROT rotation detector
+                        AXIS_D0Q3 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q3S7 translation detector
+                        AXIS_D0Q3 . . . -10.0032625 23.4826625 0.0
+                                   269.67561 AXIS_D0Q3S7_ROT
+    AXIS_D0Q3S7A0_ROT rotation detector
+                        AXIS_D0Q3S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S7A0 translation detector
+                        AXIS_D0Q3S7 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S7A0_ROT
+    AXIS_D0Q3S7A0_F translation detector
+                        AXIS_D0Q3S7A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S7A0_S translation detector
+                        AXIS_D0Q3S7A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S7A1_ROT rotation detector
+                        AXIS_D0Q3S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S7A1 translation detector
+                        AXIS_D0Q3S7 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S7A1_ROT
+    AXIS_D0Q3S7A1_F translation detector
+                        AXIS_D0Q3S7A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S7A1_S translation detector
+                        AXIS_D0Q3S7A1 0 1 0 0 0 0 . .
+
+;
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save__axis.depends_on
+    _item_description.description
+;            The value of _axis.depends_on  specifies the next outermost
+              axis upon which this axis depends, unless
+              _axis.rotation_axis  is specified, in which case,
+              _axis.rotation_axis  is next outermost and
+              _axis.depends_on  is second outermost.
+
+              This item is a pointer to _axis.id  in the same category.
+;
+    _item.name                      '_axis.depends_on'
+    _item.category_id                 axis
+    _item.mandatory_code              no
+     save_
+
+
+save__axis.equipment
+    _item_description.description
+;            The value of  _axis.equipment  specifies the type of
+              equipment using the axis:  'goniometer', 'detector',
+             'gravity', 'source' or 'general'.
+;
+    _item.name                      '_axis.equipment'
+    _item.category_id                 axis
+    _item.mandatory_code              implicit
+    _item_type.code                   ucode
+    _item_default.value               general
+     loop_
+    _item_enumeration.value
+    _item_enumeration.detail   goniometer
+                              'equipment used to orient or position samples'
+                               detector
+                              'equipment used to detect reflections'
+                               general
+                              'equipment used for general purposes'
+                               gravity
+                              'axis specifying the downward direction'
+                               source
+                              'axis specifying the direction sample to source'
+     save_
+
+save__axis.equipment_component
+    _item_description.description
+;            The value of  _axis.equipment_component  specifies
+              an arbitrary identifier of a component of the equipment to which
+              the axis belongs, such as 'detector_arm' or 'detector_module'.
+
+;
+    _item.name                      '_axis.equipment_component'
+    _item.category_id                 axis
+    _item.mandatory_code              no
+    _item_type.code                   ucode
+     save_
+
+
+save__axis.offset[1]
+    _item_description.description
+;             The [1] element of the three-element vector used to specify
+               the offset to the base of a rotation or translation axis.
+
+               The vector is specified in millimetres.
+;
+    _item.name                  '_axis.offset[1]'
+    _item.category_id             axis
+    _item.mandatory_code          no
+    _item_default.value           0.0
+    _item_sub_category.id         vector
+    _item_type.code               float
+    _item_units.code              millimetres
+     save_
+
+
+save__axis.offset[2]
+    _item_description.description
+;             The [2] element of the three-element vector used to specify
+               the offset to the base of a rotation or translation axis.
+
+               The vector is specified in millimetres.
+;
+    _item.name                  '_axis.offset[2]'
+    _item.category_id             axis
+    _item.mandatory_code          no
+    _item_default.value           0.0
+    _item_sub_category.id         vector
+    _item_type.code               float
+    _item_units.code              millimetres
+     save_
+
+
+save__axis.offset[3]
+    _item_description.description
+;             The [3] element of the three-element vector used to specify
+               the offset to the base of a rotation or translation axis.
+
+               The vector is specified in millimetres.
+;
+    _item.name                  '_axis.offset[3]'
+    _item.category_id             axis
+    _item.mandatory_code          no
+    _item_default.value           0.0
+    _item_sub_category.id         vector
+    _item_type.code               float
+    _item_units.code              millimetres
+     save_
+
+
+save__axis.id
+    _item_description.description
+;            The value of _axis.id  must uniquely identify
+              each axis relevant to the experiment.  Note that multiple
+              pieces of equipment may share the same axis (e.g. a twotheta
+              arm), so the category key for AXIS  also includes the
+              equipment.
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+         '_axis.id'                         axis                    yes
+         '_array_structure_list_axis.axis_id'
+                                            array_structure_list_axis
+                                                                    yes
+         '_diffrn_detector_axis.axis_id'    diffrn_detector_axis    yes
+         '_diffrn_measurement_axis.axis_id' diffrn_measurement_axis yes
+         '_diffrn_scan_axis.axis_id'        diffrn_scan_axis        yes
+         '_diffrn_scan_frame_axis.axis_id'  diffrn_scan_frame_axis  yes
+
+    _item_type.code               code
+     loop_
+    _item_linked.child_name
+    _item_linked.parent_name
+         '_axis.depends_on'                   '_axis.id'
+         '_array_structure_list_axis.axis_id' '_axis.id'
+         '_diffrn_detector_axis.axis_id'      '_axis.id'
+         '_diffrn_measurement_axis.axis_id'   '_axis.id'
+         '_diffrn_scan_axis.axis_id'          '_axis.id'
+         '_diffrn_scan_frame_axis.axis_id'    '_axis.id'
+     save_
+
+save__axis.rotation
+    _item_description.description
+;            The value of _axis.rotation  specifies
+              the fixed base rotation angle for _axis.rotation_axis
+              to which the value of any frame-by-frame setting, if any, should
+              be added.  Normally, only the fixed value would be given.
+;
+    _item.name                      '_axis.rotation'
+    _item.category_id                 axis
+    _item.mandatory_code              no
+    _item_default.value               0.0
+    _item_type.code                   float
+    _item_units.code                  degrees
+     save_
+
+
+save__axis.rotation_axis
+    _item_description.description
+;            The value of _axis.rotation_axis  specifies
+              an optional additional dependency for this axis to be applied
+              after applying _axis.depends_on.
+
+              This item is a pointer to _axis.id  in the same category.
+;
+    _item.name                      '_axis.rotation_axis'
+    _item.category_id                 axis
+    _item.mandatory_code              no
+    _item_type.code                   ucode
+     save_
+
+
+save__axis.system
+    _item_description.description
+;            The value of  _axis.system  specifies the coordinate
+              system used to define the axis: 'laboratory', 'McStas', 'direct',
+             'orthogonal', 'reciprocal' or 'abstract'.
+;
+    _item.name                      '_axis.system'
+    _item.category_id                 axis
+    _item.mandatory_code              no
+    _item_type.code                   ucode
+    _item_default.value               laboratory
+     loop_
+    _item_enumeration.value
+    _item_enumeration.detail
+
+laboratory
+; the axis is referenced to the imgCIF standard laboratory Cartesian
+   coordinate system
+;
+
+McStas
+; the axis is referenced to the NeXus/HDF5 McStas laboratory Cartesian
+   coordinate system
+;
+
+direct
+; the axis is referenced to the direct lattice
+;
+
+orthogonal
+; the axis is referenced to the cell Cartesian orthogonal coordinates
+;
+
+reciprocal
+; the axis is referenced to the reciprocal lattice
+;
+
+abstract
+; the axis is referenced to an abstract Cartesian coordinate system
+;
+
+     save_
+
+
+save__axis.type
+    _item_description.description
+;            The value of _axis.type  specifies the type of
+              axis:  'rotation' or 'translation' (or 'general' when
+              the type is not relevant, as for gravity).
+;
+    _item.name                      '_axis.type'
+    _item.category_id                 axis
+    _item.mandatory_code              no
+    _item_type.code                   ucode
+    _item_default.value               general
+     loop_
+    _item_enumeration.value
+    _item_enumeration.detail      rotation
+                                 'right-handed axis of rotation'
+                                  translation
+                                 'translation in the direction of the axis'
+                                  general
+                                 'axis for which the type is not relevant'
+     save_
+
+
+save__axis.vector[1]
+    _item_description.description
+;             The [1] element of the three-element vector used to specify
+               the direction of a rotation or translation axis.
+               The vector should be normalized to be a unit vector and
+               is dimensionless.
+;
+    _item.name                  '_axis.vector[1]'
+    _item.category_id             axis
+    _item.mandatory_code          no
+    _item_default.value           0.0
+    _item_sub_category.id         vector
+    _item_type.code               float
+     save_
+
+
+save__axis.vector[2]
+    _item_description.description
+;             The [2] element of the three-element vector used to specify
+               the direction of a rotation or translation axis.
+               The vector should be normalized to be a unit vector and
+               is dimensionless.
+;
+    _item.name                  '_axis.vector[2]'
+    _item.category_id             axis
+    _item.mandatory_code          no
+    _item_default.value           0.0
+    _item_sub_category.id         vector
+    _item_type.code               float
+     save_
+
+
+save__axis.vector[3]
+    _item_description.description
+;             The [3] element of the three-element vector used to specify
+               the direction of a rotation or translation axis.
+               The vector should be normalized to be a unit vector and
+               is dimensionless.
+;
+    _item.name                  '_axis.vector[3]'
+    _item.category_id             axis
+    _item.mandatory_code          no
+    _item_default.value           0.0
+    _item_sub_category.id         vector
+    _item_type.code               float
+     save_
+
+
+save__axis.variant
+    _item_description.description
+;            The value of _axis.variant  gives the variant
+              to which the given AXIS row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant  in the
+              VARIANT  category.
+;
+    _item.name                  '_axis.variant'
+    _item.category_id             axis
+    _item.mandatory_code          implicit
+    _item_default.value          .
+    _item_type.code               code
+     save_
+
+
+
+#####################
+# DIFFRN_DATA_FRAME #
+#####################
+
+
+save_DIFFRN_DATA_FRAME
+    _category.description
+;            Data items in the DIFFRN_DATA_FRAME  category record
+              the details about each frame of data.
+
+              The items in this category were previously in a
+              DIFFRN_FRAME_DATA category, which is now deprecated.
+              The items from the old category are provided
+              as aliases but should not be used for new work.
+;
+    _category.id                   diffrn_data_frame
+    _category.mandatory_code       no
+    _category.NX_mapping_details
+; in online version
+;
+
+     loop_
+    _category_key.name             '_diffrn_data_frame.id'
+                                   '_diffrn_data_frame.detector_element_id'
+                                   '_diffrn_data_frame.variant'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'array_data_group'
+                                   'diffrn_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;     Example 1. a frame containing data from four frame elements.
+
+                       Each frame element has a common array configuration
+                       'array_1' described in ARRAY_STRUCTURE  and related
+                       categories.  The data for each detector element are
+                       stored in four groups of binary data in the
+                       ARRAY_DATA  category, linked by the array_id and
+                       binary_id.
+;
+;
+        loop_
+        _diffrn_data_frame.id
+        _diffrn_data_frame.detector_element_id
+        _diffrn_data_frame.array_id
+        _diffrn_data_frame.binary_id
+        frame_1   d1_ccd_1  array_1  1
+        frame_1   d1_ccd_2  array_1  2
+        frame_1   d1_ccd_3  array_1  3
+        frame_1   d1_ccd_4  array_1  4
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save__diffrn_data_frame.array_id
+    _item_description.description
+;            This item is a pointer to _array_structure.id  in the
+              ARRAY_STRUCTURE  category.
+;
+    _item.name                  '_diffrn_data_frame.array_id'
+    _item.category_id             diffrn_data_frame
+    _item.mandatory_code          implicit
+    _item_aliases.alias_name    '_diffrn_frame_data.array_id'
+    _item_aliases.dictionary      cif_img.dic
+    _item_aliases.version         1.0
+    _item_type.code               code
+     save_
+
+
+save__diffrn_data_frame.array_section_id
+    _item_description.description
+;            This item is a pointer to _array_structure_list_section.id
+              in the ARRAY_STRUCTURE_LIST_SECTION  category.
+;
+    _item.name                  '_diffrn_data_frame.array_section_id'
+    _item.category_id             diffrn_data_frame
+    _item.mandatory_code          implicit
+    _item_type.code               code
+     save_
+
+
+save__diffrn_data_frame.binary_id
+    _item_description.description
+;            This item is a pointer to _array_data.binary_id  in the
+              ARRAY_DATA  category.
+;
+    _item.name                  '_diffrn_data_frame.binary_id'
+    _item.category_id             diffrn_data_frame
+    _item.mandatory_code          implicit
+    _item_aliases.alias_name    '_diffrn_frame_data.binary_id'
+    _item_aliases.dictionary      cif_img.dic
+    _item_aliases.version         1.0
+    _item_type.code               int
+     save_
+
+
+save__diffrn_data_frame.center_fast
+    _item_description.description
+;            The value of _diffrn_data_frame.center_fast  is
+              the fast index axis beam centre position relative to the detector
+              element face in the units specified in the data item
+              _diffrn_data_frame.center_units  along the fast
+              axis of the detector from the centre of the first pixel to
+              the point at which the Z axis (which should be collinear with the
+              beam) intersects the face of the detector, if in fact it does.
+              At the time of the measurement the current settings of
+              the detector positioner for the given frame are used.
+
+              It is important to note that for measurements in mm,
+              the sense of the axis is used, rather than the sign of the
+              pixel-to-pixel increments.
+
+;
+    _item.name '_diffrn_data_frame.center_fast'
+    _item.category_id             diffrn_data_frame
+    _item.mandatory_code          no
+    _item_type.code               float
+     save_
+
+
+save__diffrn_data_frame.center_slow
+    _item_description.description
+;             The value of _diffrn_data_frame.center_slow  is
+              the slow index axis beam centre position relative to the detector
+              element face in the units specified in the data item
+              _diffrn_data_frame.center_units  along the slow
+              axis of the detector from the centre of the first pixel to
+              the point at which the Z axis (which should be collinear with the
+              beam) intersects the face of the detector, if in fact it does.
+              At the time of the measurement the current settings of
+              the detector positioner for the given frame are used.
+
+              It is important to note that the sense of the axis is used,
+              rather than the sign of the pixel-to-pixel increments.
+;
+    _item.name '_diffrn_data_frame.center_slow'
+    _item.category_id             diffrn_data_frame
+    _item.mandatory_code          no
+    _item_type.code               float
+     save_
+
+
+save__diffrn_data_frame.center_derived
+    _item_description.description
+;             The value of _diffrn_data_frame.center_derived
+              is assumed to be 'yes', i.e. that values of
+              _diffrn_data_frame.center_fast  and
+              _diffrn_data_frame.center_slow
+              are derived from the axis settings rather than measured.
+;
+    _item.name                  '_diffrn_data_frame.center_derived'
+    _item.category_id             diffrn_data_frame
+    _item.mandatory_code          no
+    _item_type.code               ucode
+    _item_default.value           'yes'
+     save_
+
+
+save__diffrn_data_frame.center_units
+    _item_description.description
+;             The value of _diffrn_data_frame.center_units
+              specifies the units in which the values of
+              _diffrn_data_frame.center_fast  and
+              _diffrn_data_frame.center_slow
+              are presented.  The default is 'mm' for millimetres.  The
+              alternatives are 'pixels' and 'bins'.  In all cases the
+              centre distances are measured from the centre of the
+              first pixel, i.e. in a 2x2 binning, the measuring origin
+              is offset from the centres of the bins by one half pixel
+              towards the first pixel.
+
+              If 'bins' is specified, the data in
+                  _array_intensities.pixel_fast_bin_size,
+                  _array_intensities.pixel_slow_bin_size, and
+                  _array_intensities.pixel_binning_method
+              are used to define the binning scheme.
+;
+    _item.name '_diffrn_data_frame.center_units'
+    _item.category_id             diffrn_data_frame
+    _item.mandatory_code          no
+    _item_type.code               code
+     loop_
+    _item_enumeration.value
+    _item_enumeration.detail
+                                   mm        'millimetres'
+                                   pixels    'detector pixels'
+                                   bins      'detector bins'
+     save_
+
+
+save__diffrn_data_frame.detector_element_id
+    _item_description.description
+;             This item is a pointer to _diffrn_detector_element.id
+              in the DIFFRN_DETECTOR_ELEMENT  category.
+;
+    _item.name                  '_diffrn_data_frame.detector_element_id'
+    _item.category_id             diffrn_data_frame
+    _item.mandatory_code          yes
+    _item_aliases.alias_name    '_diffrn_frame_data.detector_element_id'
+    _item_aliases.dictionary      cif_img.dic
+    _item_aliases.version         1.0
+    _item_type.code               code
+     save_
+
+
+save__diffrn_data_frame.id
+    _item_description.description
+;             The value of _diffrn_data_frame.id  must uniquely identify
+              each complete frame of data.
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+           '_diffrn_data_frame.id'        diffrn_data_frame  yes
+           '_diffrn_refln.frame_id'       diffrn_refln       yes
+           '_diffrn_scan.frame_id_start'  diffrn_scan        yes
+           '_diffrn_scan.frame_id_end'    diffrn_scan        yes
+           '_diffrn_scan_frame.frame_id'  diffrn_scan_frame  yes
+           '_diffrn_scan_frame_axis.frame_id'
+                                          diffrn_scan_frame_axis
+                                                             yes
+           '_diffrn_scan_frame_monitor.frame_id'
+                                          diffrn_scan_frame_monitor
+                                                             implicit
+    _item_aliases.alias_name    '_diffrn_frame_data.id'
+    _item_aliases.dictionary      cif_img.dic
+    _item_aliases.version         1.0
+    _item_type.code               code
+     loop_
+    _item_linked.child_name
+    _item_linked.parent_name
+           '_diffrn_refln.frame_id'        '_diffrn_data_frame.id'
+           '_diffrn_scan.frame_id_start'   '_diffrn_data_frame.id'
+           '_diffrn_scan.frame_id_end'     '_diffrn_data_frame.id'
+           '_diffrn_scan_frame.frame_id'   '_diffrn_data_frame.id'
+           '_diffrn_scan_frame_axis.frame_id'
+                                           '_diffrn_data_frame.id'
+           '_diffrn_scan_frame_monitor.frame_id'
+                                           '_diffrn_data_frame.id'
+     save_
+
+
+save__diffrn_data_frame.details
+    _item_description.description
+;             The value of _diffrn_data_frame.details  should give a
+              description of special aspects of each frame of data.
+
+              This is an appropriate location in which to record
+              information from vendor headers as presented in those
+              headers, but it should never be used as a substitute
+              for providing the fully parsed information within
+              the appropriate imgCIF/CBF categories.
+
+              Normally, when a conversion from a miniCBF has been done
+              the data from _array_data.header_convention
+              should be transferred to this data item and
+              _array_data.header_convention
+              should be removed.
+;
+    _item.name                  '_diffrn_data_frame.details'
+    _item.category_id             diffrn_data_frame
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_frame_data.details'
+    _item_aliases.dictionary      cif_img.dic
+    _item_aliases.version         1.4
+    _item_type.code               text
+     loop_
+    _item_examples.case
+    _item_examples.detail
+;
+HEADER_BYTES = 512;
+DIM = 2;
+BYTE_ORDER = big_endian;
+TYPE = unsigned_short;
+SIZE1 = 3072;
+SIZE2 = 3072;
+PIXEL_SIZE = 0.102588;
+BIN = 2x2;
+DETECTOR_SN = 901;
+TIME = 29.945155;
+DISTANCE = 200.000000;
+PHI = 85.000000;
+OSC_START = 85.000000;
+OSC_RANGE = 1.000000;
+WAVELENGTH = 0.979381;
+BEAM_CENTER_X = 157.500000;
+BEAM_CENTER_Y = 157.500000;
+PIXEL SIZE = 0.102588;
+OSCILLATION RANGE = 1;
+EXPOSURE TIME = 29.9452;
+TWO THETA = 0;
+BEAM CENTRE = 157.5 157.5;
+;
+;              Example of header information extracted from an ADSC Quantum
+               315 detector header by CBFlib_0.7.6.  Image provided by Chris
+               Nielsen of ADSC from a data collection at SSRL beamline 1-5.
+;
+     save_
+
+
+save__diffrn_data_frame.variant
+    _item_description.description
+;             The value of _diffrn_data_frame.variant  gives the variant
+              to which the given DIFFRN_DATA_FRAME row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant  in the
+              VARIANT  category.
+;
+    _item.name                  '_diffrn_data_frame.variant'
+    _item.category_id             diffrn_data_frame
+    _item.mandatory_code          implicit
+    _item_default.value          .
+    _item_type.code               code
+     save_
+
+
+##########################################################################
+#  The following is a restatement of the mmCIF DIFFRN_DETECTOR,          #
+#  DIFFRN_MEASUREMENT and DIFFRN_RADIATION categories, modified for      #
+#  the CBF/imgCIF extensions                                             #
+##########################################################################
+
+###################
+# DIFFRN_DETECTOR #
+###################
+
+
+save_DIFFRN_DETECTOR
+    _category.description
+;   Data items in the DIFFRN_DETECTOR  category describe the
+    detector used to measure the scattered radiation, including
+    any analyser and post-sample collimation.
+;
+    _category.id                  diffrn_detector
+    _category.mandatory_code      no
+    _category.NX_mapping_details
+; in online version
+;
+
+     loop_
+    _category_key.name          '_diffrn_detector.diffrn_id'
+                                '_diffrn_detector.id'
+                                '_diffrn_detector.variant'
+     loop_
+    _category_group.id           'inclusive_group'
+                                 'diffrn_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;   Example 1. based on PDB entry 5HVP and laboratory records for the
+                structure corresponding to PDB entry 5HVP.
+;
+;
+    _diffrn_detector.diffrn_id              'd1'
+    _diffrn_detector.detector               'multiwire'
+    _diffrn_detector.type                   'Siemens'
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save__diffrn_detector.details
+    _item_description.description
+;             A description of special aspects of the radiation detector.
+;
+    _item.name                  '_diffrn_detector.details'
+    _item.category_id             diffrn_detector
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_detector_details'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+    _item_type.code                   text
+    _item_examples.case        'slow mode'
+     save_
+
+
+save__diffrn_detector.detector
+    _item_description.description
+;             The general class of the radiation detector.
+;
+    _item.name                  '_diffrn_detector.detector'
+    _item.category_id             diffrn_detector
+    _item.mandatory_code          no
+     loop_
+    _item_aliases.alias_name
+    _item_aliases.dictionary
+    _item_aliases.version       '_diffrn_radiation_detector'
+                                  cifdic.c91
+                                  1.0
+                                '_diffrn_detector'
+                                  cif_core.dic
+                                  2.0
+    _item_type.code               text
+     loop_
+    _item_examples.case          'photographic film'
+                                 'scintillation counter'
+                                 'CCD plate'
+                                 'BF~3~ counter'
+     save_
+
+
+save__diffrn_detector.diffrn_id
+    _item_description.description
+;             This data item is a pointer to _diffrn.id  in the DIFFRN
+              category.
+
+              The value of _diffrn.id  uniquely defines a set of
+              diffraction data.
+;
+    _item.name                  '_diffrn_detector.diffrn_id'
+    _item.category_id             diffrn_detector
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+
+save__diffrn_detector.dtime
+    _item_description.description
+;             The deadtime in microseconds of the detector(s) used to
+              measure the diffraction intensities.
+;
+    _item.name                  '_diffrn_detector.dtime'
+    _item.category_id             diffrn_detector
+    _item.mandatory_code          no
+     loop_
+    _item_aliases.alias_name
+    _item_aliases.dictionary
+    _item_aliases.version       '_diffrn_radiation_detector_dtime'
+                                  cifdic.c91
+                                  1.0
+                                '_diffrn_detector_dtime'
+                                  cif_core.dic
+                                  2.0
+     loop_
+    _item_range.maximum
+    _item_range.minimum            .    0.0
+                                  0.0   0.0
+    _item_type.code               float
+    _item_units.code              microseconds
+     save_
+
+
+save__diffrn_detector.id
+    _item_description.description
+;             The value of _diffrn_detector.id  must uniquely identify
+              each detector used to collect each diffraction data set.
+
+              If the value of _diffrn_detector.id  is not given, it is
+              implicitly equal to the value of
+              _diffrn_detector.diffrn_id.
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+             '_diffrn_detector.id'         diffrn_detector       implicit
+             '_diffrn_detector_axis.detector_id'
+                                           diffrn_detector_axis       yes
+             '_diffrn_scan_frame_monitor.detector_id'
+                                           diffrn_scan_frame_monitor  yes
+     loop_
+    _item_linked.child_name
+    _item_linked.parent_name
+             '_diffrn_detector_axis.detector_id'
+                                         '_diffrn_detector.id'
+             '_diffrn_scan_frame_monitor.detector_id'
+                                         '_diffrn_detector.id'
+
+    _item_type.code               code
+     save_
+
+
+save__diffrn_detector.layer_thickness
+    _item_description.description
+;             The thickness in mm of the sensing layer of the detector
+              for use in angular corrections.
+;
+    _item.name                  '_diffrn_detector.layer_thickness'
+    _item.category_id             diffrn_detector
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum            .    0.0
+                                  0.0   0.0
+    _item_type.code               float
+    _item_units.code              millimetres
+     save_
+
+
+save__diffrn_detector.gain_setting
+    _item_description.description
+;             The gain setting for detector.   This is a text string usually
+              reflecting a detector setting that may have a simple or very
+              complex relationship with the value of
+              _array_intensities.gain
+              and should not be used directly for computations without
+              further information.
+
+              This tag is provided for completeness in recording the settings
+              of an experiment using a detector with a panel-switch, jumper
+              or control command that allows a choice of gain settings.
+;
+    _item.name                  '_diffrn_detector.gain_setting'
+    _item.category_id             diffrn_detector
+    _item.mandatory_code          no
+    _item_type.code               text
+    save_
+
+
+save__diffrn_detector.number_of_axes
+    _item_description.description
+;             The value of _diffrn_detector.number_of_axes  gives the
+              number of axes of the positioner for the detector identified
+              by _diffrn_detector.id.
+
+              The word 'positioner' is a general term used in
+              instrumentation design for devices that are used to change
+              the positions of portions of apparatus by linear
+              translation, rotation or combinations of such motions.
+
+              Axes which are used to provide a coordinate system for the
+              face of an area detector should not be counted for this
+              data item.
+
+              The description of each axis should be provided by entries
+              in DIFFRN_DETECTOR_AXIS.
+;
+    _item.name                  '_diffrn_detector.number_of_axes'
+    _item.category_id             diffrn_detector
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .   1
+                                  1   1
+    _item_type.code               int
+     save_
+
+
+save__diffrn_detector.type
+    _item_description.description
+;             The make, model or name of the detector device used.
+;
+    _item.name                  '_diffrn_detector.type'
+    _item.category_id             diffrn_detector
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_detector_type'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+    _item_type.code               text
+     save_
+
+
+save__diffrn_detector.variant
+    _item_description.description
+;             The value of _diffrn_detector.variant  gives the variant
+              to which the given DIFFRN_DETECTOR row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant  in the
+              VARIANT  category.
+;
+    _item.name                  '_diffrn_detector.variant'
+    _item.category_id             diffrn_detector
+    _item.mandatory_code          implicit
+    _item_default.value          .
+    _item_type.code               code
+     save_
+
+
+########################
+# DIFFRN_DETECTOR_AXIS #
+########################
+
+
+save_DIFFRN_DETECTOR_AXIS
+    _category.description
+;   Data items in the DIFFRN_DETECTOR_AXIS  category associate
+    axes with detectors.
+;
+    _category.id                   diffrn_detector_axis
+    _category.mandatory_code       no
+    _category.NX_mapping_details
+; in online version
+;
+
+     loop_
+    _category_key.name          '_diffrn_detector_axis.detector_id'
+                                '_diffrn_detector_axis.axis_id'
+                                '_diffrn_detector_axis.variant'
+     loop_
+    _category_group.id           'inclusive_group'
+                                 'diffrn_group'
+     save_
+
+
+save__diffrn_detector_axis.axis_id
+    _item_description.description
+;             This data item is a pointer to _axis.id  in
+               the AXIS category.
+;
+    _item.name                  '_diffrn_detector_axis.axis_id'
+    _item.category_id             diffrn_detector_axis
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+
+save__diffrn_detector_axis.detector_id
+    _item_description.description
+;             This data item is a pointer to _diffrn_detector.id  in
+              the DIFFRN_DETECTOR  category.
+
+              This item was previously named _diffrn_detector_axis.id
+              which is now a deprecated name.  The old name is
+              provided as an alias but should not be used for new work.
+;
+    _item.name                  '_diffrn_detector_axis.detector_id'
+    _item.category_id             diffrn_detector_axis
+    _item.mandatory_code          yes
+    _item_aliases.alias_name    '_diffrn_detector_axis.id'
+    _item_aliases.dictionary      cif_img.dic
+    _item_aliases.version         1.0
+    _item_type.code               code
+     save_
+
+
+save__diffrn_detector_axis.variant
+    _item_description.description
+;            The value of _diffrn_detector_axis.variant  gives the variant
+             to which the given DIFFRN_DETECTOR_AXIS row is related.
+
+             If this value is not given, the variant is assumed to be
+             the default null variant.
+
+             This item is a pointer to _variant.variant  in the
+             VARIANT  category.
+;
+    _item.name                  '_diffrn_detector_axis.variant'
+    _item.category_id             diffrn_detector_axis
+    _item.mandatory_code          implicit
+    _item_default.value          .
+    _item_type.code               code
+     save_
+
+
+###########################
+# DIFFRN_DETECTOR_ELEMENT #
+###########################
+
+
+save_DIFFRN_DETECTOR_ELEMENT
+    _category.description
+;   Data items in the DIFFRN_DETECTOR_ELEMENT  category record
+    the details about spatial layout and other characteristics
+    of each element of a detector which may have multiple elements.
+
+    In most cases, giving more detailed information
+    in ARRAY_STRUCTURE_LIST and ARRAY_STRUCTURE_LIST_AXIS
+    is preferable to simply providing the centre of the
+    detector element.
+;
+    _category.id                   diffrn_detector_element
+    _category.mandatory_code       no
+    _category.NX_mapping_details
+; in online version
+;
+
+     loop_
+    _category_key.name             '_diffrn_detector_element.id'
+                                   '_diffrn_detector_element.detector_id'
+                                   '_diffrn_detector_element.variant'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'array_data_group'
+                                   'diffrn_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;      Example 1. Detector d1 is composed of four CCD detector elements,
+        each 200 mm by 200 mm, arranged in a square, in the pattern
+
+                   1     2
+                      *
+                   3     4
+
+        Note that the beam centre is slightly displaced from each of the
+        detector elements, just beyond the lower right corner of 1,
+        the lower left corner of 2, the upper right corner of 3 and
+        the upper left corner of 4.  For each element, the detector
+        face coordinate system is assumed to have the fast axis
+        running from left to right and the slow axis running from
+        top to bottom with the origin at the top left corner.
+;
+;
+        loop_
+        _diffrn_detector_element.detector_id
+        _diffrn_detector_element.id
+        _diffrn_detector_element.reference_center_fast
+        _diffrn_detector_element.reference_center_slow
+        _diffrn_detector_element.reference_center_units
+        d1     d1_ccd_1  201.5 201.5  mm
+        d1     d1_ccd_2  -1.8  201.5  mm
+        d1     d1_ccd_3  201.6  -1.4  mm
+        d1     d1_ccd_4  -1.7   -1.5  mm
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save__diffrn_detector_element.id
+    _item_description.description
+;            The value of _diffrn_detector_element.id  must uniquely
+             identify each element of a detector.
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+           '_diffrn_detector_element.id'
+           diffrn_detector_element
+           yes
+    _item_type.code               code
+     loop_
+    _item_linked.child_name
+    _item_linked.parent_name
+           '_diffrn_data_frame.detector_element_id'
+           '_diffrn_detector_element.id'
+
+     save_
+
+
+save__diffrn_detector_element.detector_id
+    _item_description.description
+;             This item is a pointer to _diffrn_detector.id
+              in the DIFFRN_DETECTOR  category.
+;
+    _item.name                  '_diffrn_detector_element.detector_id'
+    _item.category_id             diffrn_detector_element
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+
+save__diffrn_detector_element.reference_center_fast
+    _item_description.description
+;             The value of _diffrn_detector_element.reference_center_fast  is
+              the fast index axis beam centre position relative to the detector
+              element face in the units specified in the data item
+              _diffrn_detector_element.reference_center_units  along the fast
+              axis of the detector from the centre of the first pixel to
+              the point at which the Z-axis (which should be collinear with the
+              beam) intersects the face of the detector, if in fact it does.
+              At the time of the measurement all settings of the detector
+              positioner should be at their reference settings.  If more than
+              one reference setting has been used the value given should be
+              representative of the beam centre as determined from the ensemble
+              of settings.
+
+              It is important to note that for measurements in mm,
+              the sense of the axis is used, rather than the sign of the
+              pixel-to-pixel increments.
+
+;
+    _item.name '_diffrn_detector_element.reference_center_fast'
+    _item.category_id             diffrn_detector_element
+    _item.mandatory_code          no
+    _item_type.code               float
+
+     save_
+
+
+save__diffrn_detector_element.reference_center_slow
+    _item_description.description
+;             The value of _diffrn_detector_element.reference_center_slow  is
+              the slow index axis beam centre position relative to the detector
+              element face in the units specified in the data item
+              _diffrn_detector_element.reference_center_units  along the slow
+              axis of the detector from the centre of the first pixel to
+              the point at which the Z-axis (which should be collinear with the
+              beam) intersects the face of the detector, if in fact it does.
+              At the time of the measurement all settings of the detector
+              positioner should be at their reference settings.  If more than
+              one reference setting has been used the value given should be
+              representative of the beam centre as determined from the ensemble
+              of settings.
+
+              It is important to note that the sense of the axis is used,
+              rather than the sign of the pixel-to-pixel increments.
+;
+    _item.name '_diffrn_detector_element.reference_center_slow'
+    _item.category_id             diffrn_detector_element
+    _item.mandatory_code          no
+    _item_type.code               float
+     save_
+
+
+save__diffrn_detector_element.reference_center_units
+    _item_description.description
+;             The value of _diffrn_detector_element.reference_center_units
+              specifies the units in which the values of
+              _diffrn_detector_element.reference_center_fast  and
+              _diffrn_detector_element.reference_center_slow
+              are presented.  The default is 'mm' for millimetres.  The
+              alternatives are 'pixels' and 'bins'.  In all cases the
+              centre distances are measured from the centre of the
+              first pixel, i.e. in a 2x2 binning, the measuring origin
+              is offset from the centres of the bins by one half pixel
+              towards the first pixel.
+
+              If 'bins' is specified, the data in
+                  _array_intensities.pixel_fast_bin_size,
+                  _array_intensities.pixel_slow_bin_size, and
+                  _array_intensities.pixel_binning_method
+              are used to define the binning scheme.
+;
+    _item.name '_diffrn_detector_element.reference_center_units'
+    _item.category_id             diffrn_detector_element
+    _item.mandatory_code          no
+    _item_type.code               code
+     loop_
+    _item_enumeration.value
+    _item_enumeration.detail
+                                   mm        'millimetres'
+                                   pixels    'detector pixels'
+                                   bins      'detector bins'
+     save_
+
+
+save__diffrn_detector_element.variant
+    _item_description.description
+;             The value of _diffrn_detector_element.variant  gives the variant
+              to which the given DIFFRN_DETECTOR_ELEMENT row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant  in the
+               VARIANT  category.
+;
+    _item.name                  '_diffrn_detector_element.variant'
+    _item.category_id             diffrn_detector_element
+    _item.mandatory_code          implicit
+    _item_default.value          .
+    _item_type.code               code
+     save_
+
+
+########################
+## DIFFRN_MEASUREMENT ##
+########################
+
+
+save_DIFFRN_MEASUREMENT
+    _category.description
+;   Data items in the DIFFRN_MEASUREMENT  category record details
+    about the device used to orient and/or position the crystal
+    during data measurement and the manner in which the
+    diffraction data were measured.
+;
+    _category.id                  diffrn_measurement
+    _category.mandatory_code      no
+    _category.NX_mapping_details
+; in online version
+;
+
+     loop_
+    _category_key.name          '_diffrn_measurement.device'
+                                '_diffrn_measurement.diffrn_id'
+                                '_diffrn_measurement.id'
+                                '_diffrn_measurement.variant'
+     loop_
+    _category_group.id           'inclusive_group'
+                                 'diffrn_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;    Example 1. based on PDB entry 5HVP and laboratory records for the
+                 structure corresponding to PDB entry 5HVP
+;
+;
+    _diffrn_measurement.diffrn_id           'd1'
+    _diffrn_measurement.device              '3-circle camera'
+    _diffrn_measurement.device_type        'Supper model X'
+    _diffrn_measurement.device_details      'none'
+    _diffrn_measurement.method              'omega scan'
+    _diffrn_measurement.details
+    ; 440 frames, 0.20 degrees, 150 sec, detector distance 12 cm,
+      detector angle 22.5 degrees
+    ;
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;     Example 2. based on data set TOZ of Willis, Beckwith & Tozer
+                  [Acta Cryst. (1991), C47, 2276-2277].
+;
+;
+    _diffrn_measurement.diffrn_id        's1'
+    _diffrn_measurement.device_type      'Philips PW1100/20 diffractometer'
+    _diffrn_measurement.method           'theta/2theta (\q/2\q)'
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save__diffrn_measurement.device
+    _item_description.description
+;             The general class of goniometer or device used to support
+              and orient the specimen.
+
+              If the value of _diffrn_measurement.device  is not given,
+              it is implicitly equal to the value of
+              _diffrn_measurement.diffrn_id.
+
+              Either _diffrn_measurement.device  or
+              _diffrn_measurement.id  may be used to link to other
+              categories.  If the experimental setup admits multiple
+              devices, then _diffrn_measurement.id  is used to provide
+              a unique link.
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+             '_diffrn_measurement.device'  diffrn_measurement      implicit
+             '_diffrn_measurement_axis.measurement_device'
+                                           diffrn_measurement_axis implicit
+     loop_
+    _item_linked.child_name
+    _item_linked.parent_name
+             '_diffrn_measurement_axis.measurement_device'
+                                         '_diffrn_measurement.device'
+    _item_aliases.alias_name    '_diffrn_measurement_device'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+    _item_type.code               text
+     loop_
+    _item_examples.case          '3-circle camera'
+                                 '4-circle camera'
+                                 'kappa-geometry camera'
+                                 'oscillation camera'
+                                 'precession camera'
+     save_
+
+
+save__diffrn_measurement.device_details
+    _item_description.description
+;             A description of special aspects of the device used to
+              measure the diffraction intensities.
+;
+    _item.name                  '_diffrn_measurement.device_details'
+    _item.category_id             diffrn_measurement
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_measurement_device_details'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+    _item_type.code               text
+    _item_examples.case
+;                                 commercial goniometer modified locally to
+                                  allow for 90\% \t arc
+;
+     save_
+
+
+save__diffrn_measurement.device_type
+    _item_description.description
+;             The make, model or name of the measurement device
+              (goniometer) used.
+;
+    _item.name                  '_diffrn_measurement.device_type'
+    _item.category_id             diffrn_measurement
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_measurement_device_type'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+    _item_type.code               text
+     loop_
+    _item_examples.case          'Supper model q'
+                                 'Huber model r'
+                                 'Enraf-Nonius model s'
+                                 'home-made'
+     save_
+
+
+save__diffrn_measurement.diffrn_id
+    _item_description.description
+;             This data item is a pointer to _diffrn.id  in the DIFFRN
+              category.
+;
+    _item.name                  '_diffrn_measurement.diffrn_id'
+    _item.category_id             diffrn_measurement
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+
+save__diffrn_measurement.details
+    _item_description.description
+;             A description of special aspects of the intensity
+              measurement.
+;
+    _item.name                  '_diffrn_measurement.details'
+    _item.category_id             diffrn_measurement
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_measurement_details'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+    _item_type.code               text
+    _item_examples.case
+;                                 440 frames, 0.20 degrees, 150 sec, detector
+                                  distance 12 cm, detector angle 22.5 degrees
+;
+     save_
+
+
+save__diffrn_measurement.id
+    _item_description.description
+;             The value of _diffrn_measurement.id  must uniquely identify
+              the set of mechanical characteristics of the device used to
+              orient and/or position the sample used during the collection
+              of each diffraction data set.
+
+              If the value of _diffrn_measurement.id  is not given, it is
+              implicitly equal to the value of
+              _diffrn_measurement.diffrn_id.
+
+              Either _diffrn_measurement.device  or
+              _diffrn_measurement.id  may be used to link to other
+              categories.  If the experimental setup admits multiple
+              devices, then _diffrn_measurement.id  is used to provide
+              a unique link.
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+             '_diffrn_measurement.id'      diffrn_measurement      implicit
+             '_diffrn_measurement_axis.measurement_id'
+                                           diffrn_measurement_axis implicit
+     loop_
+    _item_linked.child_name
+    _item_linked.parent_name
+             '_diffrn_measurement_axis.measurement_id'
+                                         '_diffrn_measurement.id'
+
+    _item_type.code               code
+     save_
+
+
+save__diffrn_measurement.method
+    _item_description.description
+;             Method used to measure intensities.
+;
+    _item.name                  '_diffrn_measurement.method'
+    _item.category_id             diffrn_measurement
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_measurement_method'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+    _item_type.code               text
+    _item_examples.case
+      'profile data from theta/2theta (\q/2\q) scans'
+     save_
+
+
+save__diffrn_measurement.number_of_axes
+    _item_description.description
+;             The value of _diffrn_measurement.number_of_axes  gives the
+              number of axes of the positioner for the goniometer or
+              other sample orientation or positioning device identified
+              by _diffrn_measurement.id.
+
+              The description of the axes should be provided by entries in
+              DIFFRN_MEASUREMENT_AXIS.
+;
+    _item.name                  '_diffrn_measurement.number_of_axes'
+    _item.category_id             diffrn_measurement
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .   1
+                                  1   1
+    _item_type.code               int
+     save_
+
+
+save__diffrn_measurement.sample_detector_distance
+    _item_description.description
+;             The value of _diffrn_measurement.sample_detector_distance  gives
+              the unsigned distance in millimetres from the sample to the
+              detector along the beam.  Normally this distance is derived
+              from the axis settings.
+;
+    _item.name                  '_diffrn_measurement.sample_detector_distance'
+    _item.category_id             diffrn_measurement
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .   0.0
+    _item_type.code               float
+    _item_units.code              'millimetres'
+     save_
+
+save__diffrn_measurement.sample_detector_distance_derived
+    _item_description.description
+;             The value of _diffrn_measurement.sample_detector_distance_derived
+              is assumed to be 'yes', i.e. that value of
+              _diffrn_measurement.sample_detector_distance
+              is derived from the axis settings rather than measured.
+;
+    _item.name                  '_diffrn_measurement.sample_detector_distance_derived'
+    _item.category_id             diffrn_measurement
+    _item.mandatory_code          no
+    _item_type.code               ucode
+    _item_default.value           'yes'
+     save_
+
+
+save__diffrn_measurement.sample_detector_voffset
+    _item_description.description
+;             The value of _diffrn_measurement.sample_detector_voffset  gives
+              the signed distance in millimetres in the vertical
+              direction (positive for up) from the centre of
+              the beam to the centre of the detector.
+;
+    _item.name                  '_diffrn_measurement.sample_detector_voffset'
+    _item.category_id             diffrn_measurement
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .  .
+                                  .  .
+    _item_type.code               float
+    _item_units.code              'millimetres'
+     save_
+
+
+save__diffrn_measurement.specimen_support
+    _item_description.description
+;             The physical device used to support the crystal during data
+              collection.
+;
+    _item.name                  '_diffrn_measurement.specimen_support'
+    _item.category_id             diffrn_measurement
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_measurement_specimen_support'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+    _item_type.code               text
+     loop_
+    _item_examples.case          'glass capillary'
+                                 'quartz capillary'
+                                 'fiber'
+                                 'metal loop'
+     save_
+
+
+save__diffrn_measurement.variant
+    _item_description.description
+;            The value of _diffrn_measurement.variant  gives the variant
+             to which the given DIFFRN_MEASUREMENT row is related.
+
+             If this value is not given, the variant is assumed to be
+             the default null variant.
+
+             This item is a pointer to _variant.variant  in the
+             VARIANT  category.
+;
+    _item.name                  '_diffrn_measurement.variant'
+    _item.category_id             diffrn_measurement
+    _item.mandatory_code          implicit
+    _item_default.value          .
+    _item_type.code               code
+     save_
+
+
+###########################
+# DIFFRN_MEASUREMENT_AXIS #
+###########################
+
+
+save_DIFFRN_MEASUREMENT_AXIS
+    _category.description
+;   Data items in the DIFFRN_MEASUREMENT_AXIS  category associate
+    axes with goniometers.
+;
+    _category.id                   diffrn_measurement_axis
+    _category.mandatory_code       no
+    _category.NX_mapping_details
+; in online version
+;
+
+     loop_
+    _category_key.name
+                              '_diffrn_measurement_axis.measurement_device'
+                              '_diffrn_measurement_axis.measurement_id'
+                              '_diffrn_measurement_axis.axis_id'
+                              '_diffrn_measurement_axis.variant'
+     loop_
+    _category_group.id        'inclusive_group'
+                              'diffrn_group'
+     save_
+
+
+save__diffrn_measurement_axis.axis_id
+    _item_description.description
+;             This data item is a pointer to _axis.id  in
+              the AXIS  category.
+;
+    _item.name                  '_diffrn_measurement_axis.axis_id'
+    _item.category_id             diffrn_measurement_axis
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+
+save__diffrn_measurement_axis.measurement_device
+    _item_description.description
+;             This data item is a pointer to _diffrn_measurement.device
+              in the DIFFRN_MEASUREMENT  category.
+;
+    _item.name
+      '_diffrn_measurement_axis.measurement_device'
+    _item.category_id             diffrn_measurement_axis
+    _item.mandatory_code          implicit
+    _item_type.code               text
+     save_
+
+
+save__diffrn_measurement_axis.measurement_id
+    _item_description.description
+;             This data item is a pointer to _diffrn_measurement.id  in
+              the DIFFRN_MEASUREMENT  category.
+
+              This item was previously named _diffrn_measurement_axis.id,
+              which is now a deprecated name.  The old name is
+              provided as an alias but should not be used for new work.
+;
+    _item.name                  '_diffrn_measurement_axis.measurement_id'
+    _item.category_id             diffrn_measurement_axis
+    _item.mandatory_code          implicit
+    _item_aliases.alias_name    '_diffrn_measurement_axis.id'
+    _item_aliases.dictionary      cif_img.dic
+    _item_aliases.version         1.0
+    _item_type.code               code
+     save_
+
+
+save__diffrn_measurement_axis.variant
+    _item_description.description
+;             The value of _diffrn_measurement_axis.variant  gives the variant
+              to which the given DIFFRN_MEASUREMENT_AXIS row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant  in the
+              VARIANT  category.
+;
+    _item.name                  '_diffrn_measurement_axis.variant'
+    _item.category_id             diffrn_measurement_axis
+    _item.mandatory_code          implicit
+    _item_default.value          .
+    _item_type.code               code
+     save_
+
+
+####################
+# DIFFRN_RADIATION #
+####################
+
+
+save_DIFFRN_RADIATION
+    _category.description
+;             Data items in the DIFFRN_RADIATION  category describe
+              the radiation used for measuring diffraction intensities,
+              its collimation and monochromatization before the sample.
+
+              Post-sample treatment of the beam is described by data
+              items in the DIFFRN_DETECTOR  category.
+;
+    _category.id                  diffrn_radiation
+    _category.mandatory_code      no
+    _category.NX_mapping_details
+; in online version
+;
+
+
+     loop_
+    _category_key.name          '_diffrn_radiation.diffrn_id'
+                                '_diffrn_radiation.variant'
+     loop_
+    _category_group.id           'inclusive_group'
+                                 'diffrn_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;   Example 1. based on PDB entry 5HVP and laboratory records for the
+                structure corresponding to PDB entry 5HVP
+;
+;
+    _diffrn_radiation.diffrn_id             'set1'
+
+    _diffrn_radiation.collimation           '0.3 mm double pinhole'
+    _diffrn_radiation.monochromator         'graphite'
+    _diffrn_radiation.type                  'Cu K\a'
+    _diffrn_radiation.wavelength_id          1
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;    Example 2. based on data set TOZ of Willis, Beckwith & Tozer
+                [Acta Cryst. (1991), C47, 2276-2277].
+;
+;
+    _diffrn_radiation.wavelength_id     1
+    _diffrn_radiation.type              'Cu K\a'
+    _diffrn_radiation.monochromator     'graphite'
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save__diffrn_radiation.beam_width
+    _item_description.description
+;             Full width at half maximum of the beam incident on the sample
+              in the plane of polarization (or horizontally if unpolarized).
+;
+    _item.name                  '_diffrn_radiation.beam_width'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_type.code               float
+    _item_units.code              micrometres
+     save_
+
+
+save__diffrn_radiation.beam_height
+    _item_description.description
+;             Full width at half maximum of the beam incident on the sample
+              orthogonal to the plane of polarization (or vertically
+              if unpolarized).
+;
+    _item.name                  '_diffrn_radiation.beam_width'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_type.code               float
+    _item_units.code              micrometres
+     save_
+
+
+save__diffrn_radiation.beam_flux
+    _item_description.description
+;             The average flux integrated over the beam incident on the sample.
+;
+    _item.name                  '_diffrn_radiation.beam_flux'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_type.code               float
+    _item_units.code              'photons per second'
+     save_
+
+
+save__diffrn_radiation.collimation
+    _item_description.description
+;             The collimation or focusing applied to the radiation.
+;
+    _item.name                  '_diffrn_radiation.collimation'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_radiation_collimation'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+    _item_type.code               text
+     loop_
+    _item_examples.case          '0.3 mm double-pinhole'
+                                 '0.5 mm'
+                                 'focusing mirrors'
+     save_
+
+
+save__diffrn_radiation.diffrn_id
+    _item_description.description
+;             This data item is a pointer to _diffrn.id  in the DIFFRN
+              category.
+;
+    _item.name                  '_diffrn_radiation.diffrn_id'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+
+save__diffrn_radiation.div_x_source
+    _item_description.description
+;             Beam crossfire in degrees parallel to the laboratory X axis
+              (see AXIS  category).
+
+              This is a characteristic of the X-ray beam as it illuminates
+              the sample (or specimen) after all monochromation and
+              collimation.
+
+              This is the standard uncertainty (estimated standard
+              deviation, e.s.d.)  of the directions of photons in
+              the XZ plane around the mean source beam direction.
+
+              Note that for some synchrotrons this value is specified
+              in milliradians, in which case a conversion is needed.
+              To convert a value in milliradians to a value in degrees,
+              multiply by 0.180 and divide by \p.
+;
+    _item.name                  '_diffrn_radiation.div_x_source'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_type.code               float
+    _item_units.code              degrees
+     save_
+
+
+save__diffrn_radiation.div_y_source
+    _item_description.description
+;             Beam crossfire in degrees parallel to the laboratory Y axis
+              (see AXIS  category).
+
+              This is a characteristic of the X-ray beam as it illuminates
+              the sample (or specimen) after all monochromation and
+              collimation.
+
+              This is the standard uncertainty (estimated standard deviation,
+              e.s.d.) of the directions of photons in the YZ plane around
+              the mean source beam direction.
+
+              Note that for some synchrotrons this value is specified
+              in milliradians, in which case a conversion is needed.
+              To convert a value in milliradians to a value in degrees,
+              multiply by 0.180 and divide by \p.
+;
+    _item.name                  '_diffrn_radiation.div_y_source'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_type.code               float
+    _item_units.code              degrees
+    _item_default.value           0.0
+     save_
+
+
+save__diffrn_radiation.div_x_y_source
+    _item_description.description
+;             Beam crossfire correlation in degrees squared between the
+              crossfire laboratory X-axis component and the crossfire
+              laboratory Y-axis component (see AXIS category).
+
+              This is a characteristic of the X-ray beam as it illuminates
+              the sample (or specimen) after all monochromation and
+              collimation.
+
+              This is the mean of the products of the deviations of the
+              direction of each photon in XZ plane times the deviations
+              of the direction of the same photon in the YZ plane
+              around the mean source beam direction.  This will be zero
+              for uncorrelated crossfire.
+
+              Note that for some synchrotrons, this value is specified in
+              milliradians squared, in which case a conversion is
+              needed. To convert a value in milliradians squared to a value
+              in degrees squared, multiply by 0.180^2^ and divide by \p^2^.
+;
+    _item.name                  '_diffrn_radiation.div_x_y_source'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_type.code               float
+    _item_units.code              degrees_squared
+    _item_default.value           0.0
+     save_
+
+
+save__diffrn_radiation.filter_edge
+    _item_description.description
+;              Absorption edge in \%angstr\"oms of the radiation filter used.
+;
+    _item.name                  '_diffrn_radiation.filter_edge'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_radiation_filter_edge'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+     loop_
+    _item_range.maximum
+    _item_range.minimum            .    0.0
+                                  0.0   0.0
+    _item_type.code               float
+    _item_units.code              angstroms
+     save_
+
+
+save__diffrn_radiation.inhomogeneity
+    _item_description.description
+;             Half-width in millimetres of the incident beam in the
+              direction perpendicular to the diffraction plane.
+;
+    _item.name                  '_diffrn_radiation.inhomogeneity'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_radiation_inhomogeneity'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+     loop_
+    _item_range.maximum
+    _item_range.minimum            .    0.0
+                                  0.0   0.0
+    _item_type.code               float
+    _item_units.code              millimetres
+     save_
+
+
+save__diffrn_radiation.monochromator
+    _item_description.description
+;             The method used to obtain monochromatic radiation. If a
+              monochromator crystal is used, the material and the
+              indices of the Bragg reflection are specified.
+;
+    _item.name                  '_diffrn_radiation.monochromator'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_radiation_monochromator'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+    _item_type.code               text
+     loop_
+    _item_examples.case          'Zr filter'
+                                 'Ge 220'
+                                 'none'
+                                 'equatorial mounted graphite'
+     save_
+
+
+save__diffrn_radiation.polarisn_norm
+    _item_description.description
+;             The angle in degrees, as viewed from the specimen, between the
+              perpendicular component of the polarization and the diffraction
+              plane. See _diffrn_radiation_polarisn_ratio.
+;
+    _item.name                  '_diffrn_radiation.polarisn_norm'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_radiation_polarisn_norm'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+     loop_
+    _item_range.maximum
+    _item_range.minimum           90.0  90.0
+                                  90.0 -90.0
+                                 -90.0 -90.0
+    _item_type.code               float
+    _item_units.code              degrees
+     save_
+
+
+save__diffrn_radiation.polarisn_norm_esd
+    _item_description.description
+;             The standard uncertainty (estimated standard deviation, e.s.d.) of
+              _diffrn_radiation.polarisn_norm,
+              the angle in degrees, as viewed from the specimen, between the
+              perpendicular component of the polarization and the diffraction
+              plane. See _diffrn_radiation_polarisn_ratio.
+;
+    _item.name                  '_diffrn_radiation.polarisn_norm_esd'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .     0.0
+                                  0.0   0.0
+    _item_type.code               float
+    _item_units.code              degrees
+     loop_
+    _item_related.related_name
+    _item_related.function_code  '_diffrn_radiation.polarisn_norm'
+                                 'associated_value'
+     save_
+
+
+save__diffrn_radiation.polarisn_ratio
+    _item_description.description
+;             Polarization ratio of the diffraction beam incident on the
+              crystal. This is the ratio of the perpendicularly polarized to
+              the parallel polarized component of the radiation. The
+              perpendicular component forms an angle of
+              _diffrn_radiation.polarisn_norm  to the normal to the
+              diffraction plane of the sample (i.e. the plane containing
+              the incident and reflected beams).
+;
+    _item.name                  '_diffrn_radiation.polarisn_ratio'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_radiation_polarisn_ratio'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+     loop_
+    _item_range.maximum
+    _item_range.minimum            .    0.0
+                                  0.0   0.0
+    _item_type.code               float
+     save_
+
+
+save__diffrn_radiation.polarisn_ratio_esd
+    _item_description.description
+;             The standard uncertainty (estimated standard deviation, e.s.d.) of
+              _diffrn_radiation.polarisn_ratio,
+              the polarization ratio of the diffraction beam incident on the
+              crystal.
+;
+    _item.name                  '_diffrn_radiation.polarisn_ratio_esd'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum            .    0.0
+                                  0.0   0.0
+    _item_type.code               float
+     loop_
+    _item_related.related_name
+    _item_related.function_code  '_diffrn_radiation.polarisn_ratio'
+                                 'associated_value'
+     save_
+
+
+save__diffrn_radiation.polarizn_source_norm
+    _item_description.description
+;             The angle in degrees, as viewed from the specimen, between
+              the normal to the polarization plane and the laboratory
+              Y-axis as defined in the AXIS category.
+
+              Note that this is the angle of polarization of the source
+              photons, either directly from a synchrotron beamline or
+              from a monochromator.
+
+              This differs from the value of
+              _diffrn_radiation.polarisn_norm
+              in that _diffrn_radiation.polarisn_norm  refers to
+              polarization relative to the diffraction plane rather than
+              to the laboratory axis system.
+
+              In the case of an unpolarized beam, or a beam with true
+              circular polarization, in which no single plane of
+              polarization can be determined, the plane should be taken
+              as the XZ plane and the angle as 0.
+
+              See _diffrn_radiation.polarizn_source_ratio.
+;
+    _item.name                  '_diffrn_radiation.polarizn_source_norm'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           90.0   90.0
+                                  90.0  -90.0
+                                 -90.0  -90.0
+    _item_type.code               float
+    _item_units.code              degrees
+    _item_default.value           0.0
+     save_
+
+
+save__diffrn_radiation.polarizn_source_norm_esd
+    _item_description.description
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_radiation.polarizn_source_norm,
+              the angle in degrees, as viewed from the specimen, between
+              the normal to the polarization plane and the laboratory
+              Y-axis as defined in the AXIS category.
+;
+    _item.name
+        '_diffrn_radiation.polarizn_source_norm_esd'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .      0.0
+                                  0.0    0.0
+    _item_type.code               float
+    _item_units.code              degrees
+     loop_
+    _item_related.related_name
+    _item_related.function_code  '_diffrn_radiation.polarizn_source_norm'
+                                 'associated_value'
+     save_
+
+
+save__diffrn_radiation.polarizn_source_ratio
+    _item_description.description
+;             The quantity (Ip-In)/(Ip+In), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization and In is the intensity (amplitude squared)
+              of the electric vector in the plane of the normal to the
+              plane of polarization.
+
+              In the case of an unpolarized beam, or a beam with true
+              circular polarization, in which no single plane of
+              polarization can be determined, the plane is to be taken
+              as the XZ plane and the normal is parallel to the Y axis.
+
+              Thus, if there was complete polarization in the plane of
+              polarization, the value of
+              _diffrn_radiation.polarizn_source_ratio  would be 1, and
+              for an unpolarized beam
+              _diffrn_radiation.polarizn_source_ratio  would have a
+              value of 0.
+
+              If the X axis has been chosen to lie in the plane of
+              polarization, this definition will agree with the definition
+              of 'MONOCHROMATOR' in the Denzo glossary, and values of near
+              1 should be expected for a bending-magnet source.  However,
+              if the X-axis were perpendicular to the polarization plane
+              (not a common choice), then the Denzo value would be the
+              negative of _diffrn_radiation.polarizn_source_ratio.
+
+              See http://www.hkl-xray.com for information on Denzo and
+              Otwinowski & Minor (1997).
+
+              This differs both in the choice of ratio and choice of
+              orientation from _diffrn_radiation.polarisn_ratio, which,
+              unlike _diffrn_radiation.polarizn_source_ratio, is
+              unbounded.
+
+              Reference: Otwinowski, Z. & Minor, W. (1997). 'Processing of
+              X-ray diffraction data collected in oscillation mode.' Methods
+              Enzymol. 276, 307-326.
+;
+    _item.name                  '_diffrn_radiation.polarizn_source_ratio'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           1.0    1.0
+                                  1.0   -1.0
+                                 -1.0   -1.0
+    _item_type.code               float
+     save_
+
+
+save__diffrn_radiation.polarizn_source_ratio_esd
+    _item_description.description
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_radiation.polarizn_source_ratio,
+              (Ip-In)/(Ip+In), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization and In is the intensity (amplitude squared)
+              of the electric vector in the plane of the normal to the
+              plane of polarization.
+;
+    _item.name                  '_diffrn_radiation.polarizn_source_ratio_esd'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .      0.0
+                                  0.0    0.0
+    _item_type.code               float
+     loop_
+    _item_related.related_name
+    _item_related.function_code  '_diffrn_radiation.polarizn_source_ratio'
+                                 'associated_value'
+     save_
+
+
+save__diffrn_radiation.polarizn_Stokes_I
+    _item_description.description
+;             The quantity Ip+In+Inp, where Ip is the intensity (amplitude
+              squared) of the electric vector in the plane of polarization,
+              In is the intensity (amplitude squared) of the electric vector
+              in the plane of the normal to the plane of polarization,
+              and Inp is the intensity (amplitude squared) of the
+              non-polarized (incoherent) electric vector.
+
+              This is an average or other representative sample of the
+              scan.
+
+              This is the first of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
+
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
+
+              Note that, if the polarized intensity Ip+In is required,
+              (Ip+In)^2^ is the sum of Q^2^+U^2^+V^2^.
+
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200 -- 3205.
+;
+    _item.name                  '_diffrn_radiation.polarizn_Stokes_I'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          implicit
+    _item_default.value           1.0
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                                   .    0.0
+                                  0.0   0.0
+    _item_type.code               float
+     save_
+
+
+save__diffrn_radiation.polarizn_Stokes_I_esd
+    _item_description.description
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_radiation.polarizn_Stokes_I,
+              Ip+In+Inp, where Ip is the intensity (amplitude squared)
+              of the electric vector in the plane of polarization,
+              In is the intensity (amplitude squared) of the electric vector
+              in the plane of the normal to the plane of polarization,
+              and Inp is the intensity (amplitude squared) of the
+              non-polarized (incoherent) electric vector.
+;
+    _item.name                  '_diffrn_radiation.polarizn_Stokes_I_esd'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .      0.0
+                                  0.0    0.0
+    _item_type.code               float
+     loop_
+    _item_related.related_name
+    _item_related.function_code  '_diffrn_radiation.polarizn_Stokes_I'
+                                 'associated_value'
+     save_
+
+
+save__diffrn_radiation.polarizn_Stokes_Q
+    _item_description.description
+;             The quantity (Ip-In)*cos(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y axis as defined in the
+              AXIS  category.
+
+              This is an average or other representative sample of the
+              scan.
+
+              This is the second of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
+
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
+
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200 -- 3205.
+;
+    _item.name                  '_diffrn_radiation.polarizn_Stokes_Q'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_type.code               float
+     save_
+
+
+save__diffrn_radiation.polarizn_Stokes_Q_esd
+    _item_description.description
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_radiation.polarizn_Stokes_Q,
+              (Ip-In)*cos(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y-axis as defined in the
+              AXIS  category.
+;
+    _item.name                  '_diffrn_radiation.polarizn_Stokes_Q_esd'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .      0.0
+                                  0.0    0.0
+    _item_type.code               float
+     loop_
+    _item_related.related_name
+    _item_related.function_code  '_diffrn_radiation.polarizn_Stokes_Q'
+                                 'associated_value'
+     save_
+
+
+save__diffrn_radiation.polarizn_Stokes_U
+    _item_description.description
+;             The quantity (Ip-In)*sin(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y axis as defined in the
+              AXIS  category.
+
+              This is an average or other representative sample of the
+              scan.
+
+              This is the third of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry at al. (1977)].
+
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
+
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200 -- 3205.
+;
+    _item.name                  '_diffrn_radiation.polarizn_Stokes_U'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_type.code               float
+     save_
+
+
+save__diffrn_radiation.polarizn_Stokes_U_esd
+    _item_description.description
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_radiation.polarizn_Stokes_U,
+              (Ip-In)*sin(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y-axis as defined in the
+              AXIS  category.
+;
+    _item.name                  '_diffrn_radiation.polarizn_Stokes_U_esd'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .      0.0
+                                  0.0    0.0
+    _item_type.code               float
+     loop_
+    _item_related.related_name
+    _item_related.function_code  '_diffrn_radiation.polarizn_Stokes_U'
+                                 'associated_value'
+     save_
+
+
+save__diffrn_radiation.polarizn_Stokes_V
+    _item_description.description
+;             The quantity +/-2*sqrt(IpIn), with a + sign for right-handed
+              circular polarization, where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization and In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y axis as defined in the
+              AXIS  category.
+
+              This is an average or other representative sample of the
+              scan.
+
+              This is the fourth of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
+
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
+
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200 -- 3205.
+;
+    _item.name                  '_diffrn_radiation.polarizn_Stokes_V'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_type.code               float
+     save_
+
+
+save__diffrn_radiation.polarizn_Stokes_V_esd
+    _item_description.description
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_radiation.polarizn_Stokes_V,
+              +/-2*sqrt(IpIn), with a + sign for right-handed circular
+              polarization, where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization and In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y axis as defined in the
+              AXIS  category.
+;
+    _item.name                  '_diffrn_radiation.polarizn_Stokes_V_esd'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .      0.0
+                                  0.0    0.0
+    _item_type.code               float
+     loop_
+    _item_related.related_name
+    _item_related.function_code  '_diffrn_radiation.polarizn_Stokes_V'
+                                 'associated_value'
+     save_
+
+
+save__diffrn_radiation.probe
+    _item_description.description
+;             Name of the type of radiation used. It is strongly
+              recommended that this be given so that the
+              probe radiation is clearly specified.
+;
+    _item.name                  '_diffrn_radiation.probe'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_radiation_probe'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+    _item_type.code               line
+     loop_
+    _item_enumeration.value      'x-ray'
+                                 'neutron'
+                                 'electron'
+                                 'gamma'
+     save_
+
+
+save__diffrn_radiation.type
+    _item_description.description
+;             The nature of the radiation. This is typically a description
+              of the X-ray wavelength in Siegbahn notation.
+;
+    _item.name                  '_diffrn_radiation.type'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_radiation_type'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+    _item_type.code               line
+     loop_
+    _item_examples.case          'CuK\a'
+                                 'Cu K\a~1~'
+                                 'Cu K-L~2,3~'
+                                 'white-beam'
+     save_
+
+
+save__diffrn_radiation.xray_symbol
+    _item_description.description
+;             The IUPAC symbol for the X-ray wavelength for the probe
+              radiation.
+;
+    _item.name                  '_diffrn_radiation.xray_symbol'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_radiation_xray_symbol'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+    _item_type.code               line
+     loop_
+    _item_enumeration.value
+    _item_enumeration.detail     'K-L~3~'
+                                 'K\a~1~ in older Siegbahn notation'
+                                 'K-L~2~'
+                                 'K\a~2~ in older Siegbahn notation'
+                                 'K-M~3~'
+                                 'K\b~1~ in older Siegbahn notation'
+                                 'K-L~2,3~'
+                                 'use where K-L~3~ and K-L~2~ are not resolved'
+     save_
+
+
+save__diffrn_radiation.wavelength_id
+    _item_description.description
+;             This data item is a pointer to
+              _diffrn_radiation_wavelength.id  in the
+              DIFFRN_RADIATION_WAVELENGTH category.
+;
+    _item.name                  '_diffrn_radiation.wavelength_id'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+
+save__diffrn_radiation.variant
+    _item_description.description
+;             The value of _diffrn_radiation.variant  gives the variant
+              to which the given DIFFRN_RADIATION row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant  in the
+              VARIANT  category.
+;
+    _item.name                  '_diffrn_radiation.variant'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          implicit
+    _item_default.value          .
+    _item_type.code               code
+     save_
+
+
+################
+# DIFFRN_REFLN #
+################
+
+
+save_DIFFRN_REFLN
+    _category.description
+;   This category redefinition has been added to extend the key of
+    the standard DIFFRN_REFLN  category.
+
+    Data items in the DIFFRN_REFLN category record details about
+    the intensities in the diffraction data set
+    identified by _diffrn_refln.diffrn_id.
+
+    The DIFFRN_REFLN data items refer to individual intensity
+    measurements and must be included in looped lists.
+
+    The DIFFRN_REFLNS data items specify the parameters that apply
+    to all intensity  measurements in the particular diffraction
+    data set identified by _diffrn_reflns.diffrn_id and
+    _diffrn_refln.frame_id
+;
+    _category.id                   diffrn_refln
+    _category.mandatory_code       no
+    _category.NX_mapping_details
+; in online version
+;
+     loop_
+    _category_key.name             '_diffrn_refln.diffrn_id'
+                                   '_diffrn_refln.id'
+                                   '_diffrn_refln.frame_id'
+                                   '_diffrn_refln.variant'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'diffrn_group'
+     save_
+
+
+save__diffrn_refln.frame_id
+    _item_description.description
+;             This item is a pointer to _diffrn_data_frame.id
+              in the DIFFRN_DATA_FRAME  category.
+;
+    _item.name                  '_diffrn_refln.frame_id'
+    _item.category_id             diffrn_refln
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+save__diffrn_refln.variant
+    _item_description.description
+;             The value of _diffrn_refln.variant  gives the variant
+              to which the given DIFFRN_REFLN row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant  in the
+              VARIANT  category.
+;
+    _item.name                  '_diffrn_refln.variant'
+    _item.category_id             diffrn_refln
+    _item.mandatory_code          implicit
+    _item_default.value          .
+    _item_type.code               code
+     save_
+
+
+save__diffrn_refln.id
+    _item_description.description
+;             This item is a placeholder for the definition in the
+              PDBx/mmCIF dictionary.
+;
+    _item.name                  '_diffrn_refln.id'
+    _item.category_id             diffrn_refln
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+
+save__diffrn_refln.diffrn_id
+    _item_description.description
+;             This item is a placeholder for the definition in the
+              PDBx/mmCIF dictionary
+;
+    _item.name                  '_diffrn_refln.diffrn_id'
+    _item.category_id             diffrn_refln
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+
+###############
+# DIFFRN_SCAN #
+###############
+
+save_DIFFRN_SCAN
+    _category.description
+;   Data items in the DIFFRN_SCAN  category describe the parameters of one
+    or more scans, relating axis positions to frames.
+;
+    _category.id                   diffrn_scan
+    _category.mandatory_code       no
+    _category.NX_mapping_details
+; in online version
+;
+
+     loop_
+    _category_key.name            '_diffrn_scan.id'
+                                  '_diffrn_scan.variant'
+     loop_
+    _category_group.id            'inclusive_group'
+                                  'diffrn_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;   Example 1. derived from a suggestion by R. M. Sweet.
+
+   The vector of each axis is not given here, because it is provided in
+   the AXIS category.  By making _diffrn_scan_axis.scan_id and
+   _diffrn_scan_axis.axis_id keys of the DIFFRN_SCAN_AXIS category,
+   an arbitrary number of scanning and fixed axes can be specified for a
+   scan.  In this example, three rotation axes and one translation axis
+   at nonzero values are specified, with one axis stepping.  There is no
+   reason why more axes could not have been specified to step. Range
+   information has been specified, but note that it can be calculated from
+   the  number of frames and the increment, so the data item
+   _diffrn_scan_axis.angle_range  could be dropped.
+
+   Both the sweep data and the data for a single frame are specified.
+
+   Note that the information on how the axes are stepped is given twice,
+   once in terms of the overall averages in the value of
+   _diffrn_scan.integration_time and the values for DIFFRN_SCAN_AXIS,
+   and precisely for the given frame in the value for
+   _diffrn_scan_frame.integration_time  and the values for
+   DIFFRN_SCAN_FRAME_AXIS .  If dose-related adjustments are made to
+   scan times and nonlinear stepping is done, these values may differ.
+   Therefore, in interpreting the data for a particular frame it is
+   important to use the frame-specific data.
+
+   There are three date/times in this set: *.date_start and
+   *. date_end_estimated, both of which are mandatory, because the former
+   is data which can be logged at the start of collection and the latter
+   is data that can be estimated at the same time, and *.date_end which
+   can only be logged exactly if the data collection completes normally.
+;
+;
+      _diffrn_scan.id                    1
+      _diffrn_scan.date_start          '2001-11-18T03:26:42'
+      _diffrn_scan.date_end_estimated  '2001-11-18T03:36:45'
+      _diffrn_scan.date_end            '2001-11-18T03:36:45'
+      _diffrn_scan.integration_time     3.0
+      _diffrn_scan.frame_id_start       mad_L2_000
+      _diffrn_scan.frame_id_end         mad_L2_200
+      _diffrn_scan.frames               201
+
+     loop_
+      _diffrn_scan_axis.scan_id
+      _diffrn_scan_axis.axis_id
+      _diffrn_scan_axis.angle_start
+      _diffrn_scan_axis.angle_range
+      _diffrn_scan_axis.angle_increment
+      _diffrn_scan_axis.displacement_start
+      _diffrn_scan_axis.displacement_range
+      _diffrn_scan_axis.displacement_increment
+
+       1 omega 200.0 20.0 0.1 . . .
+       1 kappa -40.0  0.0 0.0 . . .
+       1 phi   127.5  0.0 0.0 . . .
+       1 tranz  . . .   2.3 0.0 0.0
+
+      _diffrn_scan_frame.scan_id                    1
+      _diffrn_scan_frame.date                '2001-11-18T03:27:33'
+      _diffrn_scan_frame.integration_time     3.0
+      _diffrn_scan_frame.frame_id             mad_L2_018
+      _diffrn_scan_frame.frame_number         18
+
+     loop_
+      _diffrn_scan_frame_axis.frame_id
+      _diffrn_scan_frame_axis.axis_id
+      _diffrn_scan_frame_axis.angle
+      _diffrn_scan_frame_axis.angle_increment
+      _diffrn_scan_frame_axis.displacement
+      _diffrn_scan_frame_axis.displacement_increment
+
+       mad_L2_018 omega 201.8  0.1 ..
+       mad_L2_018 kappa -40.0  0.0 ..
+       mad_L2_018 phi   127.5  0.0 ..
+       mad_L2_018 tranz  .     .  2.3 0.0
+;
+
+;  Example 2. a more extensive example (R. M. Sweet, P. J. Ellis &
+   H. J. Bernstein).
+
+   A detector is placed 240 mm along the Z axis from the goniometer.
+   This leads to a choice:  either the axes of
+   the detector are defined at the origin, and then a Z setting of -240
+   is entered, or the axes are defined with the necessary Z offset.
+   In this case, the setting is used and the offset is left as zero.
+   This axis is called DETECTOR_Z.
+
+   The axis for positioning the detector in the Y direction depends
+   on the detector Z axis.  This axis is called DETECTOR_Y.
+
+   The axis for positioning the detector in the X direction depends
+   on the detector Y axis (and therefore on the detector Z axis).
+   This axis is called DETECTOR_X.
+
+   This detector may be rotated around the Y axis.  This rotation axis
+   depends on the three translation axes.  It is called DETECTOR_PITCH.
+
+   A coordinate system is defined on the face of the detector in terms of
+   2300 0.150 mm pixels in each direction.  The ELEMENT_X axis is used to
+   index the first array index of the data array and the ELEMENT_Y
+   axis is used to index the second array index.  Because the pixels
+   are 0.150mm x 0.150mm, the centre of the first pixel is at (0.075,
+   0.075) in this coordinate system.
+;
+
+;    ###CBF: VERSION 1.1
+
+     data_image_1
+
+     # category DIFFRN
+    _diffrn.id P6MB
+    _diffrn.crystal_id P6MB_CRYSTAL7
+
+     # category DIFFRN_SOURCE
+     loop_
+    _diffrn_source.diffrn_id
+    _diffrn_source.source
+    _diffrn_source.type
+      P6MB synchrotron 'SSRL beamline 9-1'
+
+     # category DIFFRN_RADIATION
+     loop_
+     _diffrn_radiation.diffrn_id
+     _diffrn_radiation.wavelength_id
+     _diffrn_radiation.monochromator
+     _diffrn_radiation.polarizn_source_ratio
+     _diffrn_radiation.polarizn_source_norm
+     _diffrn_radiation.div_x_source
+     _diffrn_radiation.div_y_source
+     _diffrn_radiation.div_x_y_source
+      P6MB WAVELENGTH1 'Si 111' 0.8 0.0 0.08 0.01 0.00
+
+     # category DIFFRN_RADIATION_WAVELENGTH
+     loop_
+    _diffrn_radiation_wavelength.id
+    _diffrn_radiation_wavelength.wavelength
+    _diffrn_radiation_wavelength.wt
+      WAVELENGTH1 0.98 1.0
+
+     # category DIFFRN_DETECTOR
+     loop_
+     _diffrn_detector.diffrn_id
+     _diffrn_detector.id
+     _diffrn_detector.type
+     _diffrn_detector.number_of_axes
+      P6MB MAR345-SN26 'MAR 345' 4
+
+     # category DIFFRN_DETECTOR_AXIS
+     loop_
+     _diffrn_detector_axis.detector_id
+     _diffrn_detector_axis.axis_id
+      MAR345-SN26 DETECTOR_X
+      MAR345-SN26 DETECTOR_Y
+      MAR345-SN26 DETECTOR_Z
+      MAR345-SN26 DETECTOR_PITCH
+
+     # category DIFFRN_DETECTOR_ELEMENT
+     loop_
+     _diffrn_detector_element.id
+     _diffrn_detector_element.detector_id
+      ELEMENT1 MAR345-SN26
+
+     # category DIFFRN_DATA_FRAME
+     loop_
+     _diffrn_data_frame.id
+     _diffrn_data_frame.detector_element_id
+     _diffrn_data_frame.array_id
+     _diffrn_data_frame.binary_id
+      FRAME1 ELEMENT1 ARRAY1 1
+
+     # category DIFFRN_MEASUREMENT
+     loop_
+     _diffrn_measurement.diffrn_id
+     _diffrn_measurement.id
+     _diffrn_measurement.number_of_axes
+     _diffrn_measurement.method
+      P6MB GONIOMETER 3 rotation
+
+     # category DIFFRN_MEASUREMENT_AXIS
+     loop_
+     _diffrn_measurement_axis.measurement_id
+     _diffrn_measurement_axis.axis_id
+      GONIOMETER GONIOMETER_PHI
+      GONIOMETER GONIOMETER_KAPPA
+      GONIOMETER GONIOMETER_OMEGA
+
+     # category DIFFRN_SCAN
+     loop_
+     _diffrn_scan.id
+     _diffrn_scan.frame_id_start
+     _diffrn_scan.frame_id_end
+     _diffrn_scan.frames
+      SCAN1 FRAME1 FRAME1 1
+
+     # category DIFFRN_SCAN_AXIS
+     loop_
+     _diffrn_scan_axis.scan_id
+     _diffrn_scan_axis.axis_id
+     _diffrn_scan_axis.angle_start
+     _diffrn_scan_axis.angle_range
+     _diffrn_scan_axis.angle_increment
+     _diffrn_scan_axis.displacement_start
+     _diffrn_scan_axis.displacement_range
+     _diffrn_scan_axis.displacement_increment
+      SCAN1 GONIOMETER_OMEGA 12.0 1.0 1.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_KAPPA 23.3 0.0 0.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_PHI -165.8 0.0 0.0 0.0 0.0 0.0
+      SCAN1 DETECTOR_Z 0.0 0.0 0.0 -240.0 0.0 0.0
+      SCAN1 DETECTOR_Y 0.0 0.0 0.0 0.6 0.0 0.0
+      SCAN1 DETECTOR_X 0.0 0.0 0.0 -0.5 0.0 0.0
+      SCAN1 DETECTOR_PITCH 0.0 0.0 0.0 0.0 0.0 0.0
+
+     # category DIFFRN_SCAN_FRAME
+     loop_
+     _diffrn_scan_frame.frame_id
+     _diffrn_scan_frame.frame_number
+     _diffrn_scan_frame.integration_time
+     _diffrn_scan_frame.scan_id
+     _diffrn_scan_frame.date
+      FRAME1 1 20.0 SCAN1 1997-12-04T10:23:48
+
+     # category DIFFRN_SCAN_FRAME_AXIS
+     loop_
+     _diffrn_scan_frame_axis.frame_id
+     _diffrn_scan_frame_axis.axis_id
+     _diffrn_scan_frame_axis.angle
+     _diffrn_scan_frame_axis.displacement
+      FRAME1 GONIOMETER_OMEGA 12.0 0.0
+      FRAME1 GONIOMETER_KAPPA 23.3 0.0
+      FRAME1 GONIOMETER_PHI -165.8 0.0
+      FRAME1 DETECTOR_Z 0.0 -240.0
+      FRAME1 DETECTOR_Y 0.0 0.6
+      FRAME1 DETECTOR_X 0.0 -0.5
+      FRAME1 DETECTOR_PITCH 0.0 0.0
+
+     # category AXIS
+     loop_
+     _axis.id
+     _axis.type
+     _axis.equipment
+     _axis.depends_on
+     _axis.vector[1] _axis.vector[2] _axis.vector[3]
+     _axis.offset[1] _axis.offset[2] _axis.offset[3]
+      GONIOMETER_OMEGA rotation goniometer . 1 0 0 . . .
+      GONIOMETER_KAPPA rotation goniometer GONIOMETER_OMEGA 0.64279
+      0 0.76604 . . .
+      GONIOMETER_PHI   rotation goniometer GONIOMETER_KAPPA 1 0 0
+     . . .
+      SOURCE           general source . 0 0 1 . . .
+      GRAVITY          general gravity . 0 -1 0 . . .
+      DETECTOR_Z       translation detector . 0 0 1 0 0 0
+      DETECTOR_Y       translation detector DETECTOR_Z 0 1 0 0 0 0
+      DETECTOR_X       translation detector DETECTOR_Y 1 0 0 0 0 0
+      DETECTOR_PITCH   rotation    detector DETECTOR_X 0 1 0 0 0 0
+      ELEMENT_X        translation detector DETECTOR_PITCH
+     1 0 0 172.43 -172.43 0
+      ELEMENT_Y        translation detector ELEMENT_X
+     0 1 0 0 0 0
+
+     # category ARRAY_STRUCTURE_LIST
+     loop_
+     _array_structure_list.array_id
+     _array_structure_list.index
+     _array_structure_list.dimension
+     _array_structure_list.precedence
+     _array_structure_list.direction
+     _array_structure_list.axis_set_id
+      ARRAY1 1 2300 1 increasing ELEMENT_X
+      ARRAY1 2 2300 2 increasing ELEMENT_Y
+
+     # category ARRAY_STRUCTURE_LIST_AXIS
+     loop_
+     _array_structure_list_axis.axis_set_id
+     _array_structure_list_axis.axis_id
+     _array_structure_list_axis.displacement
+     _array_structure_list_axis.displacement_increment
+      ELEMENT_X ELEMENT_X 0.075 0.150
+      ELEMENT_Y ELEMENT_Y 0.075 0.150
+
+     # category ARRAY_ELEMENT_SIZE
+     loop_
+     _array_element_size.array_id
+     _array_element_size.index
+     _array_element_size.size
+      ARRAY1 1 150e-6
+      ARRAY1 2 150e-6
+
+     # category ARRAY_INTENSITIES
+     loop_
+     _array_intensities.array_id
+     _array_intensities.binary_id
+     _array_intensities.linearity
+     _array_intensities.gain
+     _array_intensities.gain_esd
+     _array_intensities.overload
+     _array_intensities.undefined_value
+      ARRAY1 1 linear 1.15 0.2 240000 0
+
+      # category ARRAY_STRUCTURE
+     loop_
+      _array_structure.id
+      _array_structure.encoding_type
+      _array_structure.compression_type
+      _array_structure.byte_order
+      ARRAY1 "signed 32-bit integer" packed little_endian
+
+     # category ARRAY_DATA
+     loop_
+     _array_data.array_id
+     _array_data.binary_id
+     _array_data.data
+      ARRAY1 1
+     ;
+     --CIF-BINARY-FORMAT-SECTION--
+     Content-Type: application/octet-stream;
+         conversions="X-CBF_PACKED"
+     Content-Transfer-Encoding: BASE64
+     X-Binary-Size: 3801324
+     X-Binary-ID: 1
+     X-Binary-Element-Type: "signed 32-bit integer"
+     Content-MD5: 07lZFvF+aOcW85IN7usl8A==
+
+     AABRAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZBQSr1sKNBOeOe9HITdMdDUnbq7bg
+     ...
+     8REo6TtBrxJ1vKqAvx9YDMD6J18Qg83OMr/tgssjMIJMXATDsZobL90AEXc4KigE
+
+     --CIF-BINARY-FORMAT-SECTION----
+     ;
+;
+
+;   Example 3. Example 2 revised for a spiral scan (R. M. Sweet,
+    P. J. Ellis & H. J. Bernstein).
+
+   A detector is placed 240 mm along the Z axis from the
+   goniometer, as in Example 2 above, but in this example the
+   image plate is scanned in a spiral pattern from the outside edge in.
+
+   The axis for positioning the detector in the Y direction depends
+   on the detector Z axis.  This axis is called DETECTOR_Y.
+
+   The axis for positioning the detector in the X direction depends
+   on the detector Y axis (and therefore on the detector Z axis).
+   This axis is called DETECTOR_X.
+
+   This detector may be rotated around the Y axis.  This rotation axis
+   depends on the three translation axes.  It is called DETECTOR_PITCH.
+
+   A coordinate system is defined on the face of the detector in
+   terms of a coupled rotation axis and radial scan axis to form
+   a spiral scan.  The rotation axis is called  ELEMENT_ROT  and the
+   radial axis is called ELEMENT_RAD.  A 150 micrometre radial pitch
+   and a 75 micrometre 'constant velocity' angular pitch are assumed.
+
+   Indexing is carried out first on the rotation axis and the radial axis
+   is made to be dependent on it.
+
+   The two axes are coupled to form an axis set ELEMENT_SPIRAL.
+;
+;    ###CBF: VERSION 1.1
+
+     data_image_1
+
+     # category DIFFRN
+    _diffrn.id P6MB
+    _diffrn.crystal_id P6MB_CRYSTAL7
+
+     # category DIFFRN_SOURCE
+     loop_
+    _diffrn_source.diffrn_id
+    _diffrn_source.source
+    _diffrn_source.type
+      P6MB synchrotron 'SSRL beamline 9-1'
+
+     # category DIFFRN_RADIATION
+          loop_
+     _diffrn_radiation.diffrn_id
+     _diffrn_radiation.wavelength_id
+     _diffrn_radiation.monochromator
+     _diffrn_radiation.polarizn_source_ratio
+     _diffrn_radiation.polarizn_source_norm
+     _diffrn_radiation.div_x_source
+     _diffrn_radiation.div_y_source
+     _diffrn_radiation.div_x_y_source
+      P6MB WAVELENGTH1 'Si 111' 0.8 0.0 0.08 0.01 0.00
+
+     # category DIFFRN_RADIATION_WAVELENGTH
+     loop_
+    _diffrn_radiation_wavelength.id
+    _diffrn_radiation_wavelength.wavelength
+    _diffrn_radiation_wavelength.wt
+      WAVELENGTH1 0.98 1.0
+
+     # category DIFFRN_DETECTOR
+     loop_
+     _diffrn_detector.diffrn_id
+     _diffrn_detector.id
+     _diffrn_detector.type
+     _diffrn_detector.number_of_axes
+      P6MB MAR345-SN26 'MAR 345' 4
+
+     # category DIFFRN_DETECTOR_AXIS
+     loop_
+     _diffrn_detector_axis.detector_id
+     _diffrn_detector_axis.axis_id
+      MAR345-SN26 DETECTOR_X
+      MAR345-SN26 DETECTOR_Y
+      MAR345-SN26 DETECTOR_Z
+      MAR345-SN26 DETECTOR_PITCH
+
+     # category DIFFRN_DETECTOR_ELEMENT
+     loop_
+     _diffrn_detector_element.id
+     _diffrn_detector_element.detector_id
+      ELEMENT1 MAR345-SN26
+
+     # category DIFFRN_DATA_FRAME
+     loop_
+     _diffrn_data_frame.id
+     _diffrn_data_frame.detector_element_id
+     _diffrn_data_frame.array_id
+     _diffrn_data_frame.binary_id
+      FRAME1 ELEMENT1 ARRAY1 1
+
+     # category DIFFRN_MEASUREMENT
+     loop_
+     _diffrn_measurement.diffrn_id
+     _diffrn_measurement.id
+     _diffrn_measurement.number_of_axes
+     _diffrn_measurement.method
+      P6MB GONIOMETER 3 rotation
+
+     # category DIFFRN_MEASUREMENT_AXIS
+     loop_
+     _diffrn_measurement_axis.measurement_id
+     _diffrn_measurement_axis.axis_id
+      GONIOMETER GONIOMETER_PHI
+      GONIOMETER GONIOMETER_KAPPA
+      GONIOMETER GONIOMETER_OMEGA
+
+     # category DIFFRN_SCAN
+     loop_
+     _diffrn_scan.id
+     _diffrn_scan.frame_id_start
+     _diffrn_scan.frame_id_end
+     _diffrn_scan.frames
+      SCAN1 FRAME1 FRAME1 1
+
+     # category DIFFRN_SCAN_AXIS
+     loop_
+     _diffrn_scan_axis.scan_id
+     _diffrn_scan_axis.axis_id
+     _diffrn_scan_axis.angle_start
+     _diffrn_scan_axis.angle_range
+     _diffrn_scan_axis.angle_increment
+     _diffrn_scan_axis.displacement_start
+     _diffrn_scan_axis.displacement_range
+     _diffrn_scan_axis.displacement_increment
+      SCAN1 GONIOMETER_OMEGA 12.0 1.0 1.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_KAPPA 23.3 0.0 0.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_PHI -165.8 0.0 0.0 0.0 0.0 0.0
+      SCAN1 DETECTOR_Z 0.0 0.0 0.0 -240.0 0.0 0.0
+      SCAN1 DETECTOR_Y 0.0 0.0 0.0 0.6 0.0 0.0
+      SCAN1 DETECTOR_X 0.0 0.0 0.0 -0.5 0.0 0.0
+      SCAN1 DETECTOR_PITCH 0.0 0.0 0.0 0.0 0.0 0.0
+
+     # category DIFFRN_SCAN_FRAME
+     loop_
+     _diffrn_scan_frame.frame_id
+     _diffrn_scan_frame.frame_number
+     _diffrn_scan_frame.integration_time
+     _diffrn_scan_frame.scan_id
+     _diffrn_scan_frame.date
+      FRAME1 1 20.0 SCAN1 1997-12-04T10:23:48
+
+     # category DIFFRN_SCAN_FRAME_AXIS
+     loop_
+     _diffrn_scan_frame_axis.frame_id
+     _diffrn_scan_frame_axis.axis_id
+     _diffrn_scan_frame_axis.angle
+     _diffrn_scan_frame_axis.displacement
+      FRAME1 GONIOMETER_OMEGA 12.0 0.0
+      FRAME1 GONIOMETER_KAPPA 23.3 0.0
+      FRAME1 GONIOMETER_PHI -165.8 0.0
+      FRAME1 DETECTOR_Z 0.0 -240.0
+      FRAME1 DETECTOR_Y 0.0 0.6
+      FRAME1 DETECTOR_X 0.0 -0.5
+      FRAME1 DETECTOR_PITCH 0.0 0.0
+
+     # category AXIS
+     loop_
+     _axis.id
+     _axis.type
+     _axis.equipment
+     _axis.depends_on
+     _axis.vector[1] _axis.vector[2] _axis.vector[3]
+     _axis.offset[1] _axis.offset[2] _axis.offset[3]
+      GONIOMETER_OMEGA rotation goniometer . 1 0 0 . . .
+      GONIOMETER_KAPPA rotation goniometer GONIOMETER_OMEGA 0.64279
+      0 0.76604 . . .
+      GONIOMETER_PHI   rotation goniometer GONIOMETER_KAPPA 1 0 0
+     . . .
+      SOURCE           general source . 0 0 1 . . .
+      GRAVITY          general gravity . 0 -1 0 . . .
+      DETECTOR_Z       translation detector . 0 0 1 0 0 0
+      DETECTOR_Y       translation detector DETECTOR_Z 0 1 0 0 0 0
+      DETECTOR_X       translation detector DETECTOR_Y 1 0 0 0 0 0
+      DETECTOR_PITCH   rotation    detector DETECTOR_X 0 1 0 0 0 0
+      ELEMENT_ROT      translation detector DETECTOR_PITCH 0 0 1 0 0 0
+      ELEMENT_RAD      translation detector ELEMENT_ROT 0 1 0 0 0 0
+
+     # category ARRAY_STRUCTURE_LIST
+     loop_
+     _array_structure_list.array_id
+     _array_structure_list.index
+     _array_structure_list.dimension
+     _array_structure_list.precedence
+     _array_structure_list.direction
+     _array_structure_list.axis_set_id
+      ARRAY1 1 8309900 1 increasing ELEMENT_SPIRAL
+
+     # category ARRAY_STRUCTURE_LIST_AXIS
+     loop_
+     _array_structure_list_axis.axis_set_id
+     _array_structure_list_axis.axis_id
+     _array_structure_list_axis.angle
+     _array_structure_list_axis.displacement
+     _array_structure_list_axis.angular_pitch
+     _array_structure_list_axis.radial_pitch
+      ELEMENT_SPIRAL ELEMENT_ROT 0    .  0.075  .
+      ELEMENT_SPIRAL ELEMENT_RAD . 172.5  .    -0.150
+
+     # category ARRAY_ELEMENT_SIZE
+     # the actual pixels are 0.075 by 0.150 mm
+     # We give the coarser dimension here.
+     loop_
+     _array_element_size.array_id
+     _array_element_size.index
+     _array_element_size.size
+      ARRAY1 1 150e-6
+
+     # category ARRAY_INTENSITIES
+     loop_
+     _array_intensities.array_id
+     _array_intensities.binary_id
+     _array_intensities.linearity
+     _array_intensities.gain
+     _array_intensities.gain_esd
+     _array_intensities.overload
+     _array_intensities.undefined_value
+      ARRAY1 1 linear 1.15 0.2 240000 0
+
+      # category ARRAY_STRUCTURE
+     loop_
+      _array_structure.id
+      _array_structure.encoding_type
+      _array_structure.compression_type
+      _array_structure.byte_order
+      ARRAY1 "signed 32-bit integer" packed little_endian
+
+     # category ARRAY_DATA
+     loop_
+     _array_data.array_id
+     _array_data.binary_id
+     _array_data.data
+      ARRAY1 1
+     ;
+     --CIF-BINARY-FORMAT-SECTION--
+     Content-Type: application/octet-stream;
+         conversions="X-CBF_PACKED"
+     Content-Transfer-Encoding: BASE64
+     X-Binary-Size: 3801324
+     X-Binary-ID: 1
+     X-Binary-Element-Type: "signed 32-bit integer"
+     Content-MD5: 07lZFvF+aOcW85IN7usl8A==
+
+     AABRAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZBQSr1sKNBOeOe9HITdMdDUnbq7bg
+     ...
+     8REo6TtBrxJ1vKqAvx9YDMD6J18Qg83OMr/tgssjMIJMXATDsZobL90AEXc4KigE
+
+     --CIF-BINARY-FORMAT-SECTION----
+     ;
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+       save_
+
+
+save__diffrn_scan.id
+    _item_description.description
+;             The value of _diffrn_scan.id  uniquely identifies each
+              scan.  The identifier is used to tie together all the
+              information about the scan.
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+       '_diffrn_scan.id'                 diffrn_scan             yes
+       '_diffrn_scan_axis.scan_id'       diffrn_scan_axis        yes
+       '_diffrn_scan_collection.scan_id'
+                                           diffrn_scan_collection  implicit
+       '_diffrn_scan_frame.scan_id'      diffrn_scan_frame       yes
+    _item_type.code               code
+     loop_
+    _item_linked.child_name
+    _item_linked.parent_name
+       '_diffrn_scan_axis.scan_id'          '_diffrn_scan.id'
+       '_diffrn_scan_axis.scan_id'          '_diffrn_scan.id'
+       '_diffrn_scan_frame.scan_id'         '_diffrn_scan.id'
+     save_
+
+
+save__diffrn_scan.date_end
+    _item_description.description
+;             The date and time of the end of the scan.  Note that this
+              may be an estimate generated during the scan, before the
+              precise time of the end of the scan is known, in which
+              case _diffrn_scan.date_end_estimated  should be used instead.
+;
+    _item.name                 '_diffrn_scan.date_end'
+    _item.category_id          diffrn_scan
+    _item.mandatory_code       no
+    _item_type.code            yyyy-mm-dd
+     save_
+
+
+save__diffrn_scan.date_end_estimated
+    _item_description.description
+;             The estimated date and time of the end of the scan.  Note
+              that this may be generated at the start or during the scan,
+              before the precise time of the end of the scan is known.
+;
+    _item.name                 '_diffrn_scan.date_end_estimated'
+    _item.category_id          diffrn_scan
+    _item.mandatory_code       yes
+    _item_type.code            yyyy-mm-dd
+     save_
+
+
+save__diffrn_scan.date_start
+    _item_description.description
+;             The date and time of the start of the scan.
+;
+    _item.name                 '_diffrn_scan.date_start'
+    _item.category_id          diffrn_scan
+    _item.mandatory_code       yes
+    _item_type.code            yyyy-mm-dd
+     save_
+
+
+save__diffrn_scan.integration_time
+    _item_description.description
+;             Approximate average time in seconds to integrate each
+              step of the scan.  The precise time for integration
+              of each particular step must be provided in
+              _diffrn_scan_frame.integration_time, even
+              if all steps have the same integration time.
+;
+    _item.name                 '_diffrn_scan.integration_time'
+    _item.category_id          diffrn_scan
+    _item.mandatory_code       no
+    _item_type.code            float
+    _item_units.code           'seconds'
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0.0
+     save_
+
+
+save__diffrn_scan.frame_id_start
+    _item_description.description
+;             The value of this data item is the identifier of the
+              first frame in the scan.
+
+              This item is a pointer to _diffrn_data_frame.id  in the
+              DIFFRN_DATA_FRAME  category.
+;
+    _item.name                 '_diffrn_scan.frame_id_start'
+    _item.category_id          diffrn_scan
+    _item.mandatory_code       yes
+    _item_type.code            code
+     save_
+
+
+save__diffrn_scan.frame_id_end
+    _item_description.description
+;             The value of this data item is the identifier of the
+              last frame in the scan.
+
+              This item is a pointer to _diffrn_data_frame.id  in the
+              DIFFRN_DATA_FRAME  category.
+;
+    _item.name                 '_diffrn_scan.frame_id_end'
+    _item.category_id          diffrn_scan
+    _item.mandatory_code       yes
+    _item_type.code            code
+     save_
+
+
+save__diffrn_scan.frames
+    _item_description.description
+;             The value of this data item is the number of frames in
+              the scan.
+;
+    _item.name                 '_diffrn_scan.frames'
+    _item.category_id          diffrn_scan
+    _item.mandatory_code       no
+    _item_type.code            int
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   1
+                            1   1
+     save_
+
+save__diffrn_scan.time_period
+    _item_description.description
+;             Approximate average time in seconds between the start
+              of each step of the scan.  The precise start-to-start
+              time increment of each particular step may be provided in
+              _diffrn_scan_frame.time_period.
+;
+    _item.name                 '_diffrn_scan.time_period'
+    _item.category_id          diffrn_scan
+    _item.mandatory_code       no
+    _item_type.code            float
+    _item_units.code           'seconds'
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0.0
+     save_
+
+
+save__diffrn_scan.time_rstrt_incr
+    _item_description.description
+;             Approximate average time in seconds between the end
+              of integration of each step of the scan and the start
+              of integration of the next step.
+
+              In general, this will agree with
+              _diffrn_scan_frame.time_rstrt_incr .  The
+              sum of the values of _diffrn_scan_frame.integration_time
+              and  _diffrn_scan_frame.time_rstrt_incr  is the
+              time from the start of integration of one frame and the start of
+              integration for the next frame and should equal the value of
+              _diffrn_scan_frame.time_period  for this
+              frame.   If the individual frame values vary, then the value of
+              _diffrn_scan.time_rstrt_incr  will be
+              representative of the ensemble of values of
+              _diffrn_scan_frame.time_rstrt_incr  (e.g.
+              the mean).
+;
+    _item.name                 '_diffrn_scan.time_rstrt_incr'
+    _item.category_id          diffrn_scan
+    _item.mandatory_code       no
+    _item_type.code            float
+    _item_units.code           'seconds'
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0.0
+     save_
+
+
+save__diffrn_scan.variant
+    _item_description.description
+;             The value of _diffrn_scan.variant  gives the variant
+              to which the given DIFFRN_SCAN row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant  in the
+              VARIANT  category.
+;
+    _item.name                  '_diffrn_scan.variant'
+    _item.category_id             diffrn_scan
+    _item.mandatory_code          implicit
+    _item_default.value          .
+    _item_type.code               code
+     save_
+
+
+####################
+# DIFFRN_SCAN_AXIS #
+####################
+
+save_DIFFRN_SCAN_AXIS
+    _category.description
+;   Data items in the DIFFRN_SCAN_AXIS  category describe the settings of
+    axes for particular scans.  Unspecified axes are assumed to be at
+    their zero points.
+;
+    _category.id                   diffrn_scan_axis
+    _category.mandatory_code       no
+    _category.NX_mapping_details
+; in online version
+;
+
+     loop_
+    _category_key.name
+                                  '_diffrn_scan_axis.scan_id'
+                                  '_diffrn_scan_axis.axis_id'
+                                  '_diffrn_scan_axis.variant'
+     loop_
+    _category_group.id           'inclusive_group'
+                                 'diffrn_group'
+     save_
+
+
+save__diffrn_scan_axis.scan_id
+    _item_description.description
+;             The value of this data item is the identifier of the
+              scan for which axis settings are being specified.
+
+              Multiple axes may be specified for the same value of
+              _diffrn_scan.id.
+
+              This item is a pointer to _diffrn_scan.id  in the
+              DIFFRN_SCAN  category.
+;
+    _item.name                 '_diffrn_scan_axis.scan_id'
+    _item.category_id          diffrn_scan_axis
+    _item.mandatory_code       yes
+    _item_type.code            code
+     save_
+
+
+save__diffrn_scan_axis.axis_id
+    _item_description.description
+;             The value of this data item is the identifier of one of
+              the axes for the scan for which settings are being specified.
+
+              Multiple axes may be specified for the same value of
+              _diffrn_scan.id.
+
+              This item is a pointer to _axis.id  in the
+              AXIS category.
+;
+    _item.name                 '_diffrn_scan_axis.axis_id'
+    _item.category_id          diffrn_scan_axis
+    _item.mandatory_code       yes
+    _item_type.code            code
+     save_
+
+
+save__diffrn_scan_axis.angle_start
+    _item_description.description
+;             The starting position for the specified axis in degrees.
+;
+    _item.name                 '_diffrn_scan_axis.angle_start'
+    _item.category_id          diffrn_scan_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'degrees'
+     save_
+
+
+save__diffrn_scan_axis.angle_range
+    _item_description.description
+;             The range from the starting position for the specified axis
+              in degrees.
+;
+    _item.name                 '_diffrn_scan_axis.angle_range'
+    _item.category_id          diffrn_scan_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'degrees'
+     save_
+
+
+save__diffrn_scan_axis.angle_increment
+    _item_description.description
+;             The increment for each step for the specified axis
+              in degrees.  In general, this will agree with
+              _diffrn_scan_frame_axis.angle_increment . The
+              sum of the values of _diffrn_scan_frame_axis.angle  and
+              _diffrn_scan_frame_axis.angle_increment  is the
+              angular setting of the axis at the end of the integration
+              time for a given frame.  If the individual frame values
+              vary, then the value of
+              _diffrn_scan_axis.angle_increment  will be
+              representative
+              of the ensemble of values of
+              _diffrn_scan_frame_axis.angle_increment  (e.g.
+              the mean).
+;
+    _item.name                 '_diffrn_scan_axis.angle_increment'
+    _item.category_id          diffrn_scan_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'degrees'
+     save_
+
+
+save__diffrn_scan_axis.angle_rstrt_incr
+    _item_description.description
+;             The increment after each step for the specified axis
+              in degrees.  In general, this will agree with
+              _diffrn_scan_frame_axis.angle_rstrt_incr .  The
+              sum of the values of _diffrn_scan_frame_axis.angle,
+              _diffrn_scan_frame_axis.angle_increment
+              and  _diffrn_scan_frame_axis.angle_rstrt_incr  is the
+              angular setting of the axis at the start of the integration
+              time for the next frame relative to a given frame and
+              should equal _diffrn_scan_frame_axis.angle  for this
+              next frame.   If the individual frame values
+              vary, then the value of
+              _diffrn_scan_axis.angle_rstrt_incr  will be
+              representative
+              of the ensemble of values of
+              _diffrn_scan_frame_axis.angle_rstrt_incr  (e.g.
+              the mean).
+;
+    _item.name                 '_diffrn_scan_axis.angle_rstrt_incr'
+    _item.category_id          diffrn_scan_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'degrees'
+     save_
+
+
+save__diffrn_scan_axis.displacement_start
+    _item_description.description
+;             The starting position for the specified axis in millimetres.
+;
+    _item.name                 '_diffrn_scan_axis.displacement_start'
+    _item.category_id          diffrn_scan_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save__diffrn_scan_axis.displacement_range
+    _item_description.description
+;             The range from the starting position for the specified axis
+              in millimetres.
+;
+    _item.name                 '_diffrn_scan_axis.displacement_range'
+    _item.category_id          diffrn_scan_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save__diffrn_scan_axis.displacement_increment
+    _item_description.description
+;             The increment for each step for the specified axis
+              in millimetres.  In general, this will agree with
+              _diffrn_scan_frame_axis.displacement_increment.
+              The sum of the values of
+              _diffrn_scan_frame_axis.displacement  and
+              _diffrn_scan_frame_axis.displacement_increment  is the
+              angular setting of the axis at the end of the integration
+              time for a given frame.  If the individual frame values
+              vary, then the value of
+               _diffrn_scan_axis.displacement_increment  will be
+              representative of the ensemble of values of
+               _diffrn_scan_frame_axis.displacement_increment  (e.g.
+               the mean).
+;
+    _item.name                 '_diffrn_scan_axis.displacement_increment'
+    _item.category_id          diffrn_scan_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save__diffrn_scan_axis.displacement_rstrt_incr
+    _item_description.description
+;             The increment for each step for the specified axis
+              in millimetres.  In general, this will agree with
+              _diffrn_scan_frame_axis.displacement_rstrt_incr.
+              The sum of the values of
+              _diffrn_scan_frame_axis.displacement,
+              _diffrn_scan_frame_axis.displacement_increment  and
+              _diffrn_scan_frame_axis.displacement_rstrt_incr  is the
+              angular setting of the axis at the start of the integration
+              time for the next frame relative to a given frame and
+              should equal _diffrn_scan_frame_axis.displacement
+              for this next frame.  If the individual frame values
+              vary, then the value of
+              _diffrn_scan_axis.displacement_rstrt_incr  will be
+              representative of the ensemble of values of
+               _diffrn_scan_frame_axis.displacement_rstrt_incr  (e.g.
+               the mean).
+;
+    _item.name                 '_diffrn_scan_axis.displacement_rstrt_incr'
+    _item.category_id          diffrn_scan_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save__diffrn_scan_axis.reference_angle
+    _item_description.description
+;             The setting of the specified axis in degrees
+              against which measurements of the reference beam centre
+              and reference detector distance should be made.
+
+              In general, this will agree with
+              _diffrn_scan_frame_axis.reference_angle.
+
+              If the individual frame values vary, then the value of
+              _diffrn_scan_axis.reference_angle  will be
+              representative of the ensemble of values of
+              _diffrn_scan_frame_axis.reference_angle  (e.g.
+              the mean).
+
+              If not specified, the value defaults to zero.
+;
+    _item.name                 '_diffrn_scan_axis.reference_angle'
+    _item.category_id          diffrn_scan_axis
+    _item.mandatory_code       implicit
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'degrees'
+     save_
+
+
+save__diffrn_scan_axis.reference_displacement
+    _item_description.description
+;             The setting of the specified axis in millimetres
+              against which measurements of the reference beam centre
+              and reference detector distance should be made.
+
+              In general, this will agree with
+              _diffrn_scan_frame_axis.reference_displacement.
+
+              If the individual frame values vary, then the value of
+              _diffrn_scan_axis.reference_displacement  will be
+              representative of the ensemble of values of
+              _diffrn_scan_frame_axis.reference_displacement  (e.g.
+              the mean).
+
+;
+    _item.name                 '_diffrn_scan_axis.reference_displacement'
+    _item.category_id          diffrn_scan_axis
+    _item.mandatory_code       implicit
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save__diffrn_scan_axis.variant
+    _item_description.description
+;             The value of _diffrn_scan_axis.variant  gives the variant
+              to which the given DIFFRN_SCAN_AXIS row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant  in the
+              VARIANT  category.
+;
+    _item.name                  '_diffrn_scan_axis.variant'
+    _item.category_id             diffrn_scan_axis
+    _item.mandatory_code          implicit
+    _item_default.value          .
+    _item_type.code               code
+     save_
+
+
+##########################
+# DIFFRN_SCAN_COLLECTION #
+##########################
+
+save_DIFFRN_SCAN_COLLECTION
+    _category.description
+;   Data items in the DIFFRN_SCAN_COLLECTION  category describe
+    the collection strategy for each scan.
+
+    This category is a preliminary version being developed as
+    synchrotron and XFEL collection strategies evolve.
+;
+    _category.id                   diffrn_scan_collection
+    _category.mandatory_code       no
+    _category.NX_mapping_details
+; in online version
+;
+     loop_
+    _category_key.name
+                                  '_diffrn_scan_collection.scan_id'
+                                  '_diffrn_scan_collection.variant'
+     loop_
+    _category_group.id            'inclusive_group'
+                                  'diffrn_group'
+     loop_
+    _category_examples.case
+    _category_examples.detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;   Example 1 - Describing a multi-wedge raster scan.
+;
+;
+        loop_
+        _diffrn_scan_collection.scan_id
+        _diffrn_scan_collection.details
+
+        multi_wedge
+    ;   scan 20 micrometre beam in 100 micrometre steps on 31
+        by 46 alternating raster of 20 degree wedges
+    ;
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save__diffrn_scan_collection.details
+    _item_description.description
+;             The value of _diffrn_scan_collection.details  should give a
+              description of special aspects of each collection strategy.
+;
+    _item.name                  '_diffrn_scan_collection.details'
+    _item.category_id             diffrn_scan_collection
+    _item.mandatory_code          no
+    _item_type.code               text
+     save_
+
+
+save__diffrn_scan_collection.scan_id
+    _item_description.description
+;             The value of _diffrn_scan_collection.scan_id  identifies the scan
+              containing this frame.
+
+              This item is a pointer to _diffrn_scan.id  in the
+              DIFFRN_SCAN  category.
+
+              In the case of a single-scan dataset, the value is implicit.
+;
+    _item.name             '_diffrn_scan_collection.scan_id'
+    _item.category_id        diffrn_scan_collection
+    _item.mandatory_code     implicit
+    _item_type.code          code
+     save_
+
+
+save__diffrn_scan_collection.type
+    _item_description.description
+;             The value of _diffrn_scan_collection.type  identifies
+              the strategy used in this scan, e.g. `rotation', 'raster',
+              'vector', 'still', etc.
+
+              The default is 'rotation'.
+;
+    _item.name                  '_diffrn_scan_collection.type'
+    _item.category_id             diffrn_scan_collection
+    _item.mandatory_code          implicit
+    _item_default.value           'rotation'
+    _item_type.code               text
+     save_
+
+
+save__diffrn_scan_collection.translation_width
+    _item_description.description
+;             The value of _diffrn_scan_collection.translation_width
+              gives the average single step translation in micrometres
+              in collection strategies for which this information is
+               appropriate, e.g. 'vector'.
+;
+    _item.name                  '_diffrn_scan_collection.translation_width'
+    _item.category_id             diffrn_scan_collection
+    _item.mandatory_code          no
+    _item_default.value           0.0
+    _item_type.code               float
+    _item_units.code              micrometres
+
+     save_
+
+
+save__diffrn_scan_collection.variant
+    _item_description.description
+;             The value of _diffrn_scan_collection.variant  gives the variant
+              to which the given DIFFRN_SCAN_COLLECTION row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant  in the
+              VARIANT  category.
+;
+    _item.name                  '_diffrn_scan_collection.variant'
+    _item.category_id             diffrn_scan_collection
+    _item.mandatory_code          implicit
+    _item_default.value          .
+    _item_type.code               code
+     save_
+
+
+#####################
+# DIFFRN_SCAN_FRAME #
+#####################
+
+save_DIFFRN_SCAN_FRAME
+    _category.description
+;   Data items in the DIFFRN_SCAN_FRAME  category describe
+    the relationships of particular frames to scans.
+;
+    _category.id                   diffrn_scan_frame
+    _category.mandatory_code       no
+    _category.NX_mapping_details
+; in online version
+;
+
+     loop_
+    _category_key.name
+                                  '_diffrn_scan_frame.scan_id'
+                                  '_diffrn_scan_frame.frame_id'
+                                  '_diffrn_scan_frame.variant'
+     loop_
+    _category_group.id            'inclusive_group'
+                                  'diffrn_group'
+     save_
+
+
+save__diffrn_scan_frame.date
+    _item_description.description
+;             The date and time of the start of the frame being scanned.
+;
+    _item.name                 '_diffrn_scan_frame.date'
+    _item.category_id          diffrn_scan_frame
+    _item.mandatory_code       no
+    _item_type.code            yyyy-mm-dd
+     save_
+
+
+save__diffrn_scan_frame.frame_id
+    _item_description.description
+;             The value of this data item is the identifier of the
+              frame being examined.
+
+              This item is a pointer to _diffrn_data_frame.id  in the
+              DIFFRN_DATA_FRAME  category.
+;
+    _item.name                 '_diffrn_scan_frame.frame_id'
+    _item.category_id          diffrn_scan_frame
+    _item.mandatory_code       yes
+    _item_type.code            code
+     save_
+
+
+save__diffrn_scan_frame.frame_number
+    _item_description.description
+;             The value of this data item is the number of the frame
+              within the scan, starting with 1.  It is not necessarily
+              the same as the value of _diffrn_scan_frame.frame_id,
+              but it may be.
+
+;
+    _item.name                 '_diffrn_scan_frame.frame_number'
+    _item.category_id          diffrn_scan_frame
+    _item.mandatory_code       no
+    _item_type.code            int
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0
+                            0   0
+     save_
+
+
+save__diffrn_scan_frame.integration_time
+    _item_description.description
+;             The time in seconds to integrate this step of the scan.
+              This should be the precise time of integration of each
+              particular frame.  The value of this data item should
+              be given explicitly for each frame and not inferred
+              from the value of _diffrn_scan.integration_time.
+;
+    _item.name                 '_diffrn_scan_frame.integration_time'
+    _item.category_id          diffrn_scan_frame
+    _item.mandatory_code       yes
+    _item_type.code            float
+    _item_units.code           'seconds'
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0.0
+     save_
+
+
+save__diffrn_scan_frame.polarizn_Stokes_I
+    _item_description.description
+;             The quantity Ip+In+Inp, where Ip is the intensity (amplitude
+              squared) of the electric vector in the plane of polarization,
+              In is the intensity (amplitude squared) of the electric vector
+              in the plane of the normal to the plane of polarization,
+              and Inp is the intensity (amplitude squared) of the
+              non-polarized (incoherent) electric vector.
+
+              This is an average or other representative sample of the
+              frame.
+
+              This is the first of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
+
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
+
+              Note that, if the polarized intensity Ip+In is required,
+              (Ip+In)^2^ is the sum of Q^2^+U^2^+V^2^.
+
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200--3205.
+;
+    _item.name                  '_diffrn_scan_frame.polarizn_Stokes_I'
+    _item.category_id             diffrn_scan_frame
+    _item.mandatory_code          implicit
+    _item_default.value           1.0
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                                   .    0.0
+                                  0.0   0.0
+    _item_type.code               float
+     save_
+
+save__diffrn_scan_frame.polarizn_Stokes_I_esd
+    _item_description.description
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_scan_frame.polarizn_Stokes_I,
+              Ip+In+Inp, where Ip is the intensity (amplitude squared)
+              of the electric vector in the plane of polarization,
+              In is the intensity (amplitude squared) of the electric vector
+              in the plane of the normal to the plane of polarization,
+              and Inp is the intensity (amplitude squared) of the
+              non-polarized (incoherent) electric vector.
+;
+    _item.name                  '_diffrn_scan_frame.polarizn_Stokes_I_esd'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .      0.0
+                                  0.0    0.0
+    _item_type.code               float
+     loop_
+    _item_related.related_name
+    _item_related.function_code  '_diffrn_scan_frame.polarizn_Stokes_I'
+                                 'associated_value'
+     save_
+
+
+save__diffrn_scan_frame.polarizn_Stokes_Q
+    _item_description.description
+;             The quantity (Ip-In)*cos(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y axis as defined in the
+              AXIS  category.
+
+              This is an average or other representative sample of the
+              frame.
+
+              This is the second of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
+
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
+
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200--3205.
+;
+    _item.name                  '_diffrn_scan_frame.polarizn_Stokes_Q'
+    _item.category_id             diffrn_scan_frame
+    _item.mandatory_code          no
+     loop_
+    _item_type.code               float
+     save_
+
+
+save__diffrn_scan_frame.polarizn_Stokes_Q_esd
+    _item_description.description
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_scan_frame.polarizn_Stokes_Q,
+              (Ip-In)*cos(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y-axis as defined in the
+              AXIS  category.
+;
+    _item.name                  '_diffrn_scan_frame.polarizn_Stokes_Q_esd'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .      0.0
+                                  0.0    0.0
+    _item_type.code               float
+     loop_
+    _item_related.related_name
+    _item_related.function_code  '_diffrn_scan_frame.polarizn_Stokes_Q'
+                                 'associated_value'
+     save_
+
+
+save__diffrn_scan_frame.polarizn_Stokes_U
+    _item_description.description
+;             The quantity (Ip-In)*sin(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y axis as defined in the
+              AXIS  category.
+
+              This is an average or other representative sample of the
+              frame.
+
+              This is the third of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)]
+
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
+
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200--3205.
+;
+    _item.name                  '_diffrn_scan_frame.polarizn_Stokes_U'
+    _item.category_id             diffrn_scan_frame
+    _item.mandatory_code          no
+     loop_
+    _item_type.code               float
+     save_
+
+save__diffrn_scan_frame.polarizn_Stokes_U_esd
+    _item_description.description
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_scan_frame.polarizn_Stokes_U,
+              (Ip-In)*sin(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y-axis as defined in the
+              AXIS  category.
+;
+    _item.name                  '_diffrn_scan_frame.polarizn_Stokes_U_esd'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .      0.0
+                                  0.0    0.0
+    _item_type.code               float
+     loop_
+    _item_related.related_name
+    _item_related.function_code  '_diffrn_scan_frame.polarizn_Stokes_U'
+                                 'associated_value'
+     save_
+
+
+save__diffrn_scan_frame.polarizn_Stokes_V
+    _item_description.description
+;             The quantity +/-2*sqrt(IpIn), with a + sign for right-handed
+              circular polarization, where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization and In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y axis as defined in the
+              AXIS  category.
+
+              This is an average or other representative sample of the
+              frame.
+
+              This is the fourth of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
+
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
+
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200--3205.
+;
+    _item.name                  '_diffrn_scan_frame.polarizn_Stokes_V'
+    _item.category_id             diffrn_scan_frame
+    _item.mandatory_code          no
+     loop_
+    _item_type.code               float
+     save_
+
+
+save__diffrn_scan_frame.polarizn_Stokes_V_esd
+    _item_description.description
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_scan_frame.polarizn_Stokes_V,
+              +/-2*sqrt(IpIn), with a + sign for right-handed circular
+              polarization, where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization and In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y-axis as defined in the
+              AXIS  category.
+;
+    _item.name                  '_diffrn_scan_frame.polarizn_Stokes_V_esd'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .      0.0
+                                  0.0    0.0
+    _item_type.code               float
+     loop_
+    _item_related.related_name
+    _item_related.function_code  '_diffrn_scan_frame.polarizn_Stokes_V'
+                                 'associated_value'
+     save_
+
+
+save__diffrn_scan_frame.scan_id
+    _item_description.description
+;             The value of _diffrn_scan_frame.scan_id  identifies the scan
+              containing this frame.
+
+              This item is a pointer to _diffrn_scan.id  in the
+              DIFFRN_SCAN  category.
+;
+    _item.name             '_diffrn_scan_frame.scan_id'
+    _item.category_id        diffrn_scan_frame
+    _item.mandatory_code     yes
+    _item_type.code          code
+     save_
+
+
+save__diffrn_scan_frame.time_period
+    _item_description.description
+;             The time in seconds between the start of this frame and the
+              start of the next frame, if any.  If there is no next frame,
+              a null value should be given.
+;
+    _item.name                 '_diffrn_scan_frame.time_period'
+    _item.category_id          diffrn_scan_frame
+    _item.mandatory_code       no
+    _item_type.code            float
+    _item_units.code           'seconds'
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0.0
+     save_
+
+
+save__diffrn_scan_frame.time_rstrt_incr
+    _item_description.description
+;             The time in seconds between the end of integration of this step of the scan
+              and the start of integration of the next step.
+
+              The sum of the values of _diffrn_scan_frame.integration_time
+              and  _diffrn_scan_frame.time_rstrt_incr  is the
+              time from the start of integration of one frame and the start of
+              integration for the next frame and should equal the value of
+              _diffrn_scan_frame.time_period  for this
+              frame.   The value of _diffrn_scan.time_rstrt_incr  will be
+              representative of the ensemble of values of
+              _diffrn_scan_frame.time_rstrt_incr  (e.g.
+              the mean).
+
+              If there is no next frame, a null value should be given.
+;
+    _item.name                 '_diffrn_scan_frame.time_rstrt_incr'
+    _item.category_id          diffrn_scan_frame
+    _item.mandatory_code       no
+    _item_type.code            float
+    _item_units.code           'seconds'
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0.0
+     save_
+
+
+save__diffrn_scan_frame.variant
+    _item_description.description
+;             The value of _diffrn_scan_frame.variant  gives the variant
+              to which the given DIFFRN_SCAN_FRAME row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant  in the
+              VARIANT  category.
+;
+    _item.name                  '_diffrn_scan_frame.variant'
+    _item.category_id             diffrn_scan_frame
+    _item.mandatory_code          implicit
+    _item_default.value          .
+    _item_type.code               code
+     save_
+
+
+##########################
+# DIFFRN_SCAN_FRAME_AXIS #
+##########################
+
+save_DIFFRN_SCAN_FRAME_AXIS
+    _category.description
+;   Data items in the DIFFRN_SCAN_FRAME_AXIS  category describe the
+    settings of axes for particular frames.  Unspecified axes are
+    assumed to be at their zero points.  If, for any given frame,
+    nonzero values apply for any of the data items in this category,
+    those values should be given explicitly in this category and not
+    simply inferred from values in DIFFRN_SCAN_AXIS.
+;
+    _category.id                   diffrn_scan_frame_axis
+    _category.mandatory_code       no
+    _category.NX_mapping_details
+; in online version
+;
+
+     loop_
+    _category_key.name
+                                  '_diffrn_scan_frame_axis.frame_id'
+                                  '_diffrn_scan_frame_axis.axis_id'
+                                  '_diffrn_scan_frame_axis.variant'
+     loop_
+    _category_group.id           'inclusive_group'
+                                 'diffrn_group'
+     save_
+
+
+save__diffrn_scan_frame_axis.axis_id
+    _item_description.description
+;             The value of this data item is the identifier of one of
+              the axes for the frame for which settings are being specified.
+
+              Multiple axes may be specified for the same value of
+              _diffrn_scan_frame.frame_id.
+
+              This item is a pointer to _axis.id  in the
+              AXIS  category.
+;
+    _item.name                 '_diffrn_scan_frame_axis.axis_id'
+    _item.category_id          diffrn_scan_frame_axis
+    _item.mandatory_code       yes
+    _item_type.code            code
+     save_
+
+
+save__diffrn_scan_frame_axis.angle
+    _item_description.description
+;             The setting of the specified axis in degrees for this frame.
+              This is the setting at the start of the integration time.
+;
+    _item.name                 '_diffrn_scan_frame_axis.angle'
+    _item.category_id          diffrn_scan_frame_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'degrees'
+     save_
+
+
+save__diffrn_scan_frame_axis.angle_increment
+    _item_description.description
+;             The increment for this frame for the angular setting of
+              the specified axis in degrees.  The sum of the values
+              of _diffrn_scan_frame_axis.angle  and
+              _diffrn_scan_frame_axis.angle_increment  is the
+              angular setting of the axis at the end of the integration
+              time for this frame.
+;
+    _item.name                 '_diffrn_scan_frame_axis.angle_increment'
+    _item.category_id          diffrn_scan_frame_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'degrees'
+     save_
+
+
+save__diffrn_scan_frame_axis.angle_rstrt_incr
+    _item_description.description
+;             The increment after this frame for the angular setting of
+              the specified axis in degrees.  The sum of the values
+              of _diffrn_scan_frame_axis.angle,
+              _diffrn_scan_frame_axis.angle_increment  and
+              _diffrn_scan_frame_axis.angle_rstrt_incr  is the
+              angular setting of the axis at the start of the integration
+              time for the next frame and should equal
+              _diffrn_scan_frame_axis.angle  for this next frame.
+;
+    _item.name               '_diffrn_scan_frame_axis.angle_rstrt_incr'
+    _item.category_id          diffrn_scan_frame_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'degrees'
+     save_
+
+
+save__diffrn_scan_frame_axis.displacement
+    _item_description.description
+;             The setting of the specified axis in millimetres for this
+              frame.  This is the setting at the start of the integration
+              time.
+;
+    _item.name               '_diffrn_scan_frame_axis.displacement'
+    _item.category_id          diffrn_scan_frame_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save__diffrn_scan_frame_axis.displacement_increment
+    _item_description.description
+;             The increment for this frame for the displacement setting of
+              the specified axis in millimetres.  The sum of the values
+              of _diffrn_scan_frame_axis.displacement  and
+              _diffrn_scan_frame_axis.displacement_increment  is the
+              angular setting of the axis at the end of the integration
+              time for this frame.
+;
+    _item.name               '_diffrn_scan_frame_axis.displacement_increment'
+    _item.category_id          diffrn_scan_frame_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save__diffrn_scan_frame_axis.displacement_rstrt_incr
+    _item_description.description
+;             The increment for this frame for the displacement setting of
+              the specified axis in millimetres.  The sum of the values
+              of _diffrn_scan_frame_axis.displacement,
+              _diffrn_scan_frame_axis.displacement_increment  and
+              _diffrn_scan_frame_axis.displacement_rstrt_incr  is the
+              angular setting of the axis at the start of the integration
+              time for the next frame and should equal
+              _diffrn_scan_frame_axis.displacement  for this next frame.
+;
+    _item.name               '_diffrn_scan_frame_axis.displacement_rstrt_incr'
+    _item.category_id          diffrn_scan_frame_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save__diffrn_scan_frame_axis.frame_id
+    _item_description.description
+;             The value of this data item is the identifier of the
+              frame for which axis settings are being specified.
+
+              Multiple axes may be specified for the same value of
+              _diffrn_scan_frame.frame_id.
+
+              This item is a pointer to _diffrn_data_frame.id  in the
+              DIFFRN_DATA_FRAME  category.
+;
+    _item.name               '_diffrn_scan_frame_axis.frame_id'
+    _item.category_id          diffrn_scan_frame_axis
+    _item.mandatory_code       yes
+    _item_type.code            code
+     save_
+
+
+save__diffrn_scan_frame_axis.reference_angle
+    _item_description.description
+;             The setting of the specified axis in degrees
+              against which measurements of the reference beam centre
+              and reference detector distance should be made.
+
+              This is normally the same for all frames, but the
+              option is provided here of making changes when
+              needed.
+
+              If not provided, it is assumed to be zero.
+;
+    _item.name               '_diffrn_scan_frame_axis.reference_angle'
+    _item.category_id          diffrn_scan_frame_axis
+    _item.mandatory_code       implicit
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'degrees'
+     save_
+
+
+save__diffrn_scan_frame_axis.reference_displacement
+    _item_description.description
+;             The setting of the specified axis in millimetres for this
+              frame against which measurements of the reference beam centre
+              and reference detector distance should be made.
+
+              This is normally the same for all frames, but the
+              option is provided here of making changes when
+              needed.
+
+              If not provided, it is assumed to be equal to
+              _diffrn_scan_frame_axis.displacement.
+;
+    _item.name               '_diffrn_scan_frame_axis.reference_displacement'
+    _item.category_id          diffrn_scan_frame_axis
+    _item.mandatory_code       implicit
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save__diffrn_scan_frame_axis.variant
+    _item_description.description
+;             The value of _diffrn_scan_frame_axis.variant  gives the variant
+              to which the given DIFFRN_SCAN_FRAME_AXIS row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant  in the
+              VARIANT  category.
+;
+    _item.name                  '_diffrn_scan_frame_axis.variant'
+    _item.category_id             diffrn_scan_frame_axis
+    _item.mandatory_code          implicit
+    _item_default.value          .
+    _item_type.code               code
+     save_
+
+
+#############################
+# DIFFRN_SCAN_FRAME_MONITOR #
+#############################
+
+
+save_DIFFRN_SCAN_FRAME_MONITOR
+    _category.description
+;   Data items in the DIFFRN_SCAN_FRAME_MONITOR  category record
+    the values and details about each monitor for each frame of data
+    during a scan.
+
+    Each monitor value is uniquely identified by the combination of
+    the scan id given by _diffrn_scan_frame.scan_id,
+    the frame id given by _diffrn_scan_frame_monitor.frame_id,
+    the monitor's detector id given by
+    _diffrn_scan_frame_monitor.detector_id,
+    and a 1-based ordinal given by _diffrn_scan_frame_monitor.id.
+
+    If there is only one frame for the scan, the value of
+    _diffrn_scan_frame_monitor.frame_id  may be omitted.
+
+    A single frame may have more than one monitor value, and each
+    monitor value may be the result of integration over the entire
+    frame integration time given by the value of
+    _diffrn_scan_frame.integration_time,
+    or many monitor values may be reported over shorter times given
+    by the value of _diffrn_scan_frame_monitor.integration_time.  If
+    only one monitor value for a given monitor is collected during
+    the integration time of the frame, the value of
+    _diffrn_scan_frame_monitor.id  may be
+    omitted.
+;
+    _category.id                   diffrn_scan_frame_monitor
+    _category.mandatory_code       no
+    _category.NX_mapping_details
+; in online version
+;
+     loop_
+    _category_key.name             '_diffrn_scan_frame_monitor.id'
+                                   '_diffrn_scan_frame_monitor.detector_id'
+                                   '_diffrn_scan_frame_monitor.scan_id'
+                                   '_diffrn_scan_frame_monitor.frame_id'
+                                   '_diffrn_scan_frame_monitor.variant'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'diffrn_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;   Example 1. The beam intensity for frame FRAME1 is being tracked
+    by a beamstop monitor detector BSM01, made from metal foil and
+    a PIN diode, located 20 mm in front of a MAR345 detector and being
+    sampled every 2 seconds in a 20 second scan.
+;
+;
+
+     # category DIFFRN_DETECTOR
+     loop_
+     _diffrn_detector.diffrn_id
+     _diffrn_detector.id
+     _diffrn_detector.type
+     _diffrn_detector.number_of_axes
+      P6MB MAR345-SN26 'MAR 345' 4
+      P6MB BSM01 'metal foil and PIN diode' 1
+
+     # category DIFFRN_DETECTOR_AXIS
+     loop_
+     _diffrn_detector_axis.detector_id
+     _diffrn_detector_axis.axis_id
+      MAR345-SN26 DETECTOR_X
+      MAR345-SN26 DETECTOR_Y
+      MAR345-SN26 DETECTOR_Z
+      MAR345-SN26 DETECTOR_PITCH
+      BSM01 MONITOR_Z
+
+
+     # category DIFFRN_DATA_FRAME
+     loop_
+     _diffrn_data_frame.id
+     _diffrn_data_frame.detector_element_id
+     _diffrn_data_frame.array_id
+     _diffrn_data_frame.binary_id
+      FRAME1 ELEMENT1 ARRAY1 1
+
+
+     # category DIFFRN_SCAN
+     loop_
+     _diffrn_scan.id
+     _diffrn_scan.frame_id_start
+     _diffrn_scan.frame_id_end
+     _diffrn_scan.frames
+      SCAN1 FRAME1 FRAME1 1
+
+     # category DIFFRN_SCAN_AXIS
+     loop_
+     _diffrn_scan_axis.scan_id
+     _diffrn_scan_axis.axis_id
+     _diffrn_scan_axis.angle_start
+     _diffrn_scan_axis.angle_range
+     _diffrn_scan_axis.angle_increment
+     _diffrn_scan_axis.displacement_start
+     _diffrn_scan_axis.displacement_range
+     _diffrn_scan_axis.displacement_increment
+      SCAN1 GONIOMETER_OMEGA 12.0 1.0 1.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_KAPPA 23.3 0.0 0.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_PHI -165.8 0.0 0.0 0.0 0.0 0.0
+      SCAN1 DETECTOR_Z 0.0 0.0 0.0 -240.0 0.0 0.0
+      SCAN1 DETECTOR_Y 0.0 0.0 0.0 0.6 0.0 0.0
+      SCAN1 DETECTOR_X 0.0 0.0 0.0 -0.5 0.0 0.0
+      SCAN1 DETECTOR_PITCH 0.0 0.0 0.0 0.0 0.0 0.0
+      SCAN1 MONITOR_Z 0.0 0.0 0.0 -220.0 0.0 0.0
+
+     # category DIFFRN_SCAN_FRAME
+     loop_
+     _diffrn_scan_frame.frame_id
+     _diffrn_scan_frame.frame_number
+     _diffrn_scan_frame.integration_time
+     _diffrn_scan_frame.scan_id
+     _diffrn_scan_frame.date
+      FRAME1 1 20.0 SCAN1 1997-12-04T10:23:48
+
+     # category DIFFRN_SCAN_FRAME_MONITOR
+     loop_
+     _diffrn_scan_frame_monitor.id
+     _diffrn_scan_frame_monitor.detector_id
+     _diffrn_scan_frame_monitor.scan_id
+     _diffrn_scan_frame_monitor.frame_id
+     _diffrn_scan_frame_monitor.integration_time
+     _diffrn_scan_frame_monitor.monitor_value
+      1  BSM01 SCAN1 FRAME1 2.0 23838345642
+      2  BSM01 SCAN1 FRAME1 2.0 23843170669
+      3  BSM01 SCAN1 FRAME1 2.0 23839478690
+      4  BSM01 SCAN1 FRAME1 2.0 23856642085
+      5  BSM01 SCAN1 FRAME1 2.0 23781717656
+      6  BSM01 SCAN1 FRAME1 2.0 23788850775
+      7  BSM01 SCAN1 FRAME1 2.0 23815576677
+      8  BSM01 SCAN1 FRAME1 2.0 23789299964
+      9  BSM01 SCAN1 FRAME1 2.0 23830195536
+      10 BSM01 SCAN1 FRAME1 2.0 23673082270
+
+     # category DIFFRN_SCAN_FRAME_AXIS
+     loop_
+     _diffrn_scan_frame_axis.frame_id
+     _diffrn_scan_frame_axis.axis_id
+     _diffrn_scan_frame_axis.angle
+     _diffrn_scan_frame_axis.displacement
+      FRAME1 GONIOMETER_OMEGA 12.0 0.0
+      FRAME1 GONIOMETER_KAPPA 23.3 0.0
+      FRAME1 GONIOMETER_PHI -165.8 0.0
+      FRAME1 DETECTOR_Z 0.0 -240.0
+      FRAME1 DETECTOR_Y 0.0 0.6
+      FRAME1 DETECTOR_X 0.0 -0.5
+      FRAME1 DETECTOR_PITCH 0.0 0.0
+      FRAME1 MONITOR_Z 0.0 -220.0
+
+     # category AXIS
+     loop_
+     _axis.id
+     _axis.type
+     _axis.equipment
+     _axis.depends_on
+     _axis.vector[1] _axis.vector[2] _axis.vector[3]
+     _axis.offset[1] _axis.offset[2] _axis.offset[3]
+      GONIOMETER_OMEGA rotation goniometer . 1 0 0 . . .
+      GONIOMETER_KAPPA rotation goniometer GONIOMETER_OMEGA 0.64279
+      0 0.76604 . . .
+      GONIOMETER_PHI   rotation goniometer GONIOMETER_KAPPA 1 0 0
+     . . .
+      SOURCE           general source . 0 0 1 . . .
+      GRAVITY          general gravity . 0 -1 0 . . .
+      DETECTOR_Z       translation detector . 0 0 1 0 0 0
+      DETECTOR_Y       translation detector DETECTOR_Z 0 1 0 0 0 0
+      DETECTOR_X       translation detector DETECTOR_Y 1 0 0 0 0 0
+      DETECTOR_PITCH   rotation    detector DETECTOR_X 0 1 0 0 0 0
+      ELEMENT_X        translation detector DETECTOR_PITCH
+     1 0 0 172.43 -172.43 0
+      ELEMENT_Y        translation detector ELEMENT_X
+     0 1 0 0 0 0
+      MONITOR_Z        translation detector . 0 0 1 0 0 0
+
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save__diffrn_scan_frame_monitor.id
+    _item_description.description
+;             This item is an integer identifier which, along with
+              _diffrn_scan_frame_monitor.detector_id,
+              _diffrn_scan_frame_monitor.scan_id, and
+              _diffrn_scan_frame_monitor.frame_id
+              should uniquely identify the monitor value being recorded.
+
+              If _array_data.binary_id  is not explicitly given,
+              it defaults to 1.
+;
+    _item.name             '_diffrn_scan_frame_monitor.id'
+    _item.category_id      diffrn_scan_frame_monitor
+    _item.mandatory_code   implicit
+    _item_default.value           1
+    _item_type.code               int
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            1  1
+                            .  1
+     save_
+
+
+save__diffrn_scan_frame_monitor.detector_id
+    _item_description.description
+;             This data item is a pointer to _diffrn_detector.id  in
+              the DIFFRN_DETECTOR  category.
+
+;
+    _item.name                  '_diffrn_scan_frame_monitor.detector_id'
+    _item.category_id             diffrn_scan_frame_monitor
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+
+save__diffrn_scan_frame_monitor.frame_id
+    _item_description.description
+;             This item is a pointer to _diffrn_data_frame.id
+              in the DIFFRN_DATA_FRAME  category.
+;
+    _item.name                  '_diffrn_scan_frame_monitor.frame_id'
+    _item.category_id             diffrn_scan_frame_monitor
+    _item.mandatory_code          implicit
+    _item_type.code               code
+     save_
+
+
+save__diffrn_scan_frame_monitor.integration_time
+    _item_description.description
+;             The precise time for integration of the monitor value given in
+              _diffrn_scan_frame_monitor.monitor_value
+              must be given in _diffrn_scan_frame_monitor.integration_time.
+;
+    _item.name                 '_diffrn_scan_frame_monitor.integration_time'
+    _item.category_id          diffrn_scan_frame_monitor
+    _item.mandatory_code       no
+    _item_type.code            float
+    _item_units.code           'seconds'
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0.0
+     save_
+
+
+save__diffrn_scan_frame_monitor.monitor_value
+    _item_description.description
+;             The value reported by the monitor detector should be given in
+              _diffrn_scan_frame_monitor.monitor_value.
+
+              The value is typed as float to allow of monitors for very
+              intense beams that cannot report all digits, but when
+              available, all digits of the  monitor should be recorded.
+
+              For convenience in automated validation, the deprecated
+              _diffrn_scan_frame_monitor.monitor_value
+              is given as an alias, but should be avoided for new data sets.
+;
+    _item.name                 '_diffrn_scan_frame_monitor.monitor_value'
+    _item.category_id          diffrn_scan_frame_monitor
+    _item.mandatory_code       no
+    _item_aliases.alias_name   '_diffrn_scan_frame_monitor.value'
+    _item_aliases.dictionary   cif_img.dic
+    _item_aliases.version      1.8.2
+    _item_type.code            float
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0.0
+     save_
+
+
+save__diffrn_scan_frame_monitor.scan_id
+    _item_description.description
+;             This item is a pointer to _diffrn_scan.id  in
+              the DIFFRN_SCAN  category.
+;
+    _item.name                  '_diffrn_scan_frame_monitor.scan_id'
+    _item.category_id             diffrn_scan_frame_monitor
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+
+save__diffrn_scan_frame_monitor.variant
+    _item_description.description
+;             The value of _diffrn_scan_frame_monitor.variant  gives the variant
+              to which the given DIFFRN_SCAN_FRAME_MONITOR row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant  in the
+              VARIANT  category.
+;
+    _item.name                  '_diffrn_scan_frame_monitor.variant'
+    _item.category_id             diffrn_scan_frame_monitor
+    _item.mandatory_code          implicit
+    _item_default.value          .
+    _item_type.code               code
+     save_
+
+
+#######
+# MAP #
+#######
+
+save_MAP
+    _category.description
+;   Data items in the MAP  category record
+    the details of maps. Maps record values of parameters,
+    such as density, that are functions of position within
+    a cell or are functions of orthogonal coordinates in
+    three space.
+
+    A map is composed of one or more map segments
+    specified in the MAP_SEGMENT category.
+
+    Examples are given in the MAP_SEGMENT category.
+;
+    _category.id                   map
+    _category.mandatory_code       no
+     loop_
+    _category_key.name             '_map.id'
+                                   '_map.diffrn_id'
+                                   '_map.entry_id'
+                                   '_map.variant'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'array_data_group'
+                                   'map_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;   Example 1. Identifying an observed density map
+                and a calculated density map
+;
+;
+
+        loop_
+        _map.id
+        _map.details
+
+        rho_calc
+   ;
+        density calculated from F_calc derived from the ATOM_SITE
+        list
+   ;
+        rho_obs
+   ;
+        density combining the observed structure factors with the
+        calculated phases
+   ;
+;
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save__map.details
+    _item_description.description
+;              The value of _map.details  should give a
+               description of special aspects of each map.
+
+;
+    _item.name                  '_map.details'
+    _item.category_id             map
+    _item.mandatory_code          no
+    _item_type.code               text
+     loop_
+    _item_examples.case
+    _item_examples.detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;   Example 1. Identifying an observed density map
+                and a calculated density map
+;
+;
+        loop_
+        _map.id
+        _map.details
+
+        rho_calc
+    ;
+        density calculated from F_calc derived from the ATOM_SITE list
+    ;
+        rho_obs
+    ;
+        density combining the observed structure factors with the
+        calculated phases
+    ;
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save__map.diffrn_id
+    _item_description.description
+;             This item is a pointer to _diffrn.id  in the
+              DIFFRN  category.
+;
+    _item.name                  '_map.diffrn_id'
+    _item.category_id             map
+    _item.mandatory_code          implicit
+    _item_type.code               code
+     save_
+
+
+save__map.entry_id
+    _item_description.description
+;             This item is a pointer to _entry.id  in the
+              ENTRY  category.
+;
+    _item.name                  '_map.entry_id'
+    _item.category_id             map
+    _item.mandatory_code          implicit
+    _item_type.code               code
+     save_
+
+
+save__map.id
+    _item_description.description
+;             The value of _map.id  must uniquely identify
+              each map for the given diffrn.id or entry.id.
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+           '_map.id'                map          yes
+           '_map_segment.id'        map_segment  yes
+    _item_type.code               code
+     loop_
+    _item_linked.child_name
+    _item_linked.parent_name
+           '_map_segment.id'        '_map.id'
+     save_
+
+
+save__map.variant
+    _item_description.description
+;             The value of _map.variant  gives the variant
+              to which the given map row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant  in the
+              VARIANT  category.
+;
+    _item.name                  '_map.variant'
+    _item.category_id             map
+    _item.mandatory_code          implicit
+    _item_default.value          .
+    _item_type.code               code
+     save_
+
+
+###############
+# MAP_SEGMENT #
+###############
+
+
+save_MAP_SEGMENT
+    _category.description
+;   Data items in the MAP_SEGMENT  category record
+    the details about each segment (section or brick) of a map.
+;
+    _category.id                   map_segment
+    _category.mandatory_code       no
+     loop_
+    _category_key.name             '_map_segment.id'
+                                   '_map_segment.map_id'
+                                   '_map_segment.variant'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'array_data_group'
+                                   'map_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;   Example 1. Identifying an observed density map
+                and a calculated density map, each consisting of one
+                segment, both using the same array structure
+                and mask.
+;
+;
+
+        loop_
+        _map.id
+        _map.details
+
+        rho_calc
+     ;
+        density calculated from F_calc derived from the ATOM_SITE list
+     ;
+        rho_obs
+     ;
+        density combining the observed structure factors with the
+        calculated phases
+     ;
+
+        loop_
+        _map_segment.map_id
+        _map_segment.id
+        _map_segment.array_id
+        _map_segment.binary_id
+        _map_segment.mask_array_id
+        _map_segment.mask_binary_id
+        rho_calc rho_calc map_structure 1 mask_structure 1
+        rho_obs  rho_obs  map_structure 2 mask_structure 1
+;
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save__map_segment.array_id
+    _item_description.description
+;             The value of _map_segment.array_id identifies the array
+              structure into which the map is organized.
+
+              This item is a pointer to _array_structure.id  in the
+              ARRAY_STRUCTURE  category.
+;
+    _item.name                  '_map_segment.array_id'
+    _item.category_id             map_segment
+    _item.mandatory_code          implicit
+    _item_type.code               code
+     save_
+
+
+save__map_segment.array_section_id
+    _item_description.description
+;             This item is a pointer to _array_structure_list_section.id
+              in the ARRAY_STRUCTURE_LIST_SECTION  category.
+;
+    _item.name                  '_map_segment.array_section_id'
+    _item.category_id             map_segment
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+
+save__map_segment.binary_id
+    _item_description.description
+;             The value of _map_segment.binary_id  distinguishes the particular
+              set of data organized according to _map_segment.array_id  in
+              which the data values of the map are stored.
+
+              This item is a pointer to _array_data.binary_id  in the
+              ARRAY_DATA  category.
+;
+    _item.name                  '_map_segment.binary_id'
+    _item.category_id             map_segment
+    _item.mandatory_code          implicit
+    _item_type.code               int
+     save_
+
+
+save__map_segment.mask_array_id
+    _item_description.description
+;             The value of _map_segment.mask_array_id, if given, describes
+              the array structure into which the mask for the map is
+              organized.  If no value is given, then all elements of
+              the map are valid.  If a value is given, then only
+              elements of the map for which the corresponding element
+              of the mask is non-zero are valid.  The value of
+              _map_segment.mask_array_id  differs from the value of
+              _map_segment.array_id  in order to permit the mask to be
+              given as, say, unsigned 8-bit integers, while the map is
+              given as a data type with more range.  However, the two
+              array structures must be aligned, using the same axes in
+              the same order with the same displacements and
+              increments.
+
+              This item is a pointer to _array_structure.id  in the
+              ARRAY_STRUCTURE  category.
+;
+    _item.name                  '_map_segment.mask_array_id'
+    _item.category_id             map_segment
+    _item.mandatory_code          implicit
+    _item_type.code               code
+     save_
+
+
+save__map_segment.mask_binary_id
+    _item_description.description
+;             The value of _map_segment.mask_binary_id  identifies the
+              particular set of data organized according to
+              _map_segment.mask_array_id specifying the mask for the map.
+
+              This item is a pointer to _array_data.binary_id  in the
+              ARRAY_DATA  category.
+;
+    _item.name                  '_map_segment.mask_binary_id'
+    _item.category_id             map_segment
+    _item.mandatory_code          implicit
+    _item_type.code               int
+     save_
+
+
+save__map_segment.mask_array_section_id
+    _item_description.description
+;             This item is a pointer to _array_structure_list_section.id
+              in the ARRAY_STRUCTURE_LIST_SECTION  category.
+;
+    _item.name                  '_map_segment.mask_array_section_id'
+    _item.category_id             map_segment
+    _item.mandatory_code          yes
+    _item_type.code               code
+    save_
+
+
+save__map_segment.id
+    _item_description.description
+;             The value of _map_segment.id  must uniquely
+              identify each segment of a map.
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+           '_map_segment.id'
+           map_segment
+           yes
+    _item_type.code               code
+     save_
+
+
+save__map_segment.map_id
+    _item_description.description
+;             This item is a pointer to _map.id
+              in the MAP  category.
+;
+    _item.name                  '_map_segment.map_id'
+    _item.category_id             map_segment
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+
+save__map_segment.details
+    _item_description.description
+;             The value of _map_segment.details  should give a
+              description of special aspects of each segment of a map.
+;
+    _item.name                  '_map_segment.details'
+    _item.category_id             map_segment
+    _item.mandatory_code          no
+    _item_type.code               text
+     loop_
+    _item_examples.case
+    _item_examples.detail
+;               Example to be provided
+;
+;
+                . . .
+;
+     save_
+
+
+save__map_segment.variant
+    _item_description.description
+;             The value of _map_segment.variant  gives the variant
+              to which the given map segment is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant  in the
+              VARIANT  category.
+;
+    _item.name                  '_map_segment.variant'
+    _item.category_id             map_segment
+    _item.mandatory_code          implicit
+    _item_default.value          .
+    _item_type.code               code
+     save_
+
+
+###########
+# VARIANT #
+###########
+
+save_VARIANT
+    _category.description
+;   Data items in the VARIANT  category record
+    the details about sets of variants of data items.
+
+    There is sometimes a need to allow for multiple versions of the
+    same data items in order to allow for refinements and corrections
+    to earlier assumptions, observations and calculations.  In order
+    to allow data sets to contain more than one variant of the same
+    information, an optional *.variant data item as a pointer to
+    _variant.variant has been added to the key of every category,
+    as an implicit data item with a null (empty) default value.
+
+    All rows in a category with the same variant value are considered
+    to be related to one another and to all rows in other categories
+    with the same variant value.  For a given variant, all such rows
+    are also considered to be related to all rows with a null variant
+    value, except that a row with a null variant value for which all
+    other components of its key are identical to those entries in
+    another row with a non-null variant value is not related the
+    the rows with that non-null variant value.  This behaviour is
+    similar to the convention for identifying alternate conformers
+    in an atom list.
+
+    An optional role may be specified for a variant as the value of
+    _variant.role.  Possible roles are null, 'preferred',
+    'raw data', 'unsuccessful trial'.
+
+    variants may carry an optional timestamp as the value of
+    _variant.timestamp.
+
+    variants may be related to other variants from which they were
+    derived by the value of _variant.variant_of.
+
+    Further details about the variant may be specified as the value
+    of _variant.details.
+
+    In order to allow variant information from multiple datasets to
+    be combined, _variant.diffrn_id and/or _variant.entry_id may
+    be used.
+;
+    _category.id                   variant
+    _category.mandatory_code       no
+     loop_
+    _category_key.name             '_variant.variant'
+                                   '_variant.diffrn_id'
+                                   '_variant.entry_id'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'variant_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;   Example 1. Distinguishing between a raw beam centre and a refined beam
+       centre inferred after indexing.  Detector d1 is composed of
+       four CCD detector elements, each 200 mm by 200 mm, arranged
+       in a square, in the pattern
+
+                   1     2
+                      *
+                   3     4
+
+       Note that the beam centre is slightly displaced from each of the
+       detector elements, just beyond the lower right corner of 1,
+       the lower left corner of 2, the upper right corner of 3 and
+       the upper left corner of 4.  For each element, the detector
+       face coordinate system is assumed to have the fast axis
+       running from left to right and the slow axis running from
+       top to bottom with the origin at the top left corner.
+
+       After indexing and refinement, the centre is shifted by 0.2 mm
+       left and 0.1 mm down.
+;
+;
+
+        loop_
+        _variant.variant
+        _variant.role
+        _variant.timestamp
+        _variant.variant_of
+        _variant.details
+            . "raw data" 2007-08-03T23:20:00 ..
+            indexed "preferred" 2007-08-04T01:17:28.
+              "indexed cell and refined beam centre"
+
+        loop_
+        _diffrn_detector_element.detector_id
+        _diffrn_detector_element.id
+        _diffrn_detector_element.reference_center_fast
+        _diffrn_detector_element.reference_center_slow
+        _diffrn_detector_element.reference_center_units
+        _diffrn_detector_element.variant
+        d1     d1_ccd_1  201.5 201.5  mm .
+        d1     d1_ccd_2  -1.8  201.5  mm .
+        d1     d1_ccd_3  201.6  -1.4  mm .
+        d1     d1_ccd_4  -1.7   -1.5  mm .
+        d1     d1_ccd_1  201.3 201.6  mm  indexed
+        d1     d1_ccd_2  -2.0  201.6  mm  indexed
+        d1     d1_ccd_3  201.3  -1.5  mm  indexed
+        d1     d1_ccd_4  -1.9   -1.6  mm  indexed
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+     save_
+
+save__variant.details
+    _item_description.description
+;             A description of special aspects of the variant.
+;
+    _item.name                  '_variant.details'
+    _item.category_id             variant
+    _item.mandatory_code          no
+    _item_type.code               text
+    _item_examples.case
+;                                indexed cell and refined beam centre
+;
+     save_
+
+save__variant.diffrn_id
+    _item_description.description
+;             This item is a pointer to _diffrn.id  in the
+              diffrn  category.
+;
+    _item.name                  '_variant.diffrn_id'
+    _item.category_id             variant
+    _item.mandatory_code          implicit
+    _item_type.code               code
+     save_
+
+save__variant.entry_id
+    _item_description.description
+;             This item is a pointer to _entry.id  in the
+              entry  category
+;
+    _item.name                  '_variant.entry_id'
+    _item.category_id             variant
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+
+save__variant.role
+    _item_description.description
+;             The value of _variant.role   specified a role
+              for this variant.  Possible roles are null, 'preferred',
+              'raw data', and 'unsuccessful trial'.
+
+              A null value for _variant.role  leaves the
+              precise role of the variant unspecified.  No inference should
+              be made that the variant with the latest time stamp is
+              preferred.
+;
+    _item.name                  '_variant.role'
+    _item.category_id            variant
+    _item.mandatory_code         no
+    _item_type.code              uline
+     loop_
+    _item_enumeration.value
+    _item_enumeration.detail
+     "preferred"
+;    A value of 'preferred' indicates that rows of any categories specifying
+     this variant should be used in preference to rows with the same key
+     specifying other variants or the null variant.  It is an error to specify
+     two variants that appear in the same category with the same key as being
+     preferred, but it is not an error to specify more than one variant as
+     preferred in other cases.
+;
+     "raw data"
+;    A value of 'raw data' indicates data prior to any corrections,
+     calculations or refinements.  It is not necessarily an error for raw data
+     also to be a variant of an earlier variant.  It may be replacement raw
+     data for earlier data believed to be erroneous.
+;
+     "unsuccessful trial"
+;    A value of 'unsuccessful trial' indicates data that should not be used
+     for further calculation.
+;
+     save_
+
+
+save__variant.timestamp
+    _item_description.description
+;             The date and time identifying a variant.  This is not
+              necessarily the precise time of the measurement or calculation
+              of the individual related data items, but a timestamp that
+              reflects the order in which the variants were defined.
+;
+    _item.name                 '_variant.timestamp'
+    _item.category_id          variant
+    _item.mandatory_code       no
+    _item_type.code            yyyy-mm-dd
+     save_
+
+
+save__variant.variant
+    _item_description.description
+;             The value of _variant.variant  must uniquely identify
+              each variant for the given diffraction experiment and/or entry
+
+              This item has been made implicit and given a default value of
+              null.
+;
+
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+             '_variant.variant'                    variant             implicit
+             '_variant.variant_of'                 variant             implicit
+             '_array_data.variant'                 array_data          implicit
+             '_array_data_external_data.variant'   array_data_external_data
+                                                                       implicit
+             '_array_element_size.variant'         array_element_size  implicit
+             '_array_intensities.variant'          array_intensities   implicit
+             '_array_structure.variant'            array_structure     implicit
+             '_array_structure_list.variant'       array_structure_list
+                                                                       implicit
+             '_array_structure_list_axis.variant'  array_structure_list_axis
+                                                                       implicit
+             '_array_structure_list_section.variant'
+                                 array_structure_list_axis_section
+                                                                       implicit
+             '_axis.variant'                       axis                implicit
+             '_diffrn_data_frame.variant'          diffrn_data_frame   implicit
+             '_diffrn_detector.variant'            diffrn_detector     implicit
+             '_diffrn_detector_axis.variant'       diffrn_detector_axis
+                                                                       implicit
+             '_diffrn_detector_element.variant'    diffrn_detector_element
+                                                                       implicit
+             '_diffrn_measurement.variant'         diffrn_measurement  implicit
+             '_diffrn_measurement_axis.variant'    diffrn_measurement_axis
+                                                                       implicit
+             '_diffrn_radiation.variant'           diffrn_radiation    implicit
+             '_diffrn_refln.variant'               diffrn_refln        implicit
+             '_diffrn_scan.variant'                diffrn_scan         implicit
+             '_diffrn_scan_axis.variant'           diffrn_scan_axis    implicit
+             '_diffrn_scan_collection.variant'     diffrn_scan_collection
+                                                                       implicit
+             '_diffrn_scan_frame.variant'          diffrn_scan_frame   implicit
+             '_diffrn_scan_frame_axis.variant'     diffrn_scan_frame_axis
+                                                                       implicit
+             '_diffrn_scan_frame_monitor.variant'  diffrn_scan_frame_monitor
+                                                                       implicit
+             '_map.variant'                        map                 implicit
+             '_map_segment.variant'                map_segment         implicit
+
+
+    _item_default.value          .
+    _item_type.code               code
+     loop_
+    _item_linked.child_name
+    _item_linked.parent_name
+             '_array_data.variant'                 '_variant.variant'
+             '_array_element_size.variant'         '_variant.variant'
+             '_array_intensities.variant'          '_variant.variant'
+             '_array_structure.variant'            '_variant.variant'
+             '_array_structure_list.variant'       '_variant.variant'
+             '_array_structure_list_axis.variant'  '_variant.variant'
+             '_axis.variant'                       '_variant.variant'
+             '_diffrn_data_frame.variant'          '_variant.variant'
+             '_diffrn_detector.variant'            '_variant.variant'
+             '_diffrn_detector_axis.variant'       '_variant.variant'
+             '_diffrn_detector_element.variant'    '_variant.variant'
+             '_diffrn_measurement.variant'         '_variant.variant'
+             '_diffrn_measurement_axis.variant'    '_variant.variant'
+             '_diffrn_radiation.variant'           '_variant.variant'
+             '_diffrn_refln.variant'               '_variant.variant'
+             '_diffrn_scan.variant'                '_variant.variant'
+             '_diffrn_scan_axis.variant'           '_variant.variant'
+             '_diffrn_scan_collection.variant'     '_variant.variant'
+             '_diffrn_scan_frame.variant'          '_variant.variant'
+             '_diffrn_scan_frame_axis.variant'     '_variant.variant'
+             '_diffrn_scan_frame_monitor.variant'  '_variant.variant'
+             '_map.variant'                        '_variant.variant'
+             '_map_segment.variant'                '_variant.variant'
+
+     save_
+
+
+save__variant.variant_of
+    _item_description.description
+;            The value of _variant.variant_of  gives the variant
+             from which this variant was derived.  If this value is not given,
+             the variant is assumed to be derived from the default null
+             variant.
+
+             This item is a pointer to _variant.variant  in the
+             VARIANT  category.
+;
+    _item.name                  '_variant.variant_of'
+    _item.category_id             variant
+    _item.mandatory_code          implicit
+    _item_type.code               code
+     save_
+
+
+
+
+########################   DEPRECATED DATA ITEMS ########################
+
+save__diffrn_detector_axis.id
+    _item_description.description
+;             This data item is a pointer to _diffrn_detector.id  in
+              the DIFFRN_DETECTOR  category.
+
+              DEPRECATED -- DO NOT USE
+;
+    _item.name                  '_diffrn_detector_axis.id'
+    _item.category_id             diffrn_detector_axis
+    _item.mandatory_code          no
+    _item_type.code               code
+     save_
+
+
+save__diffrn_detector_element.center[1]
+    _item_description.description
+;             The value of _diffrn_detector_element.center[1] is the X
+              component of the distortion-corrected beam centre in
+              millimetres from the (0, 0) (lower-left) corner of the
+              detector element viewed from the sample side.
+
+              The X and Y axes are the laboratory coordinate system
+              coordinates defined in the AXIS category  measured
+              when all positioning axes for the detector are at their zero
+              settings.  If the resulting X or Y axis is then orthogonal to the
+              detector, the Z axis is used instead of the orthogonal axis.
+
+              Because of ambiguity about the setting used to determine this
+              centre, use of this data item is deprecated.  The data item
+              _diffrn_data_frame.center_fast
+              which is referenced to the detector coordinate system and not
+              directly to the laboratory coordinate system should be used
+              instead.
+
+;
+    _item.name                  '_diffrn_detector_element.center[1]'
+    _item.category_id             diffrn_detector_element
+    _item.mandatory_code          no
+    _item_default.value           0.0
+    _item_sub_category.id         vector
+    _item_type.code               float
+    _item_related.related_name  '_diffrn_data_frame.center_fast'
+    _item_related.function_code   replacedby
+    _item_units.code              millimetres
+
+     save_
+
+
+save__diffrn_detector_element.center[2]
+    _item_description.description
+;             The value of _diffrn_detector_element.center[2] is the Y
+              component of the distortion-corrected beam centre in
+              millimetres from the (0, 0) (lower-left) corner of the
+              detector element viewed from the sample side.
+
+              The X and Y axes are the laboratory coordinate system
+              coordinates defined in the AXIS category  measured
+              when all positioning axes for the detector are at their zero
+              settings.  If the resulting X or Y axis is then orthogonal to the
+              detector, the Z axis is used instead of the orthogonal axis.
+
+              Because of ambiguity about the setting used to determine this
+              centre, use of this data item is deprecated. The data item
+              _diffrn_data_frame.center_slow
+              which is referenced to the detector coordinate system and not
+              directly to the laboratory coordinate system should be used
+              instead.
+
+;
+    _item.name                  '_diffrn_detector_element.center[2]'
+    _item.category_id             diffrn_detector_element
+    _item.mandatory_code          no
+    _item_default.value           0.0
+    _item_sub_category.id         vector
+    _item_type.code               float
+    _item_related.related_name  '_diffrn_data_frame.center_slow'
+    _item_related.function_code   replacedby
+    _item_units.code              millimetres
+
+     save_
+
+
+
+save__diffrn_measurement_axis.id
+    _item_description.description
+;             This data item is a pointer to _diffrn_measurement.id  in
+              the DIFFRN_MEASUREMENT  category.
+
+              DEPRECATED -- DO NOT USE
+;
+    _item.name                   '_diffrn_measurement_axis.id'
+    _item.category_id             diffrn_measurement_axis
+    _item.mandatory_code          no
+    _item_related.related_name   '_diffrn_measurement_axis.measurement_id'
+    _item_related.function_code   replacedby
+    _item_type.code               code
+     save_
+
+
+save__diffrn_scan_frame_monitor.value
+    _item_description.description
+;             This is a deprecated version of
+              _diffrn_scan_frame_monitor.monitor_value.
+
+              The value is typed as float to allow of monitors for very
+              intense beams that cannot report all digits, but when available,
+              all digits of the monitor should be recorded.
+
+              DEPRECATED -- DO NOT USE
+;
+    _item.name                   '_diffrn_scan_frame_monitor.value'
+    _item.category_id             diffrn_scan_frame_monitor
+    _item.mandatory_code          no
+    _item_related.related_name   '_diffrn_scan_frame_monitor.monitor_value'
+    _item_related.function_code   replacedby
+    _item_type.code               float
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0.0
+     save_
+
+
+#########################   DEPRECATED CATEGORY #########################
+#####################
+# DIFFRN_FRAME_DATA #
+#####################
+
+
+save_DIFFRN_FRAME_DATA
+    _category.description
+;   Data items in the DIFFRN_FRAME_DATA category record
+    the details about each frame of data.
+
+    The items in this category are now in the
+    DIFFRN_DATA_FRAME  category.
+
+    The items in the DIFFRN_FRAME_DATA category
+    are now deprecated.  The items from this category
+    are provided as aliases in the 1.0 dictionary
+    or, in the case of _diffrn_frame_data.details,
+    in the 1.4 dictionary.  THESE ITEMS SHOULD NOT
+    BE USED FOR NEW WORK.
+
+    The items from the old category are provided
+    in this dictionary for completeness
+    but should not be used or cited.  To avoid
+    confusion, the example has been removed
+    and the redundant parent-child links to other
+    categories have been removed.
+
+    All _item.mandatory_code values have been changed to 'no'.
+;
+    _category.id                   diffrn_frame_data
+    _category.mandatory_code       no
+     loop_
+    _category_key.name             '_diffrn_frame_data.id'
+                                   '_diffrn_frame_data.detector_element_id'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'array_data_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    THE DIFFRN_FRAME_DATA category is deprecated and should not be used.
+;
+;
+       # EXAMPLE REMOVED #
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save__diffrn_frame_data.array_id
+    _item_description.description
+;             This item is a pointer to _array_structure.id  in the
+              ARRAY_STRUCTURE category.
+
+              DEPRECATED -- DO NOT USE
+;
+    _item.name                  '_diffrn_frame_data.array_id'
+    _item.category_id             diffrn_frame_data
+    _item.mandatory_code          no
+    _item_related.related_name   '_diffrn_data_frame.array_id'
+    _item_related.function_code   replacedby
+    _item_type.code               code
+     save_
+
+
+save__diffrn_frame_data.binary_id
+    _item_description.description
+;             This item is a pointer to _array_data.binary_id  in the
+              ARRAY_STRUCTURE category.
+
+              DEPRECATED -- DO NOT USE
+;
+    _item.name                  '_diffrn_frame_data.binary_id'
+    _item.category_id             diffrn_frame_data
+    _item.mandatory_code          implicit
+    _item_related.related_name   '_diffrn_data_frame.binary_id'
+    _item_related.function_code   replacedby
+    _item_type.code               int
+     save_
+
+
+save__diffrn_frame_data.detector_element_id
+    _item_description.description
+;             This item is a pointer to _diffrn_detector_element.id
+              in the DIFFRN_DETECTOR_ELEMENT category.
+
+              DEPRECATED -- DO NOT USE
+;
+    _item.name                  '_diffrn_frame_data.detector_element_id'
+    _item.category_id             diffrn_frame_data
+    _item.mandatory_code          yes
+    _item_related.related_name   '_diffrn_data_frame.detector_element_id'
+    _item_related.function_code   replacedby
+    _item_type.code               code
+     save_
+
+
+save__diffrn_frame_data.id
+    _item_description.description
+;             The value of _diffrn_frame_data.id  must uniquely identify
+              each complete frame of data.
+
+              DEPRECATED -- DO NOT USE
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+           '_diffrn_frame_data.id'        diffrn_frame_data  yes
+    _item_related.related_name   '_diffrn_data_frame.id'
+    _item_related.function_code   replacedby
+    _item_type.code               code
+     save_
+
+
+save__diffrn_frame_data.details
+    _item_description.description
+;             The value of _diffrn_frame_data.details  should give a
+              description of special aspects of each frame of data.
+
+              DEPRECATED -- DO NOT USE
+;
+    _item.name                  '_diffrn_frame_data.details'
+    _item.category_id             diffrn_frame_data
+    _item.mandatory_code          no
+    _item_related.related_name   '_diffrn_data_frame.details'
+    _item_related.function_code   replacedby
+    _item_type.code               text
+     save_
+
+
+################ END DEPRECATED SECTION ###########
+
+
+####################
+## ITEM_TYPE_LIST ##
+####################
+#
+#
+#  The regular expressions defined here are not compliant
+#  with the POSIX 1003.2 standard as they include the
+#  '\n' and '\t' special characters.  These regular expressions
+#  have been tested using version 0.12 of Richard Stallman's
+#  GNU regular expression library in POSIX mode.
+#  In order to allow presentation of a regular expression
+#  in a text field concatenate any line ending in a backslash
+#  with the following line, after discarding the backslash.
+#
+#  A formal definition of the '\n' and '\t' special characters
+#  is most properly done in the DDL, but for completeness, please
+#  note that '\n' is the line termination character ('newline')
+#  and '\t' is the horizontal tab character.  There is a formal
+#  ambiguity in the use of '\n' for line termination, in that
+#  the intention is that the equivalent machine/OS-dependent line
+#  termination character sequence should be accepted as a match, e.g.
+#
+#      '\r' (control-M) under MacOS
+#      '\n' (control-J) under Unix
+#      '\r\n' (control-M control-J) under DOS and MS Windows
+#
+     loop_
+    _item_type_list.code
+    _item_type_list.primitive_code
+    _item_type_list.construct
+    _item_type_list.detail
+               code      char
+               '[_,.;:"&<>()/\{}'`~!@#$%A-Za-z0-9*|+-]*'
+;              code item types/single words ...
+;
+               ucode      uchar
+               '[_,.;:"&<>()/\{}'`~!@#$%A-Za-z0-9*|+-]*'
+;              code item types/single words (case insensitive) ...
+;
+               line      char
+               '[][ \t_(),.;:"&<>/\{}'`~!@#$%?+=*A-Za-z0-9|^-]*'
+;              char item types / multi-word items ...
+;
+               uline     uchar
+               '[][ \t_(),.;:"&<>/\{}'`~!@#$%?+=*A-Za-z0-9|^-]*'
+;              char item types / multi-word items (case insensitive)...
+;
+               text      char
+               '[][ \n\t()_,.;:"&<>/\{}'`~!@#$%?+=*A-Za-z0-9|^-]*'
+;              text item types / multi-line text ...
+;
+               binary    char
+;\n--CIF-BINARY-FORMAT-SECTION--\n\
+[][ \n\t()_,.;:"&<>/\{}'`~!@#$%?+=*A-Za-z0-9|^-]*\
+\n--CIF-BINARY-FORMAT-SECTION----
+;
+;              binary items are presented as MIME-like ascii-encoded
+               sections in an imgCIF.  In a CBF, raw octet streams
+               are used to convey the same information.
+;
+               int       numb
+               '-?[0-9]+'
+;              int item types are the subset of numbers that are the negative
+               or positive integers.
+;
+               float     numb
+          '-?(([0-9]+)[.]?|([0-9]*[.][0-9]+))([(][0-9]+[)])?([eE][+-]?[0-9]+)?'
+;              float item types are the subset of numbers that are the floating
+               point numbers.
+;
+               any       char
+               '.*'
+;              A catch all for items that may take any form...
+;
+               yyyy-mm-dd  char
+;\
+[0-9]?[0-9]?[0-9][0-9]-[0-9]?[0-9]-[0-9]?[0-9]\
+((T[0-2][0-9](:[0-5][0-9](:[0-5][0-9](.[0-9]+)?)?)?)?\
+([+-][0-5][0-9]:[0-5][0-9]))?
+;
+;
+               Standard format for CIF date and time strings (see
+               http://www.iucr.org/iucr-top/cif/spec/datetime.html),
+               consisting of a yyyy-mm-dd date optionally followed by
+               the character 'T' followed by a 24-hour clock time,
+               optionally followed by a signed time-zone offset.
+
+               The IUCr standard has been extended to allow for an optional
+               decimal fraction on the seconds of time.
+
+               Time is local time if no time-zone offset is given.
+
+               Note that this type extends the mmCIF yyyy-mm-dd type
+               but does not conform to the mmCIF yyyy-mm-dd:hh:mm
+               type that uses a ':' in place of the 'T' specified
+               by the IUCr standard.  For reading, both forms should
+               be accepted,  but for writing, only the IUCr form should
+               be used.
+
+               For maximal compatibility, the special time zone
+               indicator 'Z' (for 'Zulu') should be accepted on
+               reading in place of '+00:00' for GMT.
+;
+
+
+#####################
+## ITEM_UNITS_LIST ##
+#####################
+
+     loop_
+    _item_units_list.code
+    _item_units_list.detail
+#
+     'metres'                 'metres'
+     'centimetres'            'centimetres (metres * 10^( -2)^)'
+     'millimetres'            'millimetres (metres * 10^( -3)^)'
+     'micrometres'            'micrometres (metres * 10^( -6)^)'
+     'nanometres'             'nanometres  (metres * 10^( -9)^)'
+     'angstroms'              '\%angstr\"oms   (metres * 10^(-10)^)'
+     'picometres'             'picometres  (metres * 10^(-12)^)'
+     'femtometres'            'femtometres (metres * 10^(-15)^)'
+#
+     'reciprocal_metres'      'reciprocal metres (metres^(-1)^)'
+     'reciprocal_centimetres'
+        'reciprocal centimetres ((metres * 10^( -2)^)^(-1)^)'
+     'reciprocal_millimetres'
+        'reciprocal millimetres ((metres * 10^( -3)^)^(-1)^)'
+     'reciprocal_nanometres'
+        'reciprocal nanometres  ((metres * 10^( -9)^)^(-1)^)'
+     'reciprocal_angstroms'
+        'reciprocal \%angstr\"oms   ((metres * 10^(-10)^)^(-1)^)'
+     'reciprocal_picometres'
+        'reciprocal picometres  ((metres * 10^(-12)^)^(-1)^)'
+#
+     'nanometres_squared'     'nanometres squared (metres * 10^( -9)^)^2^'
+     'angstroms_squared'      '\%angstr\"oms squared  (metres * 10^(-10)^)^2^'
+     '8pi2_angstroms_squared'
+       '8\p^2^ * \%angstr\"oms squared (metres * 10^(-10)^)^2^'
+     'picometres_squared'     'picometres squared (metres * 10^(-12)^)^2^'
+#
+     'nanometres_cubed'       'nanometres cubed (metres * 10^( -9)^)^3^'
+     'angstroms_cubed'        '\%angstr\"oms cubed  (metres * 10^(-10)^)^3^'
+     'picometres_cubed'       'picometres cubed (metres * 10^(-12)^)^3^'
+#
+     'kilopascals'            'kilopascals'
+     'gigapascals'            'gigapascals'
+#
+     'hours'                  'hours'
+     'minutes'                'minutes'
+     'seconds'                'seconds'
+     'microseconds'           'microseconds'
+#
+     'degrees'                'degrees (of arc)'
+     'degrees_squared'        'degrees (of arc) squared'
+#
+     'degrees_per_minute'     'degrees (of arc) per minute'
+#
+     'celsius'                'degrees (of temperature) Celsius'
+     'kelvins'                'degrees (of temperature) Kelvin'
+#
+     'counts'                 'counts'
+     'counts_per_photon'      'counts per photon'
+#
+     'electrons'              'electrons'
+#
+     'electrons_squared'      'electrons squared'
+#
+     'electrons_per_nanometres_cubed'
+; electrons per nanometres cubed (electrons/(metres * 10^( -9)^)^(-3)^)
+;
+     'electrons_per_angstroms_cubed'
+; electrons per \%angstr\"oms cubed (electrons/(metres * 10^(-10)^)^(-3)^)
+;
+     'electrons_per_picometres_cubed'
+; electrons per picometres cubed (electrons/(metres * 10^(-12)^)^(-3)^)
+;
+     'kilowatts'              'kilowatts'
+     'milliamperes'           'milliamperes'
+     'kilovolts'              'kilovolts'
+#
+     'pixels_per_element'     '(image) pixels per (array) element'
+#
+     'arbitrary'
+; arbitrary system of units.
+;
+#
+
+     loop_
+    _item_units_conversion.from_code
+    _item_units_conversion.to_code
+    _item_units_conversion.operator
+    _item_units_conversion.factor
+###
+     'metres'                   'centimetres'              '*'   1.0E+02
+     'metres'                   'millimetres'              '*'   1.0E+03
+     'metres'                   'nanometres'               '*'   1.0E+09
+     'metres'                   'angstroms'                '*'   1.0E+10
+     'metres'                   'picometres'               '*'   1.0E+12
+     'metres'                   'femtometres'              '*'   1.0E+15
+#
+     'centimetres'              'metres'                   '*'   1.0E-02
+     'centimetres'              'millimetres'              '*'   1.0E+01
+     'centimetres'              'nanometres'               '*'   1.0E+07
+     'centimetres'              'angstroms'                '*'   1.0E+08
+     'centimetres'              'picometres'               '*'   1.0E+10
+     'centimetres'              'femtometres'              '*'   1.0E+13
+#
+     'millimetres'              'metres'                   '*'   1.0E-03
+     'millimetres'              'centimetres'              '*'   1.0E-01
+     'millimetres'              'nanometres'               '*'   1.0E+06
+     'millimetres'              'angstroms'                '*'   1.0E+07
+     'millimetres'              'picometres'               '*'   1.0E+09
+     'millimetres'              'femtometres'              '*'   1.0E+12
+#
+     'nanometres'               'metres'                   '*'   1.0E-09
+     'nanometres'               'centimetres'              '*'   1.0E-07
+     'nanometres'               'millimetres'              '*'   1.0E-06
+     'nanometres'               'angstroms'                '*'   1.0E+01
+     'nanometres'               'picometres'               '*'   1.0E+03
+     'nanometres'               'femtometres'              '*'   1.0E+06
+#
+     'angstroms'                'metres'                   '*'   1.0E-10
+     'angstroms'                'centimetres'              '*'   1.0E-08
+     'angstroms'                'millimetres'              '*'   1.0E-07
+     'angstroms'                'nanometres'               '*'   1.0E-01
+     'angstroms'                'picometres'               '*'   1.0E+02
+     'angstroms'                'femtometres'              '*'   1.0E+05
+#
+     'picometres'               'metres'                   '*'   1.0E-12
+     'picometres'               'centimetres'              '*'   1.0E-10
+     'picometres'               'millimetres'              '*'   1.0E-09
+     'picometres'               'nanometres'               '*'   1.0E-03
+     'picometres'               'angstroms'                '*'   1.0E-02
+     'picometres'               'femtometres'              '*'   1.0E+03
+#
+     'femtometres'              'metres'                   '*'   1.0E-15
+     'femtometres'              'centimetres'              '*'   1.0E-13
+     'femtometres'              'millimetres'              '*'   1.0E-12
+     'femtometres'              'nanometres'               '*'   1.0E-06
+     'femtometres'              'angstroms'                '*'   1.0E-05
+     'femtometres'              'picometres'               '*'   1.0E-03
+###
+     'reciprocal_centimetres'   'reciprocal_metres'        '*'   1.0E+02
+     'reciprocal_centimetres'   'reciprocal_millimetres'   '*'   1.0E-01
+     'reciprocal_centimetres'   'reciprocal_nanometres'    '*'   1.0E-07
+     'reciprocal_centimetres'   'reciprocal_angstroms'     '*'   1.0E-08
+     'reciprocal_centimetres'   'reciprocal_picometres'    '*'   1.0E-10
+#
+     'reciprocal_millimetres'   'reciprocal_metres'        '*'   1.0E+03
+     'reciprocal_millimetres'   'reciprocal_centimetres'   '*'   1.0E+01
+     'reciprocal_millimetres'   'reciprocal_nanometres'    '*'   1.0E-06
+     'reciprocal_millimetres'   'reciprocal_angstroms'     '*'   1.0E-07
+     'reciprocal_millimetres'   'reciprocal_picometres'    '*'   1.0E-09
+#
+     'reciprocal_nanometres'    'reciprocal_metres'        '*'   1.0E+09
+     'reciprocal_nanometres'    'reciprocal_centimetres'   '*'   1.0E+07
+     'reciprocal_nanometres'    'reciprocal_millimetres'   '*'   1.0E+06
+     'reciprocal_nanometres'    'reciprocal_angstroms'     '*'   1.0E-01
+     'reciprocal_nanometres'    'reciprocal_picometres'    '*'   1.0E-03
+#
+     'reciprocal_angstroms'     'reciprocal_metres'        '*'   1.0E+10
+     'reciprocal_angstroms'     'reciprocal_centimetres'   '*'   1.0E+08
+     'reciprocal_angstroms'     'reciprocal_millimetres'   '*'   1.0E+07
+     'reciprocal_angstroms'     'reciprocal_nanometres'    '*'   1.0E+01
+     'reciprocal_angstroms'     'reciprocal_picometres'    '*'   1.0E-02
+#
+     'reciprocal_picometres'    'reciprocal_metres'        '*'   1.0E+12
+     'reciprocal_picometres'    'reciprocal_centimetres'   '*'   1.0E+10
+     'reciprocal_picometres'    'reciprocal_millimetres'   '*'   1.0E+09
+     'reciprocal_picometres'    'reciprocal_nanometres'    '*'   1.0E+03
+     'reciprocal_picometres'    'reciprocal_angstroms'     '*'   1.0E+01
+###
+     'nanometres_squared'       'angstroms_squared'        '*'   1.0E+02
+     'nanometres_squared'       'picometres_squared'       '*'   1.0E+06
+#
+     'angstroms_squared'        'nanometres_squared'       '*'   1.0E-02
+     'angstroms_squared'        'picometres_squared'       '*'   1.0E+04
+     'angstroms_squared'        '8pi2_angstroms_squared'   '*'   78.9568
+
+#
+     'picometres_squared'       'nanometres_squared'       '*'   1.0E-06
+     'picometres_squared'       'angstroms_squared'        '*'   1.0E-04
+###
+     'nanometres_cubed'         'angstroms_cubed'          '*'   1.0E+03
+     'nanometres_cubed'         'picometres_cubed'         '*'   1.0E+09
+#
+     'angstroms_cubed'          'nanometres_cubed'         '*'   1.0E-03
+     'angstroms_cubed'          'picometres_cubed'         '*'   1.0E+06
+#
+     'picometres_cubed'         'nanometres_cubed'         '*'   1.0E-09
+     'picometres_cubed'         'angstroms_cubed'          '*'   1.0E-06
+###
+     'kilopascals'              'gigapascals'              '*'   1.0E-06
+     'gigapascals'              'kilopascals'              '*'   1.0E+06
+###
+     'hours'                    'minutes'                  '*'   6.0E+01
+     'hours'                    'seconds'                  '*'   3.6E+03
+     'hours'                    'microseconds'             '*'   3.6E+09
+#
+     'minutes'                  'hours'                    '/'   6.0E+01
+     'minutes'                  'seconds'                  '*'   6.0E+01
+     'minutes'                  'microseconds'             '*'   6.0E+07
+#
+     'seconds'                  'hours'                    '/'   3.6E+03
+     'seconds'                  'minutes'                  '/'   6.0E+01
+     'seconds'                  'microseconds'             '*'   1.0E+06
+#
+     'microseconds'             'hours'                    '/'   3.6E+09
+     'microseconds'             'minutes'                  '/'   6.0E+07
+     'microseconds'             'seconds'                  '/'   1.0E+06
+###
+     'celsius'                  'kelvins'                  '-'     273.0
+     'kelvins'                  'celsius'                  '+'     273.0
+###
+     'electrons_per_nanometres_cubed'
+     'electrons_per_angstroms_cubed'                       '*'   1.0E+03
+     'electrons_per_nanometres_cubed'
+     'electrons_per_picometres_cubed'                      '*'   1.0E+09
+#
+     'electrons_per_angstroms_cubed'
+     'electrons_per_nanometres_cubed'                      '*'   1.0E-03
+     'electrons_per_angstroms_cubed'
+     'electrons_per_picometres_cubed'                      '*'   1.0E+06
+#
+     'electrons_per_picometres_cubed'
+     'electrons_per_nanometres_cubed'                      '*'   1.0E-09
+     'electrons_per_picometres_cubed'
+     'electrons_per_angstroms_cubed'                       '*'   1.0E-06
+###
+
+########################
+## DICTIONARY_HISTORY ##
+########################
+
+     loop_
+    _dictionary_history.version
+    _dictionary_history.update
+    _dictionary_history.revision
+
+    1.8.6    2022-05-11
+
+;   Add missing archive tags to external data tags, clarify use of
+    those tags and correct typos (jrh, hjb)
+
+    + Add _array_data_external_data.archive_format
+    + Add _array_data_external_data.archive_path
+
+;
+
+    1.8.5    2021-07-09
+
+;   Handling of external data (jrh, ab, hjb)
+
+    + Remove preliminary versions of external data tags in ARRAY_DATA
+    + Add ARRAY_DATA_EXTERNAL_DATA
+    + Add _array_data.external_data_id
+    + Add _array_data_external_data.format
+    + Add _array_data_external_data.frame
+    + Add _array_data_external_data.id
+    + Add _array_data_external_data.path
+    + Add _array_data_external_data.uri
+    + Add _array_data_external_data.variant
+    + Add _array_data_external_data.version
+
+;
+
+    1.8.4    2021-04-15
+
+;   Copy-editing refinements (bm)
+
+    + Add _item_related.related_name and
+      "_item_related.function_code replacedby" to deprecated items.
+    + Add "_item_default.value  ." to *_variant items
+    + Change uses of \%Angstroms to \%angstr\"oms
+    + Change category save frames to upper case names
+    + Fix misssing superscript terminating ^
+
+    Preliminary version of external data tags (jrh)
+
+    + Add _array_data.external_format
+    + Add _array_data.external_version
+    + Add _array_data.external_location_uri
+    + Add _array_data.external_path
+    + Add _array_data.external_frame
+    + Add _array_data.external_archive_path
+    + Add _array_data.external_archive_format
+
+    Note the second block of mads is a preliminary version.  When they are
+    done they may well be removed from here and reappear in a 1.8.5
+    dictionary.
+
+;
+
+    1.8.3    2021-02-28
+
+;   Correction as per Brian McMahon
+
+    + Fix _item.name for _array_structure_list.array_section_id
+    + Remove spurious _item_aliases.alias_name from
+      _diffrn_radiation.polarisn_ratio_esd
+    + Remove spurious reference to _diffrn_scan_frame.time_rstrt_incr
+    + Provide missing _diffrn_scan_frame_monitor.monitor_value  definition
+    + Deprecate _diffrn_scan_frame_monitor.value
+;
+
+    1.8.2    2021-02-21
+
+;   Corrections and additions for ITVG 2021
+
+    + Add McStas as an axis coordinate system
+    + Add _array_intensities.underload  as optional
+    + Add _diffrn_scan_collection.details  as optional
+    + Add _diffrn_scan_collection.variant  as optional
+;
+
+    1.8.1    2021-01-30
+
+;   Copy-paste error corrections (JRH)
+
+    + Fix double underscore in _diffrn_data_frame.center_derived
+    + Fix wrong _item.name in _diffrn_scan.date_end_estimated
+    + Fix wrong _item.mandatory_code in _diffrn_scan_frame_monitor.frame_id
+    + Fix wrong _item.mandatory_code in _variant.variant_of
+;
+
+    1.8.0    2021-01-24
+
+;   Changes for 2021 ITVG and conformance with Gold Standard and NXmx (HJB)
+
+    + Add _diffrn_data_frame.center_derived  as optional
+    + Add _diffrn_measurement.sample_detector_distance_derived  as optional
+    + Change _diffrn_scan.date_start  to mandatory
+    + Add _diffrn_scan.date_end_estimated  as mandatory
+    + Fix .array_id and .binary_id columns to be implicit in all cases to
+      facilitate mini_cbfs
+
+;
+
+
+    1.7.11   2018-12-03
+
+;   Changes for CBFlib 0.9.6 release (HJB)
+
+    + Remove _array_structure_list.array_section_id
+    + Revisions to _category.NX_mapping_details in most categories for
+    array sections.
+    + Change to uniform use of entry:NXentry
+    + Change to uniform use of identification of NXdetector by detector
+    element
+    + Change to uniform use of data_ARRAYID_BINARYID
+    + Add _array_structure_list.array_section_id
+    + Add _map_segment.mask_array_section_id
+    + Add _diffrn_scan_collection.scan_id
+    + Add _diffrn_scan_collection.type
+    + Add _diffrn_scan_collection.translation_width
+    + Add _diffrn_radiation.beam_width
+    + Add _diffrn_radiation.beam_height
+    + Add _diffrn_radiation.beam_flux
+
+;
+
+
+    1.7.10   2014-04-25
+
+;  Additions of esd's to polarization tags.  Change to NeXus mapping to use
+   NXtransformations instead of NXpoise (HJB)
+
+    + Add _diffrn_radiation.polarisn_norm_esd,
+    _diffrn_radiation.polarisn_ratio_esd,
+    _diffrn_radiation.polarizn_source_norm_esd,
+    _diffrn_radiation.polarizn_source_ratio_esd,
+    _diffrn_radiation.polarizn_Stokes_I_esd,
+    _diffrn_radiation.polarizn_Stokes_Q_esd,
+    _diffrn_radiation.polarizn_Stokes_U_esd,
+    _diffrn_radiation.polarizn_Stokes_V_esd,
+    _diffrn_scan_frame.polarizn_Stokes_I_esd,
+    _diffrn_scan_frame.polarizn_Stokes_Q_esd,
+    _diffrn_scan_frame.polarizn_Stokes_U_esd,
+    _diffrn_scan_frame.polarizn_Stokes_V_esd.
+    + Change NeXus mapping for ARRAY_STRUCTURE_LIST
+    ARRAY_STRUCTURE_LIST_AXIS, AXIS,
+    DIFFRN_DETECTOR_AXIS, DIFFRN_MEASUREMENT_AXIS,
+    DIFFRN_SCAN_FRAME_AXIS.
+
+;
+
+    1.7.9   2014-04-05
+
+;  Corrections to Stokes parameter description. (HJB)
+
+    + Clarify the meaning of _diffrn_radiation.polarizn_Stokes_I
+    and _diffrn_scan_frame.polarizn_Stokes_I  to explicitly include non-polarized
+        component.
+
+    + Provide missing factor of 2 in _diffrn_radiation.polarizn_Stokes_V
+    description and _diffrn_scan_frame.polarizn_Stokes_V  description.
+
+;
+
+
+    1.7.8   2014-02-22
+
+;  Minor changes to NeXus mapping. (HJB)
+
+       + Conform NeXus mapping of DIFFRN_DETECTOR  to neXus
+       NXdetector base class terminology
+
+       + Add _diffrn_detector.gain_setting  to handle
+       the reverse mapping from NeXus of the equivalent field in NXdetector.
+;
+
+    1.7.7   2014-02-22
+
+;  Major changes to NeXus mapping to conform to JS functional
+    mapping prototype, add Stoke parameter tags for polarization
+    and beam intensity, and add an new tag for FEL axes (HJB)
+
+       + Add
+       _axis.equipment_component,
+       _diffrn_radiation.polarizn_Stokes_I,
+       _diffrn_radiation.polarizn_Stokes_Q,
+       _diffrn_radiation.polarizn_Stokes_U,
+       _diffrn_radiation.polarizn_Stokes_V,
+       _diffrn_scan_frame.polarizn_Stokes_I,
+       _diffrn_scan_frame.polarizn_Stokes_Q,
+       _diffrn_scan_frame.polarizn_Stokes_U,
+       _diffrn_scan_frame.polarizn_Stokes_V.
+       + Remove erroneous type code from _diffrn_scan_frame_monitor.value.
+       + Update dictionary version
+;
+
+
+
+    1.7.6   2013-10-29
+
+;  To avoid a conflict with PDB software, remove the null value
+    enumeration for _variant.role  (HJB)
+
+;
+
+
+    1.7.5   2013-10-27
+
+;  At request of JW for the PDB move _category.NX_mapping_details
+   to be adjacent to other category tags. (HJB)
+
+;
+
+    1.7.4   2013-10-23
+
+;  Minor cleanup and remove spurious tag
+
+    +  remove spurious _array_structure_list_section.array_set_id
+    references. (JS)
+    +  Change case of category names to conform to PDB conventions. (JW)
+
+;
+
+
+    1.7.3   2013-10-15
+
+;  Major cleanup of dictionary typos, misplaced loops, etc
+       by John Westbrook
+
+    +  Change _item.mandatory_code of all *.variant to implicit
+    +  Add _diffrn_refln.id and _diffrn_refln.diffrn_id
+    +  Correct many _item.name values that were wrong or missing
+       quote marks
+
+;
+
+
+
+    1.7.2   2013-10-07
+
+;  Add FEL detector positioning tags and change back to NXgoniometer
+
+    +  Add
+       _axis.rotation_axis  and
+       _axis.rotation  and
+    +  Change NXsample back to NXgoniometer
+
+;
+
+    1.7.1   2013-08-10
+
+;  Minor cleanup (HJB)
+
+    +  Correction to description of
+         _diffrn_data_frame.array_section_id
+    +  Change NXgoniometer to NXsample
+    +  Fix typos in NeXus mappings
+
+;
+
+    1.7     2013-06-18
+
+;  Additions to start merge of CBF, HDF5 and NeXus (HJB)
+
+    +  Define new ARRAY_STRUCTURE_LIST_SECTION category
+    +  Add new _category.NX_mapping_details DDL tag to carry
+       details on NeXus category mappings.
+    +  Define new tags _array_structure_list_section.array_id,
+       _array_structure_list_section.id,
+       _array_structure_list_section.index,
+       _array_structure_list_section.end,
+       _array_structure_list_section.start,
+       _array_structure_list_section.stride,
+       _array_structure_list_section.variant,
+       _diffrn_data_frame.array_section_id,
+       _diffrn_detector.layer_thickness,
+       _map_segment.array_section_id,
+       _map_segment.mask_array_section_id
+
+;
+
+    1.6.4   2011-07-02
+
+;  Corrections to support DLS Dectris header as per G. Winter (HJB)
+
+    +  Define new tags _diffrn_scan.time_period,
+       _diffrn_scan.time_rstrt_incr,
+       _diffrn_scan_frame.time_period,
+       _diffrn_scan_frame.time_rstrt_incr
+    +  fix bad category name in loop in _diffrn_detector.id
+    +  remove stray text field terminator at line 4642
+    +  fix unquoted tag as a value in _diffrn_scan_frame_monitor.id
+    +  make formerly mandatory and implicit deprecated items non-mandatory
+
+;
+
+   1.6.3   2010-08-26
+
+;  Cumulative corrections from 1.6.0, 1, 2 drafts (HJB)
+
+    +  Move descriptive dictionary comments into
+    _datablock.description with category tree described
+    +  add default _array_data.array_id  value of 1
+    +  add option of CBF_BACKGROUND_OFFSET_DELTA compression
+    +  add VARIANT category and tags
+    +  add DIFFRN_SCAN_FRAME_MONITOR category
+
+;
+
+   1.5.4   2007-07-28
+
+;  Typographics corrections (HJB)
+
+     + Corrected embedded degree characters to \%
+     + Corrected embedded Aring to \%A
+     + Added trailing ^ for a power
+     + Removed 2 cases of a space after an underscore
+       in tag name.
+;
+
+   1.5.3   2007-07-08
+
+;  Changes to support SLS miniCBF and suggestions
+   from the 24 May 07 BNL imgCIF workshop (HJB)
+
+     + Added new data items
+       '_array_data.header_contents',
+       '_array_data.header_convention',
+       '_diffrn_data_frame.center_fast',
+       '_diffrn_data_frame.center_slow',
+       '_diffrn_data_frame.center_units',
+       '_diffrn_measurement.sample_detector_distance',
+       '_diffrn_measurement.sample_detector_voffset
+     + Deprecated data items
+       '_diffrn_detector_element.center[1]',
+       '_diffrn_detector_element.center[2]'
+     + Added comments and example on miniCBF
+     + Changed all array_id data items to implicit
+;
+
+   1.5.2   2007-05-06
+
+;  Further clarifications of the coordinate system. (HJB)
+;
+
+   1.5.1   2007-04-26
+
+;  Improve definition of X-axis to cover the case of no goniometer
+   and clean up more line folds (HJB)
+;
+
+   1.5     2007-07-25
+
+;  This is a cumulative list of the changes proposed since the
+   imgCIF workshop in Hawaii in July 2006.  It is the result
+   of contributions by H. J. Bernstein, A. Hammersley,
+   J. Wright and W. Kabsch.
+
+   2007-02-19 Consolidated changes (edited by HJB)
+     + Added new data items
+       '_array_structure.compression_type_flag',
+       '_array_structure_list_axis.fract_displacement',
+       '_array_structure_list_axis.displacement_increment',
+       '_array_structure_list_axis.reference_angle',
+       '_array_structure_list_axis.reference_displacement',
+       '_axis.system',
+       '_diffrn_detector_element.reference_center_fast',
+       '_diffrn_detector_element.reference_center_slow',
+       '_diffrn_scan_axis.reference_angle',
+       '_diffrn_scan_axis.reference_displacement',
+       '_map.details', '_map.diffrn_id',
+       '_map.entry_id', '_map.id',
+       '_map_segment.array_id', '_map_segment.binary_id',
+       '_map_segment.mask_array_id', '_map_segment.mask_binary_id',
+       '_map_segment.id', '_map_segment.map_id',
+       '_map_segment.details.
+     + Change type of
+       '_array_structure.byte_order' and
+       '_array_structure.compression_type'
+       to ucode to make these values case-insensitive
+     + Add values 'packed_v2' and 'byte_offset' to enumeration of values for
+       '_array_structure.compression_type'
+     + Add to definitions for the binary data type to handle new compression
+       types, maps, and a variety of new axis types.
+    2007-07-25 Cleanup of typos for formal release (HJB)
+     + Corrected text fields for reference_ tag descriptions that
+       were off by one column
+     + Fix typos in comments listing fract_ tags
+     + Changed name of release from 1.5_DRAFT to 1.5
+     + Fix unclosed text fields in various map definitions
+
+;
+
+   1.4     2006-07-04
+
+;  This is a change to reintegrate all changes made in the course of
+   publication of ITVG, by the RCSB from April 2005 through
+   August 2008 and changes for the 2006 imgCIF workshop in
+   Hawaii.
+
+   2006-07-04 Consolidated changes for the 2006 imgCIF workshop (edited by HJB)
+     + Correct type of '_array_structure_list.direction' from 'int' to 'code'.
+     + Added new data items suggested by CN
+       '_diffrn_data_frame.details'
+       '_array_intensities.pixel_fast_bin_size',
+       '_array_intensities.pixel_slow_bin_size  and
+       '_array_intensities.pixel_binning_method
+     + Added deprecated item for completeness
+       '_diffrn_frame_data.details'
+     + Added entry for missing item in contents list
+       '_array_structure_list_axis.displacement'
+     + Added new MIME type X-BASE32K based on work by VL, KM, GD, HJB
+     + Correct description of MIME boundary delimiter to start in
+       column 1.
+     + General cleanup of text fields to conform to changes for ITVG
+       by removing empty lines at start and finish of text field.
+     + Amend example for ARRAY_INTENSITIES to include binning.
+     + Add local copy of type specification (as 'code') for all children
+       of '_diffrn.id '.
+     + For consistency, change all references to 'pi' to '\p' and all
+       references to 'Angstroms' to '\%Angstroms'.
+     + Clean up all powers to use IUCr convention of '^power^', as in
+       '10^3^' for '10**3'.
+     + Update 'yyyy-mm-dd' type regex to allow truncation from the right
+       and improve comments to explain handling of related mmCIF
+       'yyyy-mm-dd:hh:mm' type, and use of 'Z' for GMT time zone.
+
+   2005-03-08 and
+   2004-08-08 fixed cases where _item_units.code  used
+              instead of _item_type.code (JDW)
+   2004-04-15 fixed item ordering in
+               _diffrn_measurement_axis.measurement_id
+               added sub_category 'vector' (JDW)
+;
+
+   1.3.2   2005-06-25
+
+;  2005-06-25 ITEM_TYPE_LIST: code, ucode, line, uline regexps updated
+              to those of current mmCIF; float modified by allowing integers
+              terminated by a point as valid. The 'time' part of
+              yyyy-mm-dd types made optional in the regexp. (BM)
+
+   2005-06-17 Minor corrections as for proofs for IT G Chapter 4.6
+   (NJA)
+
+   2005-02-21  Minor corrections to spelling and punctuation
+   (NJA)
+
+   2005-01-08 Changes as per Nicola Ashcroft.
+   + Updated example 1 for DIFFRN_MEASUREMENT to agree with mmCIF.
+   + Spelled out "micrometres" for "um" and "millimetres" for "mm".
+   + Removed phrase "which may be stored" from ARRAY_STRUCTURE
+     description.
+   + Removed unused 'byte-offsets' compressions and updated
+     cites to ITVG for '_array_structure.compression_type'.
+   (HJB)
+;
+
+   1.3.1   2003-08-13
+;
+   Changes as per Frances C. Bernstein.
+   + Identify initials.
+   + Adopt British spelling for centre in text.
+   + Set \p and \%Angstrom and powers.
+   + Clean up commas and unclear wordings.
+   + Clean up tenses in history.
+   Changes as per Gotzon Madariaga.
+   + Fix the ARRAY_DATA example to align '_array_data.binary_id'
+   and X-Binary-ID.
+   + Add a range to '_array_intensities.gain_esd '.
+   + In the example of DIFFRN_DETECTOR_ELEMENT,
+   '_diffrn_detector_element.id' and
+   '_diffrn_detector_element.detector_id' interchanged.
+   + Fix typos for direction, detector and axes.
+   + Clarify description of polarisation.
+   + Clarify axes in '_diffrn_detector_element.center[1]'
+    '_diffrn_detector_element.center[2] '.
+   + Add local item types for items that are pointers.
+   (HJB)
+;
+
+
+   1.3.0   2003-07-24
+;
+   Changes as per Brian McMahon.
+   + Consistently quote tags embedded in text.
+   + Clean up introductory comments.
+   + Adjust line lengths to fit in 80 character window.
+   + Fix several descriptions in AXIS category which
+     referred to '_axis.type' instead of the current item.
+   + Fix erroneous use of deprecated item
+     '_diffrn_detector_axis.id' in examples for
+     DIFFRN_SCAN_AXIS.
+   + Add deprecated items '_diffrn_detector_axis.id'
+     and '_diffrn_measurement_axis.id'.
+   (HJB)
+;
+
+
+   1.2.4   2003-07-14
+;
+   Changes as per I. David Brown.
+   + Enhance descriptions in DIFFRN_SCAN_AXIS to make them less
+     dependent on the descriptions in DIFFRN_SCAN_FRAME_AXIS.
+   + Provide a copy of the deprecated DIFFRN_FRAME_DATA
+     category for completeness.
+   (HJB)
+;
+
+
+   1.2.3   2003-07-03
+;
+   Cleanup to conform to ITVG.
+   + Correct sign error in ..._cubed units.
+   + Correct '_diffrn_radiation.polarisn_norm' range.
+   (HJB)
+;
+
+
+   1.2.2   2003-03-10
+;
+   Correction of typos in various DIFFRN_SCAN_AXIS descriptions.
+   (HJB)
+;
+
+
+   1.2.1   2003-02-22
+;
+   Correction of ATOM_ for ARRAY_ typos in various descriptions.
+   (HJB)
+;
+
+
+   1.2     2003-02-07
+;
+   Corrections to encodings (remove extraneous hyphens) remove
+   extraneous underscore in '_array_structure.encoding_type'
+   enumeration.  Correct typos in items units list.  (HJB)
+;
+
+
+   1.1.3   2001-04-19
+;
+   Another typo corrections by Wilfred Li, and cleanup by HJB.
+;
+
+
+   1.1.2   2001-03-06
+;
+   Several typo corrections by Wilfred Li.
+;
+
+
+   1.1.1   2001-02-16
+;
+   Several typo corrections by JW.
+;
+
+
+   1.1     2001-02-06
+;
+   Draft resulting from discussions on header for use at NSLS.  (HJB)
+
+   + Change DIFFRN_FRAME_DATA to DIFFRN_DATA_FRAME.
+
+   + Change '_diffrn_detector_axis.id' to '_diffrn_detector_axis.detector_id '.
+
+   + Add '_diffrn_measurement_axis.measurement_device' and change
+     '_diffrn_measurement_axis.id' to
+     '_diffrn_measurement_axis.measurement_id '.
+
+   + Add '_diffrn_radiation.div_x_source', '_diffrn_radiation.div_y_source',
+    '_diffrn_radiation.div_x_y_source',
+    '_diffrn_radiation.polarizn_source_norm',
+   '_diffrn_radiation.polarizn_source_ratio', '_diffrn_scan.date_end',
+   '_diffrn_scan.date_start', '_diffrn_scan_axis.angle_rstrt_incr',
+   '_diffrn_scan_axis.displacement_rstrt_incr',
+   '_diffrn_scan_frame_axis.angle_increment',
+   '_diffrn_scan_frame_axis.angle_rstrt_incr',
+   '_diffrn_scan_frame_axis.displacement',
+   '_diffrn_scan_frame_axis.displacement_increment',and
+   '_diffrn_scan_frame_axis.displacement_rstrt_incr '.
+
+   + Add '_diffrn_measurement.device' to category key.
+
+   + Update yyyy-mm-dd to allow optional time with fractional seconds
+     for time stamps.
+
+   + Fix typos caught by RS.
+
+   + Add ARRAY_STRUCTURE_LIST_AXIS  category, and use concept of axis sets to
+     allow for coupled axes, as in spiral scans.
+
+   + Add examples for fairly complete headers thanks to R. Sweet and P.
+     Ellis.
+;
+
+
+   1.0     2000-12-21
+;
+   Release version - few typos and tidying up.  (BM & HJB)
+
+   + Move ITEM_TYPE_LIST, ITEM_UNITS_LIST and DICTIONARY_HISTORY to end
+   of dictionary.
+
+   + Alphabetize dictionary.
+;
+
+
+   0.7.1   2000-09-29
+;
+   Cleanup fixes.  (JW)
+
+   + Correct spelling of DIFFRN_MEASUREMENT_AXIS in '_axis.id'
+
+   + Correct ordering of uses of '_item.mandatory_code' and
+   '_item_default.value'.
+;
+
+
+   0.7.0   2000-09-09
+;
+   Respond to comments by I. David Brown.  (HJB)
+
+   + Add further comments on '\n' and '\t'.
+
+   + Update ITEM_UNITS_LIST by taking section from mmCIF dictionary
+     and adding metres.  Change 'meter' to 'metre' throughout.
+
+   + Add missing enumerations to '_array_structure.compression_type'
+     and make 'none' the default.
+
+   + Remove parent-child relationship between
+     '_array_structure_list.index' and '_array_structure_list.precedence'.
+
+   + Improve alphabetization.
+
+   + Fix '_array_intensities.gain_esd' related function.
+
+   + Improve comments in AXIS.
+
+   + Fix DIFFRN_FRAME_DATA example.
+
+   + Remove erroneous DIFFRN_MEASUREMENT  example.
+
+   + Add '_diffrn_measurement_axis.id' to the category key.
+;
+
+
+   0.6.0   1999-01-14
+;
+   Remove redundant information for ENC_NONE data.  (HJB)
+
+   + After the D5 remove binary section identifier, size and
+     compression type.
+
+   + Add Control-L to header.
+;
+
+
+   0.5.1   1999-01-03
+;
+   Cleanup of typos and syntax errors.  (HJB)
+
+   + Cleanup example details for DIFFRN_SCAN  category.
+
+   + Add missing quote marks for '_diffrn_scan.id' definition.
+;
+
+
+   0.5   1999-01-01
+;
+   Modifications for axis definitions and reduction of binary header.  (HJB)
+
+   + Restore '_diffrn_detector.diffrn_id' to DIFFRN_DETECTOR KEY.
+
+   + Add AXIS  category.
+
+   + Bring in complete DIFFRN_DETECTOR and DIFFRN_MEASUREMENT categories
+     from cif_mm.dic for clarity.
+
+   + Change '_array_structure.encoding_type' from type code to uline and
+     added X-Binary-Element-Type to MIME header.
+
+   + Add detector beam centre '_diffrn_detector_element.center[1]' and
+     '_diffrn_detector_element.center[2] '.
+
+   + Correct item name of '_diffrn_refln.frame_id '.
+
+   + Replace reference to '_array_intensities.undefined' by
+     '_array_intensities.undefined_value'.
+
+   + Replace references to '_array_intensity.scaling' with
+     '_array_intensities.scaling'.
+
+   + Add DIFFRN_SCAN ... categories.
+;
+
+
+   0.4   1998-08-11
+;
+   Modifications to the 0.3 imgCIF draft.  (HJB)
+
+   + Reflow comment lines over 80 characters and corrected typos.
+
+   + Update examples and descriptions of MIME encoded data.
+
+   + Change name to cbfext98.dic.
+;
+
+
+   0.3   1998-07-04
+;
+   Modifications for imgCIF.  (HJB)
+
+   + Add binary type, which is a text field containing a variant on
+     MIME encoded data.
+
+   + Change type of '_array_data.data' to binary and specify internal
+     structure of raw binary data.
+
+   + Add '_array_data.binary_id', and make
+     '_diffrn_frame_data.binary_id' and '_array_intensities.binary_id'
+     into pointers to this item.
+;
+
+
+   0.2   1997-12-02
+;
+   Modifications to the CBF draft.  (JW)
+
+   + Add category hierarchy for describing frame data developed from
+     discussions at the BNL imgCIF Workshop Oct 1997.   The following
+     changes are made in implementing the workshop draft.  Category
+     DIFFRN_array_data is renamed to DIFFRN_FRAME_DATA.  Category
+     DIFFRN_FRAME_TYPE is renamed to DIFFRN_DETECTOR_ELEMENT .   The
+     parent item for '_diffrn_frame_data.array_id' is changed from
+     '_array_structure_list.array_id' to '_array_structure.id'. Item
+     '_diffrn_detector.array_id' is deleted.
+   + Add data item '_diffrn_frame_data.binary_id' to identify data
+     groups within a binary section.  The formal identification of the
+     binary section is still fuzzy.
+;
+
+
+   0.1   1997-01-24
+;
+   First draft of this dictionary in DDL 2.1 compliant format by John
+   Westbrook (JW).  This version is adapted from the Crystallographic
+   Binary File (CBF) Format Draft Proposal provided by Andy Hammersley
+   (AH).
+
+   Modifications to the CBF draft.  (JW)
+
+   + In this version the array description has been cast in the categories
+     ARRAY_STRUCTURE and ARRAY_STRUCTURE_LIST.  These categories
+     have been generalized to describe array data  of arbitrary dimension.
+
+   + Array data in this description are contained in the category
+     ARRAY_DATA .  This departs from the CBF notion of data existing
+     in some special comment. In this description, data are handled as an
+     ordinary data item encapsulated in a character data type.   Although
+     data this manner deviates from CIF conventions, it does not violate
+     any DDL 2.1 rules.  DDL 2.1 regular expressions can be used to define
+     the binary representation which will permit some level of data
+     validation.  In this version, the placeholder type code "any" has
+     been used. This translates to a regular expression which will match
+     any pattern.
+
+     It should be noted that DDL 2.1 already supports array data objects
+     although these have not been used in the current mmCIF dictionary.
+     It may be possible to use the DDL 2.1 ITEM_STRUCTURE and
+     ITEM_STRUCTURE_LIST categories to provide the information that is
+     carried in by the ARRAY_STRUCTURE and ARRAY_STRUCTURE_LIST.  By
+     moving the array structure to the DDL level it would be possible to
+     define an array type as well as a regular expression defining the
+     data format.
+
+   + Multiple array sections can be properly handled within a single
+     datablock.
+;
+
+
+#-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof
+

--- a/doc/cif_img_1.8.7.dic
+++ b/doc/cif_img_1.8.7.dic
@@ -1971,7 +1971,7 @@ save__array_intensities.offset
 save__array_intensities.overload
     _item_description.description
 ;             The saturation intensity level for this data array, i.e. the
-              value above which correct intensities may not be recorded.
+              value at or above which correct intensities may not be recorded.
 
               The valid pixel values are those less than
               _array_intensities.overload  and greater than or equal to
@@ -10954,7 +10954,7 @@ save__diffrn_frame_data.details
 
     1.8.7    2022-12-31
 
-;   Start of new version
+;   Clarify overload (ab)
 
 ;
 

--- a/doc/cif_img_1.8.7.html
+++ b/doc/cif_img_1.8.7.html
@@ -1,6 +1,6 @@
 <HTML>
 <HEAD>
-<TITLE>cif_img.dic v1.8.6</TITLE>
+<TITLE>cif_img.dic v1.8.7</TITLE>
 <script type="text/javascript">
     function open_close(id) {
         var display = document.getElementById(id).style.display;
@@ -198,7 +198,7 @@ data_cif_img.dic
 #             and Crystallographic Binary File Dictionary (CBF)              #
 #            Extending the Macromolecular CIF Dictionary (mmCIF)             #
 #                                                                            #
-#                              Version 1.8.6                                 #
+#                              Version 1.8.7                                 #
 #                              of 2022-05-11                                 #
 #<a href="javascript:;" onclick="open_all();"><tt>++</tt></a>/<a href="javascript:;" onclick="close_all();"><tt>--</tt></a>                                                                       #
 <a href="javascript:;"  onclick="open_close('title1');" ><tt>#+/-</tt></a>                                                                         #
@@ -1362,7 +1362,7 @@ data_cif_img.dic
 </table></font></div>
 ;
     _dictionary.title           cif_img.dic
-    _dictionary.version         1.8.6
+    _dictionary.version         1.8.7
     _dictionary.datablock_id    cif_img.dic
 
 #########################
@@ -12626,6 +12626,12 @@ save_<a name="_diffrn_frame_data.details" >_diffrn_frame_data.details</a>
     _dictionary_history.version
     _dictionary_history.update
     _dictionary_history.revision
+
+    1.8.7    2022-12-31
+
+;   Start of new version
+
+;
 
     1.8.6    2022-05-11
 

--- a/doc/cif_img_1.8.7.html
+++ b/doc/cif_img_1.8.7.html
@@ -2771,7 +2771,7 @@ save_<a name="_array_intensities.offset" >_array_intensities.offset</a>
 save_<a name="_array_intensities.overload" >_array_intensities.overload</a>
     _item_description.description
 ;             The saturation intensity level for this data array, i.e. the
-              value above which correct intensities may not be recorded.
+              value at or above which correct intensities may not be recorded.
 
               The valid pixel values are those less than
               <a href="#_array_intensities.overload" >_array_intensities.overload</a> and greater than or equal to 
@@ -12629,7 +12629,7 @@ save_<a name="_diffrn_frame_data.details" >_diffrn_frame_data.details</a>
 
     1.8.7    2022-12-31
 
-;   Start of new version
+;   Clarify overload (ab)
 
 ;
 

--- a/doc/cif_img_1.8.7.html
+++ b/doc/cif_img_1.8.7.html
@@ -1,0 +1,13412 @@
+<HTML>
+<HEAD>
+<TITLE>cif_img.dic v1.8.6</TITLE>
+<script type="text/javascript">
+    function open_close(id) {
+        var display = document.getElementById(id).style.display;
+        if (display == "block") {
+        document.getElementById(id).style.display = "none";
+        }
+        else {
+        document.getElementById(id).style.display = "block";
+        }
+    }
+    function set_block_open(id) {
+        var display = document.getElementById(id).style.display;
+        if (display != "block") {
+        document.getElementById(id).style.display = "block";
+        }
+    }
+    function set_block_close(id) {
+        var display = document.getElementById(id).style.display;
+        if (display == "block") {
+        document.getElementById(id).style.display = "none";
+        }
+    }
+    function open_close2(id,idalt) {
+        var display = document.getElementById(id).style.display;
+        if (display == "block") {
+        document.getElementById(id).style.display = "none";
+        document.getElementById(idalt).style.display = "block";
+        }
+        else {
+        document.getElementById(id).style.display = "block";
+        document.getElementById(idalt).style.display = "none";
+        }
+    }
+    function set_block_open2(id,idalt) {
+        var display = document.getElementById(id).style.display;
+        if (display != "block") {
+        document.getElementById(id).style.display = "block";
+        document.getElementById(idalt).style.display = "none";
+        }
+    }
+    function set_block_close2(id,idalt) {
+        var display = document.getElementById(id).style.display;
+        if (display == "block") {
+        document.getElementById(id).style.display = "none";
+        document.getElementById(idalt).style.display = "block";
+        }
+    }
+    function open_all() {
+      set_block_open('title1');
+      set_block_open('contents_array_data');
+      set_block_open('contents_array_element_size');
+      set_block_open('contents_array_intensities');
+      set_block_open('contents_array_structure');
+      set_block_open('contents_array_structure_list');
+      set_block_open('contents_array_structure_list_section');
+      set_block_open('contents_array_structure_list_axis');
+      set_block_open('contents_axis');
+      set_block_open('contents_diffrn_data_frame');
+      set_block_open('contents_diffrn_detector');
+      set_block_open('contents_diffrn_detector_axis');
+      set_block_open('contents_diffrn_detector_element');
+      set_block_open('contents_diffrn_measurement');
+      set_block_open('contents_diffrn_measurement_axis');
+      set_block_open('contents_diffrn_radiation');
+      set_block_open('contents_diffrn_refln');
+      set_block_open('contents_diffrn_scan');
+      set_block_open('contents_diffrn_scan_axis');
+      set_block_open('contents_diffrn_scan_collection');
+      set_block_open('contents_diffrn_scan_frame');
+      set_block_open('contents_diffrn_scan_frame_axis');
+      set_block_open('contents_diffrn_scan_frame_monitor');
+      set_block_open('contents_map');
+      set_block_open('contents_map_segment');
+      set_block_open('contents_variant');
+      set_block_open('contents_deprecated');
+      set_block_open('axis_category_imgcif');
+      set_block_open('axis_category_mcstas');
+      set_block_open('axis_category_frac');
+      set_block_open('axis_category_real');
+      set_block_open('axis_category_recip');
+      set_block_open2('online_NX_array_data','print_NX_array_data');
+      set_block_open2('online_NX_array_element_size','print_NX_array_element_size');
+      set_block_open2('online_NX_array_intensities','print_NX_array_intensities');
+      set_block_open2('online_NX_array_structure','print_NX_array_structure');
+      set_block_open2('online_NX_array_structure_list','print_NX_array_structure_list');
+      set_block_open2('online_NX_array_structure_list_section','print_NX_array_structure_list_section');
+      set_block_open2('online_NX_array_structure_list_axis','print_NX_array_structure_list_axis');
+      set_block_open2('online_NX_axis','print_NX_axis');
+      set_block_open2('online_NX_diffrn_data_frame','print_NX_diffrn_data_frame');
+      set_block_open2('online_NX_diffrn_detector','print_NX_diffrn_detector');
+      set_block_open2('online_NX_diffrn_detector_axis','print_NX_diffrn_detector_axis');
+      set_block_open2('online_NX_diffrn_detector_element','print_NX_diffrn_detector_element');
+      set_block_open2('online_NX_diffrn_measurement','print_NX_diffrn_measurement');
+      set_block_open2('online_NX_diffrn_measurement_axis','print_NX_diffrn_measurement_axis');
+      set_block_open2('online_NX_diffrn_radiation','print_NX_diffrn_radiation');
+      set_block_open2('online_NX_diffrn_refln','print_NX_diffrn_refln');
+      set_block_open2('online_NX_diffrn_scan','print_NX_diffrn_scan');
+      set_block_open2('online_NX_diffrn_scan_axis','print_NX_diffrn_scan_axis');
+      set_block_open2('online_NX_diffrn_scan_collection','print_NX_diffrn_scan_collection');
+      set_block_open2('online_NX_diffrn_scan_frame','print_NX_diffrn_scan_frame');
+      set_block_open2('online_NX_diffrn_scan_frame_axis','print_NX_diffrn_scan_frame_axis');
+      set_block_open2('online_NX_diffrn_scan_frame_monitor','print_NX_diffrn_scan_frame_monitor');
+      set_block_open2('online_NX_diffrn_scan_frame_monitor','print_NX_diffrn_scan_frame_monitor');
+    }
+    function close_all() {
+      set_block_close('title1');
+      set_block_close('contents_array_data');
+      set_block_close('contents_array_data_external_data');
+      set_block_close('contents_array_element_size');
+      set_block_close('contents_array_intensities');
+      set_block_close('contents_array_structure');
+      set_block_close('contents_array_structure_list');
+      set_block_close('contents_array_structure_list_section');
+      set_block_close('contents_array_structure_list_axis');
+      set_block_close('contents_axis');
+      set_block_close('contents_diffrn_data_frame');
+      set_block_close('contents_diffrn_detector');
+      set_block_close('contents_diffrn_detector_axis');
+      set_block_close('contents_diffrn_detector_element');
+      set_block_close('contents_diffrn_measurement');
+      set_block_close('contents_diffrn_measurement_axis');
+      set_block_close('contents_diffrn_radiation');
+      set_block_close('contents_diffrn_refln');
+      set_block_close('contents_diffrn_scan');
+      set_block_close('contents_diffrn_scan_axis');
+      set_block_close('contents_diffrn_scan_collection');
+      set_block_close('contents_diffrn_scan_frame');
+      set_block_close('contents_diffrn_scan_frame_axis');
+      set_block_close('contents_diffrn_scan_frame_monitor');
+      set_block_close('contents_map');
+      set_block_close('contents_map_segment');
+      set_block_close('contents_variant');
+      set_block_close('contents_deprecated');
+      set_block_close('axis_category_imgcif');
+      set_block_close('axis_category_mcstas');
+      set_block_close('axis_category_frac');
+      set_block_close('axis_category_real');
+      set_block_close('axis_category_recip');
+      set_block_close2('online_NX_array_data','print_NX_array_data');
+      set_block_close2('online_NX_array_element_size','print_NX_array_element_size');
+      set_block_close2('online_NX_array_intensities','print_NX_array_intensities');
+      set_block_close2('online_NX_array_structure','print_NX_array_structure');
+      set_block_close2('online_NX_array_structure_list','print_NX_array_structure_list');
+      set_block_close2('online_NX_array_structure_list_section','print_NX_array_structure_list_section');
+      set_block_close2('online_NX_array_structure_list_axis','print_NX_array_structure_list_axis');
+      set_block_close2('online_NX_axis','print_NX_axis');
+      set_block_close2('online_NX_diffrn_data_frame','print_NX_diffrn_data_frame');
+      set_block_close2('online_NX_diffrn_detector','print_NX_diffrn_detector');
+      set_block_close2('online_NX_diffrn_detector_axis','print_NX_diffrn_detector_axis');
+      set_block_close2('online_NX_diffrn_detector_element','print_NX_diffrn_detector_element');
+      set_block_close2('online_NX_diffrn_measurement','print_NX_diffrn_measurement');
+      set_block_close2('online_NX_diffrn_measurement_axis','print_NX_diffrn_measurement_axis');
+      set_block_close2('online_NX_diffrn_radiation','print_NX_diffrn_radiation');
+      set_block_close2('online_NX_diffrn_refln','print_NX_diffrn_refln');
+      set_block_close2('online_NX_diffrn_scan','print_NX_diffrn_scan');
+      set_block_close2('online_NX_diffrn_scan_axis','print_NX_diffrn_scan_axis');
+      set_block_close2('online_NX_diffrn_scan_collection','print_NX_diffrn_scan_collection');
+      set_block_close2('online_NX_diffrn_scan_frame','print_NX_diffrn_scan_frame');
+      set_block_close2('online_NX_diffrn_scan_frame_axis','print_NX_diffrn_scan_frame_axis');
+      set_block_close2('online_NX_diffrn_scan_frame_monitor','print_NX_diffrn_scan_frame_monitor');
+      set_block_close2('online_NX_diffrn_scan_frame_monitor','print_NX_diffrn_scan_frame_monitor');
+    }
+    
+</script>
+
+</HEAD>
+<body bgcolor="#FAFAFF" text="#0808A0"
+BACKGROUND="../html_graphics/cbflibbackground.jpg" onload="open_all()">
+<font color="#0808A0">
+<H1>
+# <a href="http://www.iucr.org/iucr-top/welcome.html">
+<img alt="[IUCr Home Page]" src="../html_graphics/iucrhome.jpg" ALIGN=MIDDLE></a>
+<a href="http://www.iucr.org/iucr-top/cif/home.html">
+<img alt="[CIF Home Page]" src="../html_graphics/cifhome.jpg" ALIGN=MIDDLE></a>
+<a href="cbf_definition_rev.html"><IMG SRC="../html_graphics/CBFbutton.jpg"
+ALT="[CBF/imgCIF]" ALIGN=MIDDLE></a>
+<a href="CBFlib.html"><IMG SRC="../html_graphics/cbflibbutton.jpg"
+ALT="[CBFlib]" ALIGN=MIDDLE></a> #
+</H1>
+<H1 ALIGN=CENTER>
+# <IMG  SRC="../html_graphics/CBFbig.jpg" ALIGN=MIDDLE ALT="imgCIF/CBF"> #
+</H1>
+<H1 ALIGN=CENTER># Extensions Dictionary #</H1>
+</font><font color="#000000">
+
+<PRE>
+data_cif_img.dic
+
+    _datablock.id               cif_img.dic
+    _datablock.description
+;
+##############################################################################
+#                                                                            #
+#                       Image CIF Dictionary (imgCIF)                        #
+#             and Crystallographic Binary File Dictionary (CBF)              #
+#            Extending the Macromolecular CIF Dictionary (mmCIF)             #
+#                                                                            #
+#                              Version 1.8.6                                 #
+#                              of 2022-05-11                                 #
+#<a href="javascript:;" onclick="open_all();"><tt>++</tt></a>/<a href="javascript:;" onclick="close_all();"><tt>--</tt></a>                                                                       #
+<a href="javascript:;"  onclick="open_close('title1');" ><tt>#+/-</tt></a>                                                                         #
+<div id="title1" style="display:none">#    ###################################################################     #
+#    # *** WARNING *** THIS IS A DRAFT FOR DISCUSSION *** WARNING ***  #     #
+#    #                 SUBJECT TO CHANGE WITHOUT NOTICE                #     #
+#    #       SEND COMMENTS TO imgcif-l@iucr.org CITING THE VERSION     #     #
+#    ###################################################################     #
+#            This draft edited by B. McMahon and H. J. Bernstein             #
+#                                                                            #
+#     by Andrew P. Hammersley, Herbert J. Bernstein and John D. Westbrook    #
+#                                                                            #
+# This dictionary was adapted from a format discussed at the imgCIF Workshop #
+# held at BNL Oct 1997 and the Crystallographic Binary File Format Draft     #
+# Proposal by Andrew Hammersley.  The first DDL 2.1 Version was created by   #
+# John Westbrook.  This version is being prepared in support of the 2021     #
+# revisions to ITVG, and was drafted by Herbert J. Bernstein and             #
+# incorporates comments by James Hester, I. David Brown, John Westbrook,     #
+# Brian McMahon, Bob Sweet, Paul Ellis, Harry Powell, Wilfred Li,            #
+# Gotzon Madariaga, Frances C. Bernstein, Chris Nielsen, Nicola Ashcroft and #
+# others and reflects comments in                                            #
+# Bernstein, H. J., Foerster, A., Bhowmick, A., Brewster, A. S.,             #
+# Brockhauser, S., Gelisio, L., Hall, D. R., Leonarski, F., Mariani, V.,     #
+# Santoni, G., Vonrhein, C. & Winter, G. (2020). "Gold Standard for          #
+# Macromolecular Crystallography Diffraction Data", IUCrJ, 7, 784--792,      #
+# <a href=https://doi.org/10.1107/S2052252520008672>https://doi.org/10.1107/S2052252520008672</a>,                                 #
+# <a href=https://doi.org//10.1107/S2052252520008672/ti5018sup1.pdf>https://doi.org//10.1107/S2052252520008672/ti5018sup1.pdf</a>,                 #
+# <a href=https://doi.org//10.1107/S2052252520008672/ti5018sup2.pdf>https://doi.org//10.1107/S2052252520008672/ti5018sup2.pdf</a>                  #
+</div>##############################################################################
+#    CONTENTS
+#
+#        <a href="#CATEGORY_GROUP_LIST">CATEGORY_GROUP_LIST</a>
+#        <a href="#SUB_CATEGORY">SUB_CATEGORY</a>
+#
+#        category  <a href="#array_data">ARRAY_DATA</a> <a href="javascript:open_close('contents_array_data');">+/-</a>
+<div id="contents_array_data" style="display:none">#
+#                  <a href="#_array_data.array_id" >_array_data.array_id</a>
+#                  <a href="#_array_data.binary_id" >_array_data.binary_id</a>
+#                  <a href="#_array_data.data" >_array_data.data</a>
+#                  <a href="#_array_data.external_data_id" >_array_data.external_data_id</a>
+#                  <a href="#_array_data.header_contents" >_array_data.header_contents</a>
+#                  <a href="#_array_data.header_convention" >_array_data.header_convention</a>
+#                  <a href="#_array_data.variant" >_array_data.variant</a>
+#
+</div>#        category  <a href="#array_data_external_data">ARRAY_DATA_EXTERNAL_DATA</a> <a href="javascript:open_close('contents_array_data_external_data');">+/-</a>
+<div id="contents_array_data_external_data" style="display:none">#
+#                  <a href="#_array_data_external_data.archive_format" >_array_data_external_data.archive_format</a>
+#                  <a href="#_array_data_external_data.archive_path" >_array_data_external_data.archive_path</a>
+#                  <a href="#_array_data_external_data.format" >_array_data_external_data.format</a>
+#                  <a href="#_array_data_external_data.frame" >_array_data_external_data.frame</a>
+#                  <a href="#_array_data_external_data.id" >_array_data_external_data.id</a>
+#                  <a href="#_array_data_external_data.path" >_array_data_external_data.path</a>
+#                  <a href="#_array_data_external_data.uri" >_array_data_external_data.uri</a>
+#                  <a href="#_array_data_external_data.variant" >_array_data_external_data.variant</a>
+#                  <a href="#_array_data_external_data.version" >_array_data_external_data.version</a>
+#
+</div>#        category  <a href="#array_element_size">ARRAY_ELEMENT_SIZE</a> <a href="javascript:open_close('contents_array_element_size');">+/-</a>
+<div id="contents_array_element_size" style="display:none">#
+#                  <a href="#_array_element_size.array_id" >_array_element_size.array_id</a>
+#                  <a href="#_array_element_size.index" >_array_element_size.index</a>
+#                  <a href="#_array_element_size.size" >_array_element_size.size</a>
+#                  <a href="#_array_element_size.variant" >_array_element_size.variant</a>
+#
+</div>#        category  <a href="#array_intensities">ARRAY_INTENSITIES</a> <a href="javascript:open_close('contents_array_intensities');">+/-</a>
+<div id="contents_array_intensities" style="display:none">#
+#                  <a href="#_array_intensities.array_id" >_array_intensities.array_id</a>
+#                  <a href="#_array_intensities.binary_id" >_array_intensities.binary_id</a>
+#                  <a href="#_array_intensities.details" >_array_intensities.details</a>
+#                  <a href="#_array_intensities.gain" >_array_intensities.gain</a>
+#                  <a href="#_array_intensities.gain_esd" >_array_intensities.gain_esd</a>
+#                  <a href="#_array_intensities.linearity" >_array_intensities.linearity</a>
+#                  <a href="#_array_intensities.offset" >_array_intensities.offset</a>
+#                  <a href="#_array_intensities.overload" >_array_intensities.overload</a>
+#                  <a href="#_array_intensities.pixel_fast_bin_size" >_array_intensities.pixel_fast_bin_size</a>
+#                  <a href="#_array_intensities.pixel_slow_bin_size" >_array_intensities.pixel_slow_bin_size</a>
+#                  <a href="#_array_intensities.pixel_binning_method" >_array_intensities.pixel_binning_method</a>
+#                  <a href="#_array_intensities.scaling" >_array_intensities.scaling</a>
+#                  <a href="#_array_intensities.undefined_value" >_array_intensities.undefined_value</a>
+#                  <a href="#_array_intensities.underload" >_array_intensities.underload</a>
+#                  <a href="#_array_intensities.variant" >_array_intensities.variant</a>
+#
+</div>#        category  <a href="#array_structure">ARRAY_STRUCTURE</a> <a href="javascript:open_close('contents_array_structure');">+/-</a>
+<div id="contents_array_structure" style="display:none">#
+#                  <a href="#_array_structure.byte_order" >_array_structure.byte_order</a>
+#                  <a href="#_array_structure.compression_type" >_array_structure.compression_type</a>
+#                  <a href="#_array_structure.compression_type_flag" >_array_structure.compression_type_flag</a>
+#                  <a href="#_array_structure.encoding_type" >_array_structure.encoding_type</a>
+#                  <a href="#_array_structure.id" >_array_structure.id</a>
+#                  <a href="#_array_structure.variant" >_array_structure.variant</a>
+#
+</div>#        category  <a href="#array_structure_list">ARRAY_STRUCTURE_LIST</a> <a href="javascript:open_close('contents_array_structure_list');">+/-</a>
+<div id="contents_array_structure_list" style="display:none">#
+#                  <a href="#_array_structure_list.axis_set_id" >_array_structure_list.axis_set_id</a>
+#                  <a href="#_array_structure_list.array_id" >_array_structure_list.array_id</a>
+#                  <a href="#_array_structure_list.array_section_id" >_array_structure_list.array_section_id</a>
+#                  <a href="#_array_structure_list.dimension" >_array_structure_list.dimension</a>
+#                  <a href="#_array_structure_list.direction" >_array_structure_list.direction</a>
+#                  <a href="#_array_structure_list.index" >_array_structure_list.index</a>
+#                  <a href="#_array_structure_list.precedence" >_array_structure_list.precedence</a>
+#                  <a href="#_array_structure_list.variant" >_array_structure_list.variant</a>
+#
+</div>#        category  <a href="#array_structure_list_section">ARRAY_STRUCTURE_LIST_SECTION</a> <a href="javascript:open_close('contents_array_structure_list_section');">+/-</a>
+<div id="contents_array_structure_list_section" style="display:none">#
+#                  <a href="#_array_structure_list_section.array_id" >_array_structure_list_section.array_id</a>
+#                  <a href="#_array_structure_list_section.end" >_array_structure_list_section.end</a>
+#                  <a href="#_array_structure_list_section.id" >_array_structure_list_section.id</a>
+#                  <a href="#_array_structure_list_section.index" >_array_structure_list_section.index</a>
+#                  <a href="#_array_structure_list_section.start" >_array_structure_list_section.start</a>
+#                  <a href="#_array_structure_list_section.stride" >_array_structure_list_section.stride</a>
+#                  <a href="#_array_structure_list_section.variant" >_array_structure_list_section.variant</a>
+#
+</div>#        category  <a href="#array_structure_list_axis">ARRAY_STRUCTURE_LIST_AXIS</a> <a href="javascript:open_close('contents_array_structure_list_axis');">+/-</a>
+<div id="contents_array_structure_list_axis" style="display:none">#
+#                  <a href="#_array_structure_list_axis.axis_id" >_array_structure_list_axis.axis_id</a>
+#                  <a href="#_array_structure_list_axis.axis_set_id" >_array_structure_list_axis.axis_set_id</a>
+#                  <a href="#_array_structure_list_axis.angle" >_array_structure_list_axis.angle</a>
+#                  <a href="#_array_structure_list_axis.angle_increment" >_array_structure_list_axis.angle_increment</a>
+#                  <a href="#_array_structure_list_axis.angular_pitch" >_array_structure_list_axis.angular_pitch</a>
+#                  <a href="#_array_structure_list_axis.displacement" >_array_structure_list_axis.displacement</a>
+#                  <a href="#_array_structure_list_axis.displacement_increment" >_array_structure_list_axis.displacement_increment</a>
+#                  <a href="#_array_structure_list_axis.fract_displacement" >_array_structure_list_axis.fract_displacement</a>
+#                  <a href="#_array_structure_list_axis.fract_displacement_increment" >_array_structure_list_axis.fract_displacement_increment</a>
+#                  <a href="#_array_structure_list_axis.radial_pitch" >_array_structure_list_axis.radial_pitch</a>
+#                  <a href="#_array_structure_list_axis.reference_angle" >_array_structure_list_axis.reference_angle</a>
+#                  <a href="#_array_structure_list_axis.reference_displacement" >_array_structure_list_axis.reference_displacement</a>
+#                  <a href="#_array_structure_list_axis.variant" >_array_structure_list_axis.variant</a>
+#
+</div>#        category  <a href="#axis">AXIS</a> <a href="javascript:open_close('contents_axis');">+/-</a>
+<div id="contents_axis" style="display:none">#
+#                  <a href="#_axis.depends_on" >_axis.depends_on</a>
+#                  <a href="#_axis.equipment" >_axis.equipment</a>
+#                  <a href="#_axis.equipment_component" >_axis.equipment_component</a>
+#                  <a href="#_axis.id" >_axis.id</a></a>
+#                  <a href="#_axis.offset[1]" >_axis.offset[1]</a>
+#                  <a href="#_axis.offset[2]" >_axis.offset[2]</a>
+#                  <a href="#_axis.offset[3]" >_axis.offset[3]</a>
+#                  <a href="#_axis.rotation" >_axis.rotation</a>
+#                  <a href="#_axis.rotation_axis" >_axis.rotation_axis</a>
+#                  <a href="#_axis.type" >_axis.type</a>
+#                  <a href="#_axis.system" >_axis.system</a>
+#                  <a href="#_axis.vector[1]" >_axis.vector[1]</a>
+#                  <a href="#_axis.vector[2]" >_axis.vector[2]</a>
+#                  <a href="#_axis.vector[3]" >_axis.vector[3]</a>
+#                  <a href="#_axis.variant" >_axis.variant</a>
+#
+</div>#        category  <a href="#diffrn_data_frame">DIFFRN_DATA_FRAME</a> <a href="javascript:open_close('contents_diffrn_data_frame');">+/-</a>
+<div id="contents_diffrn_data_frame" style="display:none">#
+#                  <a href="#_diffrn_data_frame.array_id" >_diffrn_data_frame.array_id</a>
+#                  <a href="#_diffrn_data_frame.array_section_id" >_diffrn_data_frame.array_section_id</a>
+#                  <a href="#_diffrn_data_frame.binary_id" >_diffrn_data_frame.binary_id</a>
+#                  <a href="#_diffrn_data_frame.center_fast" >_diffrn_data_frame.center_fast</a>
+#                  <a href="#_diffrn_data_frame.center_slow" >_diffrn_data_frame.center_slow</a>
+#                  <a href="#_diffrn_data_frame.center_units" >_diffrn_data_frame.center_units</a>
+#                  <a href="#_diffrn_data_frame.detector_element_id" >_diffrn_data_frame.detector_element_id</a>
+#                  <a href="#_diffrn_data_frame.id" >_diffrn_data_frame.id</a>
+#                  <a href="#_diffrn_data_frame.details">_diffrn_data_frame.details</a>
+#                  <a href="#_diffrn_data_frame.variant">_diffrn_data_frame.variant</a>
+#
+</div>#        category  <a href="#diffrn_detector">DIFFRN_DETECTOR</a> <a href="javascript:open_close('contents_diffrn_detector');">+/-</a>
+<div id="contents_diffrn_detector" style="display:none">#
+#                  <a href="#_diffrn_detector.details" >_diffrn_detector.details</a>
+#                  <a href="#_diffrn_detector.detector" >_diffrn_detector.detector</a>
+#                  <a href="#_diffrn_detector.diffrn_id" >_diffrn_detector.diffrn_id</a>
+#                  <a href="#_diffrn_detector.dtime" >_diffrn_detector.dtime</a>
+#                  <a href="#_diffrn_detector.gain_setting" >_diffrn_detector.gain_setting</a>
+#                  <a href="#_diffrn_detector.id" >_diffrn_detector.id</a>
+#                  <a href="#_diffrn_detector.layer_thickness" >_diffrn_detector.layer_thickness</a>
+#                  <a href="#_diffrn_detector.number_of_axes" >_diffrn_detector.number_of_axes</a>
+#                  <a href="#_diffrn_detector.type" >_diffrn_detector.type</a>
+#                  <a href="#_diffrn_detector.variant" >_diffrn_detector.variant</a>
+#
+</div>#        category  <a href="#diffrn_detector_axis">DIFFRN_DETECTOR_AXIS</a> <a href="javascript:open_close('contents_diffrn_detector_axis');">+/-</a>
+<div id="contents_diffrn_detector_axis" style="display:none">#
+#                  <a href="#_diffrn_detector_axis.axis_id" >_diffrn_detector_axis.axis_id</a>
+#                  <a href="#_diffrn_detector_axis.detector_id" >_diffrn_detector_axis.detector_id</a>
+#                  <a href="#_diffrn_detector_axis.variant" >_diffrn_detector_axis.variant</a>
+#
+</div>#        category  <a href="#diffrn_detector_element">DIFFRN_DETECTOR_ELEMENT</a> <a href="javascript:open_close('contents_diffrn_detector_element');">+/-</a>
+<div id="contents_diffrn_detector_element" style="display:none">#
+#                  <a href="#_diffrn_detector_element.id" >_diffrn_detector_element.id</a>
+#                  <a href="#_diffrn_detector_element.detector_id" >_diffrn_detector_element.detector_id</a>
+#                  <a href="#_diffrn_detector_element.reference_center_fast" >_diffrn_detector_element.reference_center_fast</a>
+#                  <a href="#_diffrn_detector_element.reference_center_slow" >_diffrn_detector_element.reference_center_slow</a>
+#                  <a href="#_diffrn_detector_element.reference_center_units" >_diffrn_detector_element.reference_center_units</a>
+#                  <a href="#_diffrn_detector_element.variant" >_diffrn_detector_element.variant</a>
+#
+</div>#        category  <a href="#diffrn_measurement">DIFFRN_MEASUREMENT</a> <a href="javascript:open_close('contents_diffrn_measurement');">+/-</a>
+<div id="contents_diffrn_measurement" style="display:none">#
+#                  <a href="#_diffrn_measurement.diffrn_id" >_diffrn_measurement.diffrn_id</a>
+#                  <a href="#_diffrn_measurement.details" >_diffrn_measurement.details</a>
+#                  <a href="#_diffrn_measurement.device" >_diffrn_measurement.device</a>
+#                  <a href="#_diffrn_measurement.device_details" >_diffrn_measurement.device_details</a>
+#                  <a href="#_diffrn_measurement.device_type" >_diffrn_measurement.device_type</a>
+#                  <a href="#_diffrn_measurement.id" >_diffrn_measurement.id</a>
+#                  <a href="#_diffrn_measurement.method" >_diffrn_measurement.method</a>
+#                  <a href="#_diffrn_measurement.number_of_axes" >_diffrn_measurement.number_of_axes</a>
+#                  <a href="#_diffrn_measurement.sample_detector_distance" >_diffrn_measurement.sample_detector_distance</a>
+#                  <a href="#_diffrn_measurement.sample_detector_voffset" >_diffrn_measurement.sample_detector_voffset</a>
+#                  <a href="#_diffrn_measurement.specimen_support" >_diffrn_measurement.specimen_support</a>
+#                  <a href="#_diffrn_measurement.variant" >_diffrn_measurement.variant</a>
+#
+</div>#        category  <a href="#diffrn_measurement_axis">DIFFRN_MEASUREMENT_AXIS</a> <a href="javascript:open_close('contents_diffrn_measurement_axis');">+/-</a>
+<div id="contents_diffrn_measurement_axis" style="display:none">#
+#                  <a href="#_diffrn_measurement_axis.id" >_diffrn_measurement_axis.axis_id</a>
+#                  <a href="#_diffrn_measurement_axis.measurement_device" >_diffrn_measurement_axis.measurement_device</a>
+#                  <a href="#_diffrn_measurement_axis.measurement_id" >_diffrn_measurement_axis.measurement_id</a>
+#                  <a href="#_diffrn_measurement_axis.variant" >_diffrn_measurement_axis.variant</a>
+#
+</div>#        category  <a href="#diffrn_radiation">DIFFRN_RADIATION</a> <a href="javascript:open_close('contents_diffrn_radiation');">+/-</a>
+<div id="contents_diffrn_radiation" style="display:none">#
+#                  <a href="#_diffrn_radiation.beam_width">_diffrn_radiation.beam_width</a>
+#                  <a href="#_diffrn_radiation.beam_height">_diffrn_radiation.beam_height</a>
+#                  <a href="#_diffrn_radiation.beam_flux">_diffrn_radiation.beam_flux</a>
+#                  <a href="#_diffrn_radiation.collimation">_diffrn_radiation.collimation</a>
+#                  <a href="#_diffrn_radiation.diffrn_id">_diffrn_radiation.diffrn_id</a>
+#                  <a href="#_diffrn_radiation.div_x_source" >_diffrn_radiation.div_x_source</a>
+#                  <a href="#_diffrn_radiation.div_y_source" >_diffrn_radiation.div_y_source</a>
+#                  <a href="#_diffrn_radiation.div_x_y_source" >_diffrn_radiation.div_x_y_source</a>
+#                  <a href="#_diffrn_radiation.filter_edge">_diffrn_radiation.filter_edge</a>
+#                  <a href="#_diffrn_radiation.inhomogeneity">_diffrn_radiation.inhomogeneity</a>
+#                  <a href="#_diffrn_radiation.monochromator">_diffrn_radiation.monochromator</a>
+#                  <a href="#_diffrn_radiation.polarisn_norm">_diffrn_radiation.polarisn_norm</a>
+#                  <a href="#_diffrn_radiation.polarisn_ratio">_diffrn_radiation.polarisn_ratio</a>
+#                  <a href="#_diffrn_radiation.polarisn_norm_esd">_diffrn_radiation.polarisn_norm_esd</a>
+#                  <a href="#_diffrn_radiation.polarisn_ratio_esd">_diffrn_radiation.polarisn_ratio_esd</a>
+#                  <a href="#_diffrn_radiation.polarizn_source_norm" >_diffrn_radiation.polarizn_source_norm</a>
+#                  <a href="#_diffrn_radiation.polarizn_source_norm_esd" >_diffrn_radiation.polarizn_source_norm_esd</a>
+#                  <a href="#_diffrn_radiation.polarizn_source_ratio" >_diffrn_radiation.polarizn_source_ratio</a>
+#                  <a href="#_diffrn_radiation.polarizn_source_ratio_esd" >_diffrn_radiation.polarizn_source_ratio_esd</a>
+#                  <a href="#_diffrn_radiation.polarizn_Stokes_I">_diffrn_radiation.polarizn_Stokes_I</a>
+#                  <a href="#_diffrn_radiation.polarizn_Stokes_Q">_diffrn_radiation.polarizn_Stokes_Q</a>
+#                  <a href="#_diffrn_radiation.polarizn_Stokes_U">_diffrn_radiation.polarizn_Stokes_U</a>
+#                  <a href="#_diffrn_radiation.polarizn_Stokes_V">_diffrn_radiation.polarizn_Stokes_V</a>
+#                  <a href="#_diffrn_radiation.polarizn_Stokes_I_esd">_diffrn_radiation.polarizn_Stokes_I_esd</a>
+#                  <a href="#_diffrn_radiation.polarizn_Stokes_Q_esd">_diffrn_radiation.polarizn_Stokes_Q_esd</a>
+#                  <a href="#_diffrn_radiation.polarizn_Stokes_U_esd">_diffrn_radiation.polarizn_Stokes_U_esd</a>
+#                  <a href="#_diffrn_radiation.polarizn_Stokes_V_esd">_diffrn_radiation.polarizn_Stokes_V_esd</a>
+#                  <a href="#_diffrn_radiation.probe">_diffrn_radiation.probe</a>
+#                  <a href="#_diffrn_radiation.type">_diffrn_radiation.type</a>
+#                  <a href="#_diffrn_radiation.variant">_diffrn_radiation.variant</a>
+#                  <a href="#_diffrn_radiation.wavelength_id">_diffrn_radiation.wavelength_id</a>
+#                  <a href="#_diffrn_radiation.xray_symbol">_diffrn_radiation.xray_symbol</a>
+#
+</div>#        category  <a href="#diffrn_refln">DIFFRN_REFLN</a> <a href="javascript:open_close('contents_diffrn_refln');">+/-</a>
+<div id="contents_diffrn_refln" style="display:none">#
+#                  <a href="#_diffrn_refln.frame_id" >_diffrn_refln.frame_id</a>
+#                  <a href="#_diffrn_refln.variant" >_diffrn_refln.variant</a>
+#
+</div>#        category  <a href="#diffrn_scan">DIFFRN_SCAN</a> <a href="javascript:open_close('contents_diffrn_scan');">+/-</a>
+<div id="contents_diffrn_scan" style="display:none">#
+#                  <a href="#_diffrn_scan.id" >_diffrn_scan.id</a>
+#                  <a href="#_diffrn_scan.date_end" >_diffrn_scan.date_end</a>
+#                  <a href="#_diffrn_scan.date_end_estimated" >_diffrn_scan.date_end_estimated</a>
+#                  <a href="#_diffrn_scan.date_start" >_diffrn_scan.date_start</a>
+#                  <a href="#_diffrn_scan.integration_time" >_diffrn_scan.integration_time</a>
+#                  <a href="#_diffrn_scan.frame_id_start" >_diffrn_scan.frame_id_start</a>
+#                  <a href="#_diffrn_scan.frame_id_end" >_diffrn_scan.frame_id_end</a>
+#                  <a href="#_diffrn_scan.frames" >_diffrn_scan.frames</a>
+#                  <a href="#_diffrn_scan.time_period" >_diffrn_scan.time_period</a>
+#                  <a href="#_diffrn_scan.time_rstrt_incr" >_diffrn_scan.time_rstrt_incr</a>
+#                  <a href="#_diffrn_scan.variant" >_diffrn_scan.variant</a>
+#
+</div>#        category  <a href="#diffrn_scan_axis">DIFFRN_SCAN_AXIS</a> <a href="javascript:open_close('contents_diffrn_scan_axis');">+/-</a>
+<div id="contents_diffrn_scan_axis" style="display:none">#
+#                  <a href="#_diffrn_scan_axis.axis_id" >_diffrn_scan_axis.axis_id</a>
+#                  <a href="#_diffrn_scan_axis.angle_start" >_diffrn_scan_axis.angle_start</a>
+#                  <a href="#_diffrn_scan_axis.angle_range" >_diffrn_scan_axis.angle_range</a>
+#                  <a href="#_diffrn_scan_axis.angle_increment" >_diffrn_scan_axis.angle_increment</a>
+#                  <a href="#_diffrn_scan_axis.angle_rstrt_incr" >_diffrn_scan_axis.angle_rstrt_incr</a>
+#                  <a href="#_diffrn_scan_axis.displacement_start" >_diffrn_scan_axis.displacement_start</a>
+#                  <a href="#_diffrn_scan_axis.displacement_range" >_diffrn_scan_axis.displacement_range</a>
+#                  <a href="#_diffrn_scan_axis.displacement_increment" >_diffrn_scan_axis.displacement_increment</a>
+#                  <a href="#_diffrn_scan_axis.displacement_rstrt_incr" >_diffrn_scan_axis.displacement_rstrt_incr</a>
+#                  <a href="#_diffrn_scan_axis.reference_angle" >_diffrn_scan_axis.reference_angle</a>
+#                  <a href="#_diffrn_scan_axis.reference_displacement" >_diffrn_scan_axis.reference_displacement</a>
+#                  <a href="#_diffrn_scan_axis.scan_id" >_diffrn_scan_axis.scan_id</a>
+#                  <a href="#_diffrn_scan_axis.variant" >_diffrn_scan_axis.variant</a>
+#
+</div>#        category  <a href="#diffrn_scan_collection">DIFFRN_SCAN_COLLECTION</a> <a href="javascript:open_close('contents_diffrn_scan_collection');">+/-</a>
+<div id="contents_diffrn_scan_collection" style="display:none">#
+#                  <a href="#_diffrn_scan_collection.details" >_diffrn_scan_collection.details</a>
+#                  <a href="#_diffrn_scan_collection.scan_id" >_diffrn_scan_collection.scan_id</a>
+#                  <a href="#_diffrn_scan_collection.type" >_diffrn_scan_collection.type</a>
+#                  <a href="#_diffrn_scan_collection.translation_width" >_diffrn_scan_collection.translation_width</a>
+#                  <a href="#_diffrn_scan_collection.variant" >_diffrn_scan_collection.variant</a>
+#
+</div>#        category  <a href="#diffrn_scan_frame">DIFFRN_SCAN_FRAME</a> <a href="javascript:open_close('contents_diffrn_scan_frame');">+/-</a>
+<div id="contents_diffrn_scan_frame" style="display:none">#
+#                  <a href="#_diffrn_scan_frame.date" >_diffrn_scan_frame.date</a>
+#                  <a href="#_diffrn_scan_frame.frame_id" >_diffrn_scan_frame.frame_id</a>
+#                  <a href="#_diffrn_scan_frame.frame_number" >_diffrn_scan_frame.frame_number</a>
+#                  <a href="#_diffrn_scan_frame.integration_time" >_diffrn_scan_frame.integration_time</a>
+#                  <a href="#_diffrn_scan_frame.polarizn_Stokes_I">_diffrn_scan_frame.polarizn_Stokes_I</a>
+#                  <a href="#_diffrn_scan_frame.polarizn_Stokes_Q">_diffrn_scan_frame.polarizn_Stokes_Q</a>
+#                  <a href="#_diffrn_scan_frame.polarizn_Stokes_U">_diffrn_scan_frame.polarizn_Stokes_U</a>
+#                  <a href="#_diffrn_scan_frame.polarizn_Stokes_V">_diffrn_scan_frame.polarizn_Stokes_V</a>
+#                  <a href="#_diffrn_scan_frame.polarizn_Stokes_I_esd">_diffrn_scan_frame.polarizn_Stokes_I_esd</a>
+#                  <a href="#_diffrn_scan_frame.polarizn_Stokes_Q_esd">_diffrn_scan_frame.polarizn_Stokes_Q_esd</a>
+#                  <a href="#_diffrn_scan_frame.polarizn_Stokes_U_esd">_diffrn_scan_frame.polarizn_Stokes_U_esd</a>
+#                  <a href="#_diffrn_scan_frame.polarizn_Stokes_V_esd">_diffrn_scan_frame.polarizn_Stokes_V_esd</a>
+#                  <a href="#_diffrn_scan_frame.scan_id" >_diffrn_scan_frame.scan_id</a>
+#                  <a href="#_diffrn_scan_frame.time_period" >_diffrn_scan_frame.time_period</a>
+#                  <a href="#_diffrn_scan_frame.time_rstrt_incr" >_diffrn_scan_frame.time_rstrt_incr</a>
+#                  <a href="#_diffrn_scan_frame.variant" >_diffrn_scan_frame.variant</a>
+#
+</div>#        category  <a href="#diffrn_scan_frame_axis">DIFFRN_SCAN_FRAME_AXIS</a> <a href="javascript:open_close('contents_diffrn_scan_frame_axis');">+/-</a>
+<div id="contents_diffrn_scan_frame_axis" style="display:none">#
+#                  <a href="#_diffrn_scan_frame_axis.axis_id" >_diffrn_scan_frame_axis.axis_id</a>
+#                  <a href="#_diffrn_scan_frame_axis.angle" >_diffrn_scan_frame_axis.angle</a>
+#                  <a href="#_diffrn_scan_frame_axis.angle_increment" >_diffrn_scan_frame_axis.angle_increment</a>
+#                  <a href="#_diffrn_scan_frame_axis.angle_rstrt_incr" >_diffrn_scan_frame_axis.angle_rstrt_incr</a>
+#                  <a href="#_diffrn_scan_frame_axis.displacement" >_diffrn_scan_frame_axis.displacement</a>
+#                  <a href="#_diffrn_scan_frame_axis.displacement_increment" >_diffrn_scan_frame_axis.displacement_increment</a>
+#                  <a href="#_diffrn_scan_frame_axis.displacement_rstrt_incr" >_diffrn_scan_frame_axis.displacement_rstrt_incr</a>
+#                  <a href="#_diffrn_scan_frame_axis.reference_angle" >_diffrn_scan_frame_axis.reference_angle</a>
+#                  <a href="#_diffrn_scan_frame_axis.reference_displacement" >_diffrn_scan_frame_axis.reference_displacement</a>
+#                  <a href="#_diffrn_scan_frame_axis.frame_id" >_diffrn_scan_frame_axis.frame_id</a>
+#                  <a href="#_diffrn_scan_frame_axis.variant" >_diffrn_scan_frame_axis.variant</a>
+#
+</div>#        category  <a href="#diffrn_scan_frame_monitor">DIFFRN_SCAN_FRAME_MONITOR</a> <a href="javascript:open_close('contents_diffrn_scan_frame_monitor');">+/-</a>
+<div id="contents_diffrn_scan_frame_monitor" style="display:none">#
+#                  <a href="#_diffrn_scan_frame_monitor.id" >_diffrn_scan_frame_monitor.id</a>
+#                  <a href="#_diffrn_scan_frame_monitor.detector_id" >_diffrn_scan_frame_monitor.detector_id</a>
+#                  <a href="#_diffrn_scan_frame_monitor.frame_id" >_diffrn_scan_frame_monitor.frame_id</a>
+#                  <a href="#_diffrn_scan_frame_monitor.integration_time" >_diffrn_scan_frame_monitor.integration_time</a>
+#                  <a href="#_diffrn_scan_frame_monitor.monitor_value" >_diffrn_scan_frame_monitor.monitor_value</a>
+#                  <a href="#_diffrn_scan_frame_monitor.scan_id" >_diffrn_scan_frame_monitor.scan_id</a>
+#                  <a href="#_diffrn_scan_frame.variant" >_diffrn_scan_frame_monitor.variant</a>
+#
+</div>#        category  <a href="#map">MAP</a> <a href="javascript:open_close('contents_map');">+/-</a>
+<div id="contents_map" style="display:none">#
+#                  <a href="#_map.details" >_map.details</a>
+#                  <a href="#_map.diffrn_id" >_map.diffrn_id</a>
+#                  <a href="#_map.entry_id" >_map.entry_id</a>
+#                  <a href="#_map.id" >_map.id</a>
+#                  <a href="#_map.variant" >_map.variant</a>
+#
+</div>#        category  <a href="#map_segment">MAP_SEGMENT</a> <a href="javascript:open_close('contents_map_segment');">+/-</a>
+<div id="contents_map_segment" style="display:none">#
+#                  <a href="#_map_segment.array_id" >_map_segment.array_id</a>
+#                  <a href="#_map_segment.array_section_id" >_map_segment.array_section_id</a>
+#                  <a href="#_map_segment.binary_id" >_map_segment.binary_id</a>
+#                  <a href="#_map_segment.mask_array_id" >_map_segment.mask_array_id</a>
+#                  <a href="#_map_segment.mask_array_section_id" >_map_segment.mask_array_section_id</a>
+#                  <a href="#_map_segment.mask_binary_id" >_map_segment.mask_binary_id</a>
+#                  <a href="#_map_segment.id" >_map_segment.id</a>
+#                  <a href="#_map_segment.map_id" >_map_segment.map_id</a>
+#                  <a href="#_map_segment.details" >_map_segment.details</a>
+#                  <a href="#_map_segment.variant" >_map_segment.variant</a>
+#
+</div>#        category  <a href="#variant">VARIANT</a> <a href="javascript:open_close('contents_variant');">+/-</a>
+<div id="contents_variant" style="display:none">#
+#                  <a href="#_variant.details" >_variant.details</a>
+#                  <a href="#_variant.diffrn_id" >_variant.diffrn_id</a>
+#                  <a href="#_variant.entry_id" >_variant.entry_id</a>
+#                  <a href="#_variant.role" >_variant.role</a>
+#                  <a href="#_variant.timestamp" >_variant.timestamp</a>
+#                  <a href="#_variant.variant" >_variant.variant</a>
+#                  <a href="#_variant.variant_of" >_variant.variant_of</a>
+#
+</div>#       ***DEPRECATED*** data items <a href="javascript:open_close('contents_deprecated');">+/-</a>
+<div id="contents_deprecated" style="display:none">#
+#                  <a href="#_diffrn_detector_axis.id" >_diffrn_detector_axis.id</a>
+#                  <a href="#_diffrn_detector_element.center[1]" >_diffrn_detector_element.center[1]</a>
+#                  <a href="#_diffrn_detector_element.center[2]" >_diffrn_detector_element.center[2]</a>
+#                  <a href="#_diffrn_measurement_axis.id" >_diffrn_measurement_axis.id</a>
+#                  <a href="#_diffrn_scan_frame_monitor.value" >_diffrn_scan_frame_monitor.value</a>
+#
+#       ***DEPRECATED*** category  <a href="#diffrn_frame_data">DIFFRN_FRAME_DATA</a>
+#
+#                  <a href="#_diffrn_frame_data.array_id" >_diffrn_frame_data.array_id</a>
+#                  <a href="#_diffrn_frame_data.binary_id" >_diffrn_frame_data.binary_id</a>
+#                  <a href="#_diffrn_frame_data.detector_element_id" >_diffrn_frame_data.detector_element_id</a>
+#                  <a href="#_diffrn_frame_data.id" >_diffrn_frame_data.id</a>
+#                  <a href="#_diffrn_frame_data.details">_diffrn_frame_data.details</a>
+#
+</div>#        <a href="#ITEM_TYPE_LIST">ITEM_TYPE_LIST</a>
+#        <a href="#ITEM_UNITS_LIST">ITEM_UNITS_LIST</a>
+#        <a href="#DICTIONARY_HISTORY">DICTIONARY_HISTORY</a>
+#
+##############################################################################
+
+<font size="-1" color="black"><div id="print_category_group_table" style="display:block">#Category Group Table:  #<a href="javascript:open_close2('online_category_group_table','print_category_group_table');">+/-</a>
+<pre><tt>+--------------------------------------------------------------------------------------------------------------------+
+|ARRAY_DATA_GROUP|Categories that describe array data.                                                               |
+|                |---------------------------------------------------------------------------------------------------|
+|                |+-------------------------------------------------------------------------------------------------+|
+|                || ARRAY_DATA               | Data items in the ARRAY_DATA category are the containers for the     ||
+|                ||                          | array data items described in the category ARRAY_STRUCTURE.          ||
+|                ||                          |                                                                      ||
+|                ||                          | It is recognized that the data in this category need to be used in   ||
+|                ||                          | two distinct ways. During a data collection the lack of ancillary    ||
+|                ||                          | data and timing constraints in processing data may dictate the need  ||
+|                ||                          | to make a 'miniCBF' nothing more than an essential minimum of        ||
+|                ||                          | information to record the results of the data collection. In that    ||
+|                ||                          | case it is proper to use the ARRAY_DATA category as a container for  ||
+|                ||                          | just a single image and a compacted, beam-line dependent list of     ||
+|                ||                          | data collection parameter values. In such a case, only the tags      ||
+|                ||                          | '_array_data.header_convention', '_array_data.header_contents' and   ||
+|                ||                          | '_array_data.data' need be populated.                                ||
+|                ||                          |                                                                      ||
+|                ||                          | For full processing and archiving, most of the tags in this          ||
+|                ||                          | dictionary will need to be populated.                                ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | ARRAY_DATA_EXTERNAL_DATA     | Data items in the ARRAY_DATA_EXTERNAL_DATA category      | ||
+|                || |   |                              | record information needed to refer to data arrays in     | ||
+|                || |   |                              | external datasets.  All necessary metadata must also     | ||
+|                || |   |                              | be copied or linked.                                     | ||
+|                || |   |-----------------------------------------------------------------------------------------| ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                |+-------------------------------------------------------------------------------------------------+|
+|                ||--------------------------+----------------------------------------------------------------------||
+|                || ARRAY_ELEMENT_SIZE       | Data items in the ARRAY_ELEMENT_SIZE category record the physical    ||
+|                ||                          | size of array elements along each array dimension.                   ||
+|                ||--------------------------+----------------------------------------------------------------------||
+|                || ARRAY_INTENSITIES        | Data items in the ARRAY_INTENSITIES category record the information  ||
+|                ||                          | required to recover the intensity data from the set of data values   ||
+|                ||                          | stored in the ARRAY_DATA category.                                   ||
+|                ||                          |                                                                      ||
+|                ||                          | The detector may have a complex relationship between the raw         ||
+|                ||                          | intensity values and the number of incident photons. In most cases,  ||
+|                ||                          | the number stored in the final array will have a simple linear       ||
+|                ||                          | relationship to the actual number of incident photons, given by      ||
+|                ||                          | _array_intensities.gain. If raw, uncorrected values are presented    ||
+|                ||                          | (e.g. for calibration experiments), the value of                     ||
+|                ||                          | _array_intensities.linearity will be 'raw' and                       ||
+|                ||                          | _array_intensities.gain will not be used.                            ||
+|                ||--------------------------+----------------------------------------------------------------------||
+|                || ARRAY_STRUCTURE          | Data items in the ARRAY_STRUCTURE category record the organization   ||
+|                ||                          | and encoding of array data that may be stored in the ARRAY_DATA      ||
+|                ||                          | category.                                                            ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | ARRAY_STRUCTURE_LIST         | Data items in the ARRAY_STRUCTURE_LIST category record   | ||
+|                || |   |                              | the size and organization of each array dimension.       | ||
+|                || |   |                              |                                                          | ||
+|                || |   |                              | The relationship to physical axes may be given.          | ||
+|                || |   |-----------------------------------------------------------------------------------------| ||
+|                || |   | +-------------------------------------------------------------------------------------+ | ||
+|                || |   | |   | ARRAY_STRUCTURE_LIST_SECTION | Data items in the ARRAY_STRUCTURE_LIST_SECTION   | | ||
+|                || |   | |   |                              | category identify the dimension-by-dimension     | | ||
+|                || |   | |   |                              | start, end and stride of each section of an      | | ||
+|                || |   | |   |                              | array that is to be referenced.                  | | ||
+|                || |   | |   |                              |                                                  | | ||
+|                || |   | |   |                              | For any array of array_id, ARRAYID, array        | | ||
+|                || |   | |   |                              | section ids of the form                          | | ||
+|                || |   | |   |                              | ARRAYID(start1:end1:stride1,start2:end2:stride2, | | ||
+|                || |   | |   |                              | ...)                                             | | ||
+|                || |   | |   |                              | are defined by default.                          | | ||
+|                || |   | |   |------------------------------+--------------------------------------------------| | ||
+|                || |   | |   | ARRAY_STRUCTURE_LIST_AXIS    | Data items in the ARRAY_STRUCTURE_LIST_AXIS      | | ||
+|                || |   | |   |                              | category describe the physical settings of sets  | | ||
+|                || |   | |   |                              | of axes for the centres of pixels that           | | ||
+|                || |   | |   |                              | correspond to data points described in the       | | ||
+|                || |   | |   |                              | ARRAY_STRUCTURE_LIST category.                   | | ||
+|                || |   | |   |                              |                                                  | | ||
+|                || |   | |   |                              | In the simplest cases, the physical increments   | | ||
+|                || |   | |   |                              | of a single axis correspond to the increments of | | ||
+|                || |   | |   |                              | a single array index. More complex               | | ||
+|                || |   | |   |                              | organizations, e.g. spiral scans, may require    | | ||
+|                || |   | |   |                              | coupled motions along multiple axes.             | | ||
+|                || |   | |   |                              |                                                  | | ||
+|                || |   | |   |                              | Note that a spiral scan uses two coupled axes:   | | ||
+|                || |   | |   |                              | one for the angular direction and one for the    | | ||
+|                || |   | |   |                              | radial direction. This differs from a            | | ||
+|                || |   | |   |                              | cylindrical scan for which the two axes are not  | | ||
+|                || |   | |   |                              | coupled into one set.                            | | ||
+|                || |   | +-------------------------------------------------------------------------------------+ | ||
+|                || |   |-----------------------------------------------------------------------------------------| ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                |+-------------------------------------------------------------------------------------------------+|
+|----------------+---------------------------------------------------------------------------------------------------|
+|AXIS_GROUP      |Categories that describe axes.                                                                     |
+|                |---------------------------------------------------------------------------------------------------|
+|                |+-------------------------------------------------------------------------------------------------+|
+|                || AXIS | Data items in the AXIS category record the information required to describe the various  ||
+|                ||      | goniometer, detector, source and other axes needed to specify a data collection or the   ||
+|                ||      | axes defining the coordinate system of an image.                                         ||
+|                ||      |                                                                                          ||
+|                ||      | The location of each axis is specified by two vectors: the axis itself, given by a unit  ||
+|                ||      | vector in the direction of the axis, and an offset to the base of the unit vector.       ||
+|                ||      |                                                                                          ||
+|                ||      | The vectors defining an axis are referenced to an appropriate coordinate system. The     ||
+|                ||      | axis vector, itself, is a dimensionless unit vector. Where meaningful, the offset vector ||
+|                ||      | is given in millimetres. In coordinate systems not measured in metres, the offset is not ||
+|                ||      | specified and is taken as zero.                                                          ||
+|                ||      |                                                                                          ||
+|                ||      | The available coordinate systems are:                                                    ||
+|                ||      |                                                                                          ||
+|                ||      | The imgCIF standard laboratory coordinate system                                         ||
+|                ||      | The NeXus/HDF5 McStas laboratory coordinate system                                       ||
+|                ||      | The direct lattice (fractional atomic coordinates)                                       ||
+|                ||      | The orthogonal Cartesian coordinate system (real space)                                  ||
+|                ||      | The reciprocal lattice                                                                   ||
+|                ||      | An abstract orthogonal Cartesian coordinate frame                                        ||
+|                |+-------------------------------------------------------------------------------------------------+|
+|----------------+---------------------------------------------------------------------------------------------------|
+|DIFFRN_GROUP    |Categories that describe details of the diffraction experiment.                                    |
+|                |---------------------------------------------------------------------------------------------------|
+|                |+-------------------------------------------------------------------------------------------------+|
+|                || DIFFRN_DATA_FRAME          | Data items in the DIFFRN_DATA_FRAME category record the details    ||
+|                ||                            | about each frame of data.                                          ||
+|                ||                            |                                                                    ||
+|                ||                            | The items in this category were previously in a DIFFRN_FRAME_DATA  ||
+|                ||                            | category, which is now deprecated. The items from the old category ||
+|                ||                            | are provided as aliases but should not be used for new work.       ||
+|                ||----------------------------+--------------------------------------------------------------------||
+|                || DIFFRN_DETECTOR            | Data items in the DIFFRN_DETECTOR category describe the detector   ||
+|                ||                            | used to measure the scattered radiation, including any analyser    ||
+|                ||                            | and post-sample collimation.                                       ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | DIFFRN_DETECTOR_AXIS | Data items in the DIFFRN_DETECTOR_AXIS category associate axes   | ||
+|                || |   |                      | with detectors.                                                  | ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | DIFFRN_DETECTOR_ELEMENT | Data items in the DIFFRN_DETECTOR_ELEMENT category record the | ||
+|                || |   |                         | details about spatial layout and other characteristics of     | ||
+|                || |   |                         | each element of a detector which may have multiple elements.  | ||
+|                || |   |                         |                                                               | ||
+|                || |   |                         | In most cases, giving more detailed information in            | ||
+|                || |   |                         | ARRAY_STRUCTURE_LIST and ARRAY_STRUCTURE_LIST_AXIS is         | ||
+|                || |   |                         | preferable to simply providing the centre of the detector     | ||
+|                || |   |                         | element.                                                      | ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || DIFFRN_MEASUREMENT         | Data items in the DIFFRN_MEASUREMENT category record details about ||
+|                ||                            | the device used to orient and/or position the crystal during data  ||
+|                ||                            | measurement and the manner in which the diffraction data were      ||
+|                ||                            | measured.                                                          ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | DIFFRN_MEASUREMENT_AXIS | Data items in the DIFFRN_MEASUREMENT_AXIS category associate  | ||
+|                || |   |                         | axes with goniometers.                                        | ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || DIFFRN_RADIATION           | Data items in the DIFFRN_RADIATION category describe the radiation ||
+|                ||                            | used for measuring diffraction intensities, its collimation and    ||
+|                ||                            | monochromatization before the sample.                              ||
+|                ||                            |                                                                    ||
+|                ||                            | Post-sample treatment of the beam is described by data items in    ||
+|                ||                            | the DIFFRN_DETECTOR category.                                      ||
+|                ||----------------------------+--------------------------------------------------------------------||
+|                || DIFFRN_REFLN               | This category redefinition has been added to extend the key of the ||
+|                ||                            | standard DIFFRN_REFLN category.                                    ||
+|                ||                            |                                                                    ||
+|                ||                            | Data items in the DIFFRN_REFLN category record details about the   ||
+|                ||                            | intensities in the diffraction data set identified by              ||
+|                ||                            | _diffrn_refln.diffrn_id.                                           ||
+|                ||                            |                                                                    ||
+|                ||                            | The DIFFRN_REFLN data items refer to individual intensity          ||
+|                ||                            | measurements and must be included in looped lists.                 ||
+|                ||                            |                                                                    ||
+|                ||                            | The DIFFRN_REFLNS data items specify the parameters that apply to  ||
+|                ||                            | all intensity measurements in the particular diffraction data set  ||
+|                ||                            | identified by _diffrn_reflns.diffrn_id and _diffrn_refln.frame_id  ||
+|                ||----------------------------+--------------------------------------------------------------------||
+|                || DIFFRN_SCAN                | Data items in the DIFFRN_SCAN category describe the parameters of  ||
+|                ||                            | one or more scans, relating axis positions to frames.              ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | DIFFRN_SCAN_AXIS | Data items in the DIFFRN_SCAN_AXIS category describe the settings of | ||
+|                || |   |                  | axes for particular scans. Unspecified axes are assumed to be at     | ||
+|                || |   |                  | their zero points.                                                   | ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | DIFFRN_SCAN_COLLECTION | Data items in the DIFFRN_SCAN_COLLECTION category describe the | ||
+|                || |   |                        | type of collection strategy involved in each scan.             | ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | DIFFRN_SCAN_FRAME | Data items in the DIFFRN_SCAN_FRAME category describe the           | ||
+|                || |   |                   | relationships of particular frames to scans.                        | ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | +-------------------------------------------------------------------------------------+ | ||
+|                || |   | |   | DIFFRN_SCAN_FRAME_AXIS | Data items in the DIFFRN_SCAN_FRAME_AXIS category      | | ||
+|                || |   | |   |                        | describe the settings of axes for particular frames.   | | ||
+|                || |   | |   |                        | Unspecified axes are assumed to be at their zero       | | ||
+|                || |   | |   |                        | points. If, for any given frame, nonzero values apply  | | ||
+|                || |   | |   |                        | for any of the data items in this category, those      | | ||
+|                || |   | |   |                        | values should be given explicitly in this category and | | ||
+|                || |   | |   |                        | not simply inferred from values in DIFFRN_SCAN_AXIS.   | | ||
+|                || |   | +-------------------------------------------------------------------------------------+ | ||
+|                || |---+-----------------------------------------------------------------------------------------| ||
+|                || |   | +-------------------------------------------------------------------------------------+ | ||
+|                || |   | |   | DIFFRN_SCAN_FRAME_MONITOR | Data items in the DIFFRN_SCAN_FRAME_MONITOR         | | ||
+|                || |   | |   |                           | category record the values and details about each   | | ||
+|                || |   | |   |                           | monitor for each frame of data during a scan.       | | ||
+|                || |   | |   |                           |                                                     | | ||
+|                || |   | |   |                           | Each monitor value is uniquely identified by the    | | ||
+|                || |   | |   |                           | combination of the scan id given by                 | | ||
+|                || |   | |   |                           | _diffrn_scan_frame.scan_id, the frame id given by   | | ||
+|                || |   | |   |                           | _diffrn_scan_frame_monitor.frame_id, the monitor's  | | ||
+|                || |   | |   |                           | detector id given by                                | | ||
+|                || |   | |   |                           | _diffrn_scan_frame_monitor.detector_id, and a       | | ||
+|                || |   | |   |                           | 1-based ordinal given by                            | | ||
+|                || |   | |   |                           | _diffrn_scan_frame_monitor.id.                      | | ||
+|                || |   | |   |                           |                                                     | | ||
+|                || |   | |   |                           | If there is only one frame for the scan, the value  | | ||
+|                || |   | |   |                           | of _diffrn_scan_frame_monitor.frame_id may be       | | ||
+|                || |   | |   |                           | omitted.                                            | | ||
+|                || |   | |   |                           |                                                     | | ||
+|                || |   | |   |                           | A single frame may have more than one monitor       | | ||
+|                || |   | |   |                           | value, and each monitor value may be the result of  | | ||
+|                || |   | |   |                           | integration over the entire frame integration time  | | ||
+|                || |   | |   |                           | given by the value of                               | | ||
+|                || |   | |   |                           | _diffrn_scan_frame.integration_time, or many        | | ||
+|                || |   | |   |                           | monitor values may be reported over shorter times   | | ||
+|                || |   | |   |                           | given by the value of                               | | ||
+|                || |   | |   |                           | _diffrn_scan_frame_monitor.integration_time. If     | | ||
+|                || |   | |   |                           | only one monitor value for a given monitor is       | | ||
+|                || |   | |   |                           | collected during the integration time of the frame, | | ||
+|                || |   | |   |                           | the value of _diffrn_scan_frame_monitor.id may be   | | ||
+|                || |   | |   |                           | omitted.                                            | | ||
+|                || |   | +-------------------------------------------------------------------------------------+ | ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                |+-------------------------------------------------------------------------------------------------+|
+|----------------+---------------------------------------------------------------------------------------------------|
+|MAP_GROUP       |Categories that describe maps.                                                                     |
+|                |---------------------------------------------------------------------------------------------------|
+|                |+-------------------------------------------------------------------------------------------------+|
+|                || MAP     | Data items in the MAP category record the details of a map. Maps record values of     ||
+|                ||         | parameters, such as density, that are functions of position within a cell or are      ||
+|                ||         | functions of orthogonal coordinates in three space.                                   ||
+|                ||         |                                                                                       ||
+|                ||         | A map may is composed of one or more map segments specified in the MAP_SEGMENT        ||
+|                ||         | category.                                                                             ||
+|                ||         |                                                                                       ||
+|                ||         | Examples are given in the MAP_SEGMENT category.                                       ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | MAP_SEGMENT | Data items in the MAP_SEGMENT category record the details about each      | ||
+|                || |   |             | segment (section or brick) of a map.                                      | ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                |+-------------------------------------------------------------------------------------------------+|
+|----------------+---------------------------------------------------------------------------------------------------|
+|VARIANT_GROUP   |Categories that describe variants                                                                  |
+|                |---------------------------------------------------------------------------------------------------|
+|                |+-------------------------------------------------------------------------------------------------+|
+|                || VARIANT | Data items in the VARIANT category record the details about sets of variants of data  ||
+|                ||         | items.                                                                                ||
+|                ||         |                                                                                       ||
+|                ||         | There is sometimes a need to allow for multiple versions of the same data items in    ||
+|                ||         | order to allow for refinements and corrections to earlier assumptions, observations   ||
+|                ||         | and calculations. In order to allow data sets to contain more than one variant of the ||
+|                ||         | same information, an optional ...variant data item as a pointer to _variant.variant   ||
+|                ||         | has been added to the key of every category, as an implicit data item with a null     ||
+|                ||         | (empty) default value.                                                                ||
+|                ||         |                                                                                       ||
+|                ||         | All rows in a category with the same variant value are considered to be related to    ||
+|                ||         | one another and to all rows in other categories with the same variant value. For a    ||
+|                ||         | given variant, all such rows are also considered to be related to all rows with a     ||
+|                ||         | null variant value, except that a row with a null variant value is for which all      ||
+|                ||         | other components of its key are identical to those entries in another row with a      ||
+|                ||         | non-null variant value is not related the the rows with that non-null variant value.  ||
+|                ||         | This behavior is similar to the convention for identifying alternate conformers in an ||
+|                ||         | atom list.                                                                            ||
+|                ||         |                                                                                       ||
+|                ||         | An optional role may be specified for a variant as the value of _variant.role.        ||
+|                ||         | Possible roles are null, "preferred", "raw data", "unsuccessful trial".               ||
+|                ||         |                                                                                       ||
+|                ||         | variants may carry an optional timestamp as the value of _variant.timestamp.          ||
+|                ||         |                                                                                       ||
+|                ||         | variants may be related to other variants from which they were derived by the value   ||
+|                ||         | of _variant.variant_of                                                                ||
+|                ||         |                                                                                       ||
+|                ||         | Further details about the variant may be specified as the value of _variant.details.  ||
+|                ||         |                                                                                       ||
+|                ||         | In order to allow variant information from multiple datasets to be combined,          ||
+|                ||         | _variant.diffrn_id and/or _variant.entry_id may be used.                              ||
+|                |+-------------------------------------------------------------------------------------------------+|
++--------------------------------------------------------------------------------------------------------------------+
+</tt></pre>
+</div><div id="online_category_group_table" style="display:none">#Category Group Table:  #<a href="javascript:open_close2('online_category_group_table','print_category_group_table');">+/-</a>
+<table border=2>
+<tr>
+    <td valign="top" rowspan=2>ARRAY_DATA_GROUP</td>
+    <td>Categories that describe array data.</td>
+</tr>
+<tr>
+    <td>
+    <table border=2>
+      <tr>
+        <td valign="top"><a href="#array_data">ARRAY_DATA</a></td>
+        <td>Data items in the <a href="#array_data">ARRAY_DATA</a> category are the containers for
+     the array data items described in the category <a href="#array_structure">ARRAY_STRUCTURE</a>.
+     <p>
+     It is recognized that the data in this category need to be used in
+     two distinct ways.  During a data collection the lack of ancillary
+     data and timing constraints in processing data may dictate the
+     need to make a 'miniCBF' nothing more than an essential minimum
+     of information to record the results of the data collection.  In that
+     case it is proper to use the <a href="#array_data">ARRAY_DATA</a> category as a
+     container for just a single image and a compacted, beam-line
+     dependent list of data collection parameter values.  In such
+     a case, only the tags '<a href="#_array_data.header_convention">_array_data.header_convention</a>',
+     '<a href="#_array_data.header_contents">_array_data.header_contents</a>' and '<a href="#_array_data.data">_array_data.data</a>' need be
+     populated.
+     <p>
+     For full processing and archiving, most of the tags in this
+     dictionary will need to be populated.
+      </td>
+    </tr>
+      <tr>
+      <td colspan=2>
+        <table border=2>
+        <td rowspan=1 bgcolor="cyan">&nbsp;</td>
+        <td valign="top"><a href="#array_data_external_data">ARRAY_DATA_EXTERNAL_DATA</a></td>
+        <td>Data items in the <a href="#array_data_external_data">ARRAY_DATA_EXTERNAL_DATA</a> category
+        record information needed to refer to data arrays in
+        external datasets.  All necessary metadata must also
+        be copied or linked.
+        </td>
+        </table>
+      </td>
+      </tr>
+    <tr>
+      <td valign="top"><a href="#array_element_size">ARRAY_ELEMENT_SIZE</a></td>
+      <td>
+      Data items in the <a href="#array_element_size">ARRAY_ELEMENT_SIZE</a> category record the physical
+     size of array elements along each array dimension.
+      </td>
+    </tr>
+    <tr>
+      <td valign="top"><a href="#array_intensities">ARRAY_INTENSITIES</a></td>
+      <td>Data items in the <a href="#array_intensities">ARRAY_INTENSITIES</a> category record the
+      information required to recover the intensity data from
+      the set of data values stored in the <a href="#array_data">ARRAY_DATA</a> category.
+      <p>
+      The detector may have a complex relationship
+      between the raw intensity values and the number of
+      incident photons.  In most cases, the number stored
+      in the final array will have a simple linear relationship
+      to the actual number of incident photons, given by
+      <a href="#_array_intensities.gain">_array_intensities.gain</a>.  If raw, uncorrected values
+      are presented (e.g. for calibration experiments), the
+      value of <a href="#_array_intensities.linearity">_array_intensities.linearity</a> will be 'raw'
+      and <a href="#_array_intensities.gain">_array_intensities.gain</a> will not be used.
+      </td>
+    </tr>
+
+    <tr>
+      <td valign="top"><a href="#array_structure">ARRAY_STRUCTURE</a></td>
+      <td>
+      Data items in the <a href="#array_structure">ARRAY_STRUCTURE</a> category record the organization and
+      encoding of array data that may be stored in the <a href="#array_data">ARRAY_DATA</a> category.
+      </td>
+    </tr>
+    <tr>
+      <td colspan=2>
+      <table border=2>
+        <tr>
+          <td rowspan=3 bgcolor=cyan>&nbsp;</td>
+          <td valign="top"><a href="#array_structure_list">ARRAY_STRUCTURE_LIST</a></td>
+          <td>
+          Data items in the <a href="#array_structure_list">ARRAY_STRUCTURE_LIST</a> category record the size
+          and organization of each array dimension.
+          <p>
+          The relationship to physical axes may be given.
+          </td>
+        </tr>
+        <tr>
+          <td colspan=2>
+          <table border=2>
+            <tr>
+              <td rowspan=2 bgcolor=cyan>&nbsp;</td>
+              <td valign="top"><a href="#array_structure_list_section">ARRAY_STRUCTURE_LIST_SECTION</a></td>
+              <td>
+              Data items in the <a href="#array_structure_list_section">ARRAY_STRUCTURE_LIST_SECTION</a> category identify
+              the dimension-by-dimension start, end and stride of each section of an
+              array that is to be referenced.
+              <p>
+              For any array of array_id, ARRAYID, array section ids of the form<br />
+              ARRAYID(start1:end1:stride1,start2:end2:stride2, ...)<br />
+              are defined by default.
+              </td>
+            </tr>
+            <tr>
+              <td valign="top"><a href="#array_structure_list_axis">ARRAY_STRUCTURE_LIST_AXIS</a></td>
+              <td>
+              Data items in the <a href="#array_structure_list_axis">ARRAY_STRUCTURE_LIST_AXIS</a> category describe
+              the physical settings of sets of axes for the centres of pixels that
+              correspond to data points described in the
+              <a href="#array_structure_list">ARRAY_STRUCTURE_LIST</a> category.
+              <p>
+              In the simplest cases, the physical increments of a single axis correspond
+              to the increments of a single array index.  More complex organizations,
+              e.g. spiral scans, may require coupled motions along multiple axes.
+              <p>
+              Note that a spiral scan uses two coupled axes: one for the angular
+              direction and one for the radial direction.  This differs from a
+              cylindrical scan for which the two axes are not coupled into one 
+              set.
+              </td>
+            </tr>
+          </table>
+        <tr>
+        </tr>
+      </table>
+      </td>
+    </tr>
+</table>
+    <tr>
+    <td valign="top" rowspan=2>AXIS_GROUP</td>
+    <td>Categories that describe axes.</td>
+</tr>
+<tr>
+    <td>
+    <table border=2>
+      <tr>
+        <td valign="top"><a href="#AXIS">AXIS</a></td>
+        <td>
+        Data items in the <a href="#AXIS">AXIS</a> category record the information required
+        to describe the various goniometer, detector, source and other
+        axes needed to specify a data collection or the axes defining the
+        coordinate system of an image.  
+       <p>
+       The location of each axis is specified by two vectors: the axis 
+       itself, given by a  unit vector in the direction of the axis, and 
+       an offset to the base of the unit vector.  
+       <p>
+       The vectors defining an axis are referenced to an appropriate
+       coordinate system.  The axis vector, itself, is a dimensionless
+       unit vector.  Where meaningful, the offset vector is given in
+       millimetres.  In coordinate systems not measured in metres,
+       the offset is not specified and is taken as zero. 
+       <p>
+       The available coordinate systems are:
+       <p>
+         The imgCIF standard laboratory coordinate system<br />
+         The NeXus/HDF5 McStas laboratory coordinate system<br />
+         The direct lattice (fractional atomic coordinates)<br />
+         The orthogonal Cartesian coordinate system (real space)<br />
+         The reciprocal lattice<br />
+         An abstract orthogonal Cartesian coordinate frame</br >
+
+        <p>
+        </td>
+      </tr>
+   </table>
+<tr>
+    <td valign="top" rowspan=2>DIFFRN_GROUP</td>
+    <td>Categories that describe details of the diffraction experiment.</td>
+</tr>
+<tr>
+    <td>
+    <table border=2>
+      <tr>
+        <td valign="top"><a href="#DIFFRN_DATA_FRAME">DIFFRN_DATA_FRAME<a/></td>
+        <td>Data items in the <a href="#DIFFRN_DATA_FRAME">DIFFRN_DATA_FRAME</a> category record
+              the details about each frame of data.
+              <p>
+              The items in this category were previously in a
+              DIFFRN_FRAME_DATA category, which is now deprecated.
+              The items from the old category are provided
+              as aliases but should not be used for new work.
+        </td>
+      </tr>
+      <tr>
+        <td valign="top"><a href="#DIFFRN_DETECTOR">DIFFRN_DETECTOR</a></td>
+        <td>Data items in the <a href="#DIFFRN_DETECTOR">DIFFRN_DETECTOR</a> category describe the
+               detector used to measure the scattered radiation, including
+               any analyser and post-sample collimation.
+        </td>
+      </tr>
+      <tr>
+        <td colspan=2>
+        <table border=2>
+        <tr>
+          <td rowspan=1 bgcolor="cyan">&nbsp;</td>
+          <td valign="top"><a href="#diffrn_detector_axis">DIFFRN_DETECTOR_AXIS</a></td>
+          <td>Data items in the <a href="#diffrn_detector_axis">DIFFRN_DETECTOR_AXIS</a> category associate
+            axes with detectors.
+          </td>
+        </tr>
+        </table>
+        </td>
+      </tr>
+      <tr>
+        <td colspan=2>
+        <table border=2>
+        <tr>
+          <td rowspan=1 bgcolor="cyan">&nbsp;</td>
+          <td valign="top"><a href="#diffrn_detector_element">DIFFRN_DETECTOR_ELEMENT</a></td>
+          <td>
+              Data items in the <a href="#diffrn_detector_element">DIFFRN_DETECTOR_ELEMENT</a> category record
+              the details about spatial layout and other characteristics
+              of each element of a detector which may have multiple elements.
+              <p>
+              In most cases, giving more detailed information
+              in <a href="#array_structure_list">ARRAY_STRUCTURE_LIST</a> and <a href="#array_structure_list_axis">ARRAY_STRUCTURE_LIST_AXIS</a>
+              is preferable to simply providing the centre of the
+              detector element.
+          </td>
+        </tr>
+        </table>
+        </td>
+      </tr>
+      <tr>
+        <td valign="top"><a href="#diffrn_measurement">DIFFRN_MEASUREMENT</a></td>
+        <td> Data items in the <a href="#diffrn_measurement">DIFFRN_MEASUREMENT</a> category record details
+               about the device used to orient and/or position the crystal
+               during data measurement and the manner in which the
+               diffraction data were measured.
+        </td>
+      </tr>
+      <tr>
+        <td colspan=2>
+        <table border=2>
+        <tr>
+          <td rowspan=1 bgcolor="cyan">&nbsp;</td>
+          <td valign="top"><a href="#diffrn_measurement_axis">DIFFRN_MEASUREMENT_AXIS</a></td>
+          <td>
+              Data items in the <a href="#diffrn_measurement_axis">DIFFRN_MEASUREMENT_AXIS</a> category associate
+     axes with goniometers.
+          </td>
+        </tr>
+        </table>
+        </td>
+      </tr>
+      <tr>
+        <td valign="top"><a href="#diffrn_radiation">DIFFRN_RADIATION</a></td>
+        <td>  Data items in the <a href="#diffrn_radiation">DIFFRN_RADIATION</a> category describe
+               the radiation used for measuring diffraction intensities,
+               its collimation and monochromatization before the sample.
+               <p>
+               Post-sample treatment of the beam is described by data
+               items in the <a href="#DIFFRN_DETECTOR">DIFFRN_DETECTOR</a> category.
+        </td>
+      </tr>
+
+      <tr>
+        <td valign="top"><a href="#diffrn_refln">DIFFRN_REFLN</a></td>
+        <td>  This category redefinition has been added to extend the key of
+     the standard <a href="#diffrn_refln">DIFFRN_REFLN</a> category.
+     <p>
+     Data items in the DIFFRN_REFLN category record details about
+     the intensities in the diffraction data set
+     identified by _diffrn_refln.diffrn_id.
+     <p>
+     The DIFFRN_REFLN data items refer to individual intensity
+     measurements and must be included in looped lists.
+     <p>
+     The DIFFRN_REFLNS data items specify the parameters that apply
+     to all intensity  measurements in the particular diffraction
+     data set identified by _diffrn_reflns.diffrn_id and
+    _diffrn_refln.frame_id
+        </td>
+      </tr>
+
+      <tr>
+        <td valign="top"><a href="#diffrn_scan">DIFFRN_SCAN</a></td>
+        <td>  Data items in the <a href="#diffrn_scan">DIFFRN_SCAN</a> category describe the parameters of one
+     or more scans, relating axis positions to frames.
+        </td>
+      </tr>
+
+      <tr>
+        <td colspan=2>
+        <table border=2>
+        <tr>
+          <td rowspan=1 bgcolor="cyan">&nbsp;</td>
+          <td valign="top"><a href="#diffrn_scan_axis">DIFFRN_SCAN_AXIS</a></td>
+          <td>
+              Data items in the <a href="#diffrn_scan_axis">DIFFRN_SCAN_AXIS</a> category describe the settings of
+     axes for particular scans.  Unspecified axes are assumed to be at
+     their zero points.
+          </td>
+        </tr>
+        </table>
+        </td>
+      </tr>
+
+      <tr>
+        <td colspan=2>
+        <table border=2>
+        <tr>
+          <td rowspan=1 bgcolor="cyan">&nbsp;</td>
+          <td valign="top"><a href="#diffrn_scan_collection">DIFFRN_SCAN_COLLECTION</a></td>
+          <td>
+            Data items in the <a href="#diffrn_scan_collection">DIFFRN_SCAN_COLLECTION</a> category describe
+            the type of collection strategy involved in each scan.
+          </td>
+        </tr>
+        </table>
+        </td>
+      </tr>
+      <tr>
+        <td colspan=2>
+        <table border=2>
+        <tr>
+          <td rowspan=1 bgcolor="cyan">&nbsp;</td>
+          <td valign="top"><a href="#diffrn_scan_frame">DIFFRN_SCAN_FRAME</a></td>
+          <td>
+            Data items in the <a href="#diffrn_scan_frame">DIFFRN_SCAN_FRAME</a> category describe
+            the relationships of particular frames to scans.
+          </td>
+        </tr>
+        </table>
+        </td>
+      </tr>
+      <tr>
+        <td colspan=2>
+        <table border=2>
+        <tr>
+          <td rowspan=1 bgcolor="cyan">&nbsp;</td>
+          <td colspan=2>
+          <table border=2>
+          <tr>
+            <td rowspan=1 bgcolor="cyan">&nbsp;</td>
+            <td valign="top"><a href="#diffrn_scan_frame_axis">DIFFRN_SCAN_FRAME_AXIS</a></td>
+            <td>
+            Data items in the <a href="#diffrn_scan_frame_axis">DIFFRN_SCAN_FRAME_AXIS</a> category describe the
+            settings of axes for particular frames.  Unspecified axes are
+            assumed to be at their zero points.  If, for any given frame,
+            nonzero values apply for any of the data items in this category,
+            those values should be given explicitly in this category and not
+            simply inferred from values in <a href="#diffrn_scan_axis">DIFFRN_SCAN_AXIS</a>.
+            </td>
+          </tr>
+          </table>
+          </td>
+        </tr>
+
+        <tr>
+          <td rowspan=1 bgcolor="cyan">&nbsp;</td>
+          <td colspan=2>
+          <table border=2>
+          <tr>
+            <td rowspan=1 bgcolor="cyan">&nbsp;</td>
+            <td valign="top"><a href="#diffrn_scan_frame_monitor">DIFFRN_SCAN_FRAME_MONITOR</a></td>
+            <td>
+            Data items in the <a href="#diffrn_scan_frame_monitor">DIFFRN_SCAN_FRAME_MONITOR</a> category record
+            the values and details about each monitor for each frame of data
+            during a scan.
+            <p> 
+            Each monitor value is uniquely identified by the combination of
+            the scan id given by <a href="#_diffrn_scan_frame.scan_id" >_diffrn_scan_frame.scan_id</a>,
+            the frame id given by <a href="#_diffrn_scan_frame_monitor.frame_id" >_diffrn_scan_frame_monitor.frame_id</a>,
+            the monitor's detector id given by 
+            <a href="#_diffrn_scan_frame_monitor.detector_id" >_diffrn_scan_frame_monitor.detector_id</a>,
+            and a 1-based ordinal given by <a href="#_diffrn_scan_frame_monitor.id" >_diffrn_scan_frame_monitor.id</a>.
+            <p>
+            If there is only one frame for the scan, the value of
+            <a href="#_diffrn_scan_frame_monitor.frame_id" >_diffrn_scan_frame_monitor.frame_id</a> may be 
+            omitted.
+            <p>             
+            A single frame may have more than one monitor value, and each 
+            monitor value may be the result of integration over the entire
+            frame integration time given by the value of
+            <a href="#_diffrn_scan_frame.integration_time" >_diffrn_scan_frame.integration_time</a>,
+            or many monitor values may be reported over shorter times given 
+            by the value of _diffrn_scan_frame_monitor.integration_time.  If 
+            only one monitor value for a given monitor is collected during 
+            the integration time of the frame, the value of
+            <a href="#_diffrn_scan_frame_monitor.id" >_diffrn_scan_frame_monitor.id</a> may be omitted.
+            </td>
+          </tr>
+          </table>
+          </td>
+        </tr>
+
+        </table>
+        </td>
+      </tr>
+   </table>
+<tr>
+    <td valign="top" rowspan=2>MAP_GROUP</td>
+    <td>Categories that describe maps.</td>
+</tr>
+<tr>
+    <td>
+    <table border=2>
+      <tr>
+        <td valign="top"><a href="#map">MAP</a></td>
+        <td>
+        Data items in the <a href="#map">MAP</a> category record
+        the details of a map. Maps record values of parameters,
+        such as density, that are functions of position within
+        a cell or are functions of orthogonal coordinates in
+        three space.
+        <p>          
+        A map may is composed of one or more map segments
+        specified in the MAP_SEGMENT category.
+        <p>                        
+        Examples are given in the MAP_SEGMENT category.
+        </td>
+      </tr>
+      <tr>
+      <td colspan=2>
+        <table border=2>
+        <td rowspan=1 bgcolor="cyan">&nbsp;</td>
+        <td valign="top"><a href="#map_segment">MAP_SEGMENT</a></td>
+        <td>Data items in the <a href="#map_segment">MAP_SEGMENT</a> category record
+        the details about each segment (section or brick) of a map.
+        </td>
+        </table>
+      </td>
+      </tr>
+</table>
+<tr>
+    <td valign="top" rowspan=2>VARIANT_GROUP</td>
+    <td>Categories that describe variants</td>
+</tr>
+<tr>
+    <td>
+    <table border=2>
+      <tr>
+      <td valign="top"><a href="#variant">VARIANT</a></td>
+      <td>
+              Data items in the <a href="#variant">VARIANT</a> category record
+              the details about sets of variants of data items.
+              <p>
+              There is sometimes a need to allow for multiple versions of the
+              same data items in order to allow for refinements and corrections
+              to earlier assumptions, observations and calculations.  In order
+              to allow data sets to contain more than one variant of the same
+              information, an optional ...variant data item as a pointer to
+              _variant.variant has been added to the key of every category,
+              as an implicit data item with a null (empty) default value.
+              <p>
+              All rows in a category with the same variant value are considered 
+              to be related to one another and to all rows in other categories
+              with the same variant value.  For a given variant, all such rows
+              are also considered to be related to all rows with a null variant
+              value, except that a row with a null variant value is for which
+              all other components of its key are identical to those entries
+              in another row with a non-null variant value is not related the
+              the rows with that non-null variant value.  This behavior is 
+              similar to the convention for identifying alternate conformers 
+              in an atom list.
+              <p>
+              An optional role may be specified for a variant as the value of
+              _variant.role.  Possible roles are null, "preferred", 
+              "raw data", "unsuccessful trial".
+              <p>
+              variants may carry an optional timestamp as the value of
+              _variant.timestamp.
+              <p>
+              variants may be related to other variants from which they were
+              derived by the value of _variant.variant_of
+              <p>
+              Further details about the variant may be specified as the value
+              of _variant.details.
+             <p> 
+              In order to allow variant information from multiple datasets to
+              be combined, _variant.diffrn_id and/or _variant.entry_id may
+              be used. 
+      </td>
+    </tr>
+
+   </table>
+
+</td>
+</tr>
+</table></font></div>
+;
+    _dictionary.title           cif_img.dic
+    _dictionary.version         1.8.6
+    _dictionary.datablock_id    cif_img.dic
+
+#########################
+## <a name="CATEGORY_GROUP_LIST">CATEGORY_GROUP_LIST</a> ##
+#########################
+
+     loop_
+    _category_group_list.id
+    _category_group_list.parent_id
+    _category_group_list.description
+             'inclusive_group'   .
+;             Categories that belong to the dictionary extension.
+;
+             'array_data_group'
+             'inclusive_group'
+;             Categories that describe array data.
+;
+             'axis_group'
+             'inclusive_group'
+;             Categories that describe axes.
+;
+             'diffrn_group'
+             'inclusive_group'
+;             Categories that describe details of the diffraction experiment.
+;
+             'map_group'
+             'inclusive_group'
+;             Categories that describe details of map data.
+;
+             'variant_group'
+             'inclusive_group'
+;             Categories that describe details of variants.
+;
+
+
+##################
+## <a name="SUB_CATEGORY">SUB_CATEGORY</a> ##
+##################
+
+     loop_
+    _sub_category.id
+    _sub_category.description
+              'matrix'
+;              The collection of elements of a matrix.
+;
+              'vector'
+;              The collection of elements of a vector.
+;
+
+
+
+
+##############
+# <a name="ARRAY_DATA">ARRAY_DATA</a> #
+##############
+
+
+save_ARRAY_DATA
+    _category.description
+;   Data items in the <a href="#array_data">ARRAY_DATA</a> category are the containers for
+    the array data items described in the category <a href="#array_structure">ARRAY_STRUCTURE</a>.
+
+    It is recognized that the data in this category need to be used in
+    two distinct ways.  During a data collection the lack of ancillary
+    data and timing constraints in processing data may dictate the
+    need to make a 'miniCBF', nothing more than an essential minimum
+    of information to record the results of the data collection.  In that
+    case it is proper to use the <a href="#array_data">ARRAY_DATA</a> category as a
+    container for just a single image and a compacted, beamline-dependent
+    list of data collection parameter values.  In such
+    a case, only the tags '<a href="#_array_data.header_convention">_array_data.header_convention</a>',
+    '<a href="#_array_data.header_contents">_array_data.header_contents</a>' and '<a href="#_array_data.data">_array_data.data</a>' need be
+    populated.
+
+    For full processing and archiving, most of the tags in this
+    dictionary will need to be populated.
+;
+    _category.id                   array_data
+    _category.mandatory_code       no
+<div id="print_NX_array_data" style="display:block">   #_category.NX_mapping_details in online version <a href="javascript:open_close2('online_NX_array_data','print_NX_array_data');">+/-</a>
+</div><div id="online_NX_array_data" style="display:none">    _category.NX_mapping_details                  #<a href="javascript:open_close2('online_NX_array_data','print_NX_array_data');">+/-</a>
+;
+
+    _array_data.array_id ARRAYID
+    _array_data.binary_id BINARYID
+    _array_data.data  DATAARRAY
+    _array_data.header_contents HEADER
+    _array_data.header_convention HEADERCONVENTION
+
+    -->
+
+    /entry:NXentry
+     /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+           /data_ARRAYID_BINARYID -->
+                /entry/data_ARRAYID_BINARYID/data_ARRAYID_BINARYID
+            @CBF_array_id="ARRAYID"
+            @CBF_binary_id="BINARYID"
+            @CBF_header_contents="HEADER"
+            @CBF_header_convention="HEADERCONVENTION"
+;
+</div>
+     loop_
+    _category_key.name             '<a href="#_array_data.array_id" >_array_data.array_id</a>'
+                                   '<a href="#_array_data.binary_id" >_array_data.binary_id</a>'
+                                   '<a href="#_array_data.variant" >_array_data.variant</a>'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'array_data_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+        Example 1.
+
+        This example shows two binary data blocks.  The first one
+        was compressed by the CBF_CANONICAL compression algorithm and is
+        presented as hexadecimal data.  The first character 'H' on the
+        data lines means hexadecimal.  It could have been 'O' for octal
+        or 'D' for decimal.  The second character on the line shows
+        the number of bytes in each word (in this case '4'), which then
+        requires eight hexadecimal digits per word.  The third character
+        gives the order of octets within a word, in this case '&lt;'
+        for the ordering 4321 (i.e. 'big-endian').  Alternatively, the
+        character '&gt;' could have been used for the ordering 1234
+        (i.e. 'little-endian').  The block has a 'message digest'
+        to check the integrity of the data.
+
+        The second block is similar, but uses CBF_PACKED compression
+        and BASE64 encoding.  Note that the size and the digest are
+        different.
+;
+;
+
+         loop_
+        <a href="#_array_data.array_id" >_array_data.array_id</a>
+        <a href="#_array_data.binary_id" >_array_data.binary_id</a>
+        <a href="#_array_data.data" >_array_data.data</a>
+        image_1 1
+        ;
+        --CIF-BINARY-FORMAT-SECTION--
+        Content-Type: application/octet-stream;
+             conversions=&quot;<b>X</b>-CBF_CANONICAL&quot;
+        Content-Transfer-Encoding: <b>X</b>-BASE16
+        X-Binary-Size: 3927126
+        X-Binary-ID: 1
+        Content-MD5: u2sTJEovAHkmkDjPi+gWsg==
+
+        # Hexadecimal encoding, byte 0, byte order ...21
+        #
+        H4&lt; 0050B810 00000000 00000000 00000000 000F423F 00000000 00000000 ...
+        ....
+        --CIF-BINARY-FORMAT-SECTION----
+        ;
+        image_2 2
+        ;
+        --CIF-BINARY-FORMAT-SECTION--
+        Content-Type: application/octet-stream;
+             conversions=&quot;X-CBF-PACKED&quot;
+        Content-Transfer-Encoding: BASE64
+        X-Binary-Size: 3745758
+        X-Binary-ID: 2
+        Content-MD5: 1zsJjWPfol2GYl2V+QSXrw==
+
+        ELhQAAAAAAAA...
+        ...
+        --CIF-BINARY-FORMAT-SECTION----
+        ;
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+        Example 2.
+
+        This example shows a single image in a miniCBF, provided by
+        E. Eikenberry.  The entire CBF consists of one data block
+        containing one category and three tags.  The CBFlib
+        program convert_miniCBF and a suitable template file
+        can be used to convert this miniCBF to a full imgCIF
+        file.
+;
+;
+        ###CBF: VERSION 1.5
+        # CBF file written by CBFlib v0.7.8
+
+        data_insulin_pilatus6m
+
+        <a href="#_array_data.header_convention">_array_data.header_convention</a> SLS_1.0
+        <a href="#_array_data.header_contents">_array_data.header_contents</a>
+        ;
+        # Detector: PILATUS 6M SN: 60-0001
+        # 2007/Jun/17 15:12:36.928
+        # Pixel_size 172e-6 m x 172e-6 m
+        # Silicon sensor, thickness 0.000320 m
+        # Exposure_time 0.995000 s
+        # Exposure_period 1.000000 s
+        # Tau = 194.0e-09 s
+        # Count_cutoff 1048575 counts
+        # Threshold_setting 5000 eV
+        # Wavelength 1.2398 A
+        # Energy_range (0, 0) eV
+        # Detector_distance 0.15500 m
+        # Detector_Voffset -0.01003 m
+        # Beam_xy (1231.00, 1277.00) pixels
+        # Flux 22487563295 ph/s
+        # Filter_transmission 0.0008
+        # Start_angle 13.0000 deg.
+        # Angle_increment 1.0000 deg.
+        # Detector_2theta 0.0000 deg.
+        # Polarization 0.990
+        # Alpha 0.0000 deg.
+        # Kappa 0.0000 deg.
+        # Phi 0.0000 deg.
+        # Chi 0.0000 deg.
+        # Oscillation_axis  X, CW
+        # N_oscillations 1
+        ;
+
+        <a href="#_array_data.data">_array_data.data</a>
+        ;
+        --CIF-BINARY-FORMAT-SECTION--
+        Content-Type: application/octet-stream;
+             conversions="x-CBF_BYTE_OFFSET"
+        Content-Transfer-Encoding: BINARY
+        X-Binary-Size: 6247567
+        X-Binary-ID: 1
+        X-Binary-Element-Type: "signed 32-bit integer"
+        X-Binary-Element-Byte-Order: LITTLE_ENDIAN
+        Content-MD5: 8wO6i2+899lf5iO8QPdgrw==
+        X-Binary-Number-of-Elements: 6224001
+        X-Binary-Size-Fastest-Dimension: 2463
+        X-Binary-Size-Second-Dimension: 2527
+        X-Binary-Size-Padding: 4095
+
+        ...
+
+        --CIF-BINARY-FORMAT-SECTION----
+        ;
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+save_
+
+
+save_<a name="_array_data.array_id" >_array_data.array_id</a>
+    _item_description.description
+;             This item is a pointer to <a href="#_array_structure.id" >_array_structure.id</a> in the
+              <a href="#array_structure">ARRAY_STRUCTURE</a> category.
+
+              If not given, it defaults to 1.
+
+;
+    _item.name                  '<a href="#_array_data.array_id" >_array_data.array_id</a>'
+    _item.category_id             array_data
+    _item.mandatory_code          implicit
+    _item_default.value           1
+    _item_type.code               code
+     save_
+
+
+save_<a name="_array_data.binary_id" >_array_data.binary_id</a>
+    _item_description.description
+;             This item is an integer identifier which, along with
+              <a href="#_array_data.array_id" >_array_data.array_id</a>, should uniquely identify the
+              particular block of array data.
+
+              If <a href="#_array_data.binary_id" >_array_data.binary_id</a> is not explicitly given,
+              it defaults to 1.
+
+              The value of <a href="#_array_data.binary_id" >_array_data.binary_id</a> distinguishes
+              among multiple sets of data with the same array
+              structure.
+
+              If the MIME header of the data array specifies a
+              value for X-Binary-ID, the value of  <a href="#_array_data.binary_id" >_array_data.binary_id</a>
+              should be equal to the value given for X-Binary-ID.
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+             '<a href="#_array_data.binary_id" >_array_data.binary_id</a>'            array_data
+                                                                implicit
+             '<a href="#_diffrn_data_frame.binary_id" >_diffrn_data_frame.binary_id</a>'     diffrn_data_frame
+                                                                implicit
+             '<a href="#_array_intensities.binary_id" >_array_intensities.binary_id</a>'     array_intensities
+                                                                implicit
+     loop_
+    _item_linked.child_name
+    _item_linked.parent_name
+             '<a href="#_diffrn_data_frame.binary_id" >_diffrn_data_frame.binary_id</a>'     '<a href="#_array_data.binary_id" >_array_data.binary_id</a>'
+             '<a href="#_array_intensities.binary_id" >_array_intensities.binary_id</a>'     '<a href="#_array_data.binary_id" >_array_data.binary_id</a>'
+
+    _item_default.value           1
+    _item_type.code               int
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            1  1
+                            .  1
+     save_
+
+
+save_<a name="_array_data.data" >_array_data.data</a>
+    _item_description.description
+;             The value of <a href="#_array_data.data" >_array_data.data</a> contains the array data
+              encapsulated in a STAR string.  The value of this item is 
+              required unless a value is given for 
+              <a href="#_array_data.external_data_id"> _array_data.external_data_id</a> instead, in which 
+              case, a null value of '.' should be given here.
+
+              The representation used is a variant on the
+              Multipurpose Internet Mail Extensions (MIME) specified
+              in RFC 2045-2049 by N. Freed et al.  The boundary
+              delimiter used in writing an imgCIF or CBF is
+              \n--CIF-BINARY-FORMAT-SECTION-- (including the
+              required initial \n--, where \n represents the system
+              newline character(s)).
+
+              The Content-Type may be any of the discrete types permitted
+              in RFC 2045; 'application/octet-stream' is recommended
+              for diffraction images in the ARRAY_DATA category.
+              Note:  When appropriate in other categories, e.g. for
+              photographs of crystals, more precise types, such as
+              'image/jpeg', 'image/tiff', 'image/png', etc. should be used.
+
+              If an octet stream was compressed, the compression should
+              be specified by the parameter
+                conversions="X-CBF_PACKED"
+              or the parameter
+                conversions="X-CBF_CANONICAL"
+              or the parameter
+                conversions="X-CBF_BYTE_OFFSET"
+              or the parameter
+                conversions="X-CBF_BACKGROUND_OFFSET_DELTA"
+
+              If the parameter 
+                conversions=&quot;X-CBF_PACKED&quot;
+              is given it may be further modified with the parameters
+                uncorrelated_sections
+              or
+                flat
+              (e.g. conversions="X-CBF_PACKED flat").
+              In such cases the <a href="#array_structure.compression_type_flag" >_array_structure.compression_type_flag</a>
+              should also be present with the corresponding value.
+
+              If the &quot;uncorrelated_sections&quot; parameter is
+              given, each section will be compressed without using
+              the prior section for averaging.
+
+              If the &quot;flat&quot; parameter is given, each
+              image will be treated as one long row.
+
+              Note that X-CBF_CANONICAL and X-CBF_PACKED are
+              slower but more efficient compressions than the others.
+              The X-CBF_BYTE_OFFSET compression is a good compromise
+              between speed and efficiency for ordinary diffraction
+              images.  The X-CBF_BACKGROUND_OFFSET_DELTA compression
+              is oriented towards sparse data, such as masks and
+              tables of replacement pixel values for images with
+              overloaded spots.
+
+              The Content-Transfer-Encoding may be 'BASE64',
+              'Quoted-Printable', 'X-BASE8', 'X-BASE10',
+              'X-BASE16' or 'X-BASE32K', for an imgCIF or 'BINARY'
+              for a CBF.  The octal, decimal and hexadecimal transfer
+              encodings are provided for convenience in debugging and
+              are not recommended for archiving and data interchange.
+
+              In a CIF, one of the parameters 'charset=us-ascii',
+              'charset=utf-8' or 'charset=utf-16' may be used on the
+              Content-Transfer-Encoding to specify the character set
+              used for the external presentation of the encoded data.
+              If no charset parameter is given, the character set of
+              the enclosing CIF is assumed.  In any case, if a BOM
+              flag is detected (FE FF for big-endian UTF-16, FF FE for
+              little-endian UTF-16 or EF BB BF for UTF-8) is detected,
+              the indicated charset will be assumed until the end of the
+              encoded data or the detection of a different BOM.  The
+              charset of the Content-Transfer-Encoding is not the character
+              set of the encoded data, only the character set of the
+              presentation of the encoded data and should be respecified
+              for each distinct STAR string.
+
+              In an imgCIF file, the encoded binary data begin after
+              the empty line terminating the header.  In an imgCIF file,
+              the encoded binary data ends with the terminating boundary
+              delimiter '\n--CIF-BINARY-FORMAT-SECTION----'
+              in the currently effective charset or with the '\n;'
+              that terminates the STAR string.
+
+              In a CBF, the raw binary data begin after an empty line
+              terminating the header and after the sequence:
+
+              Octet   Hex   Decimal  Purpose
+                0     0C       12    Ctrl-L: page break
+                1     1A       26    Ctrl-Z: stop listings, MS-DOS
+                2     04       04    Ctrl-D: stop listings, UNIX
+                3     D5      213    binary section begins
+
+              None of these octets are included in the calculation of
+              the message size or in the calculation of the
+              message digest.
+
+              The X-Binary-Size header specifies the size of the
+              equivalent binary data in octets.  If compression was
+              used, this size is the size after compression, including
+              any book-keeping fields.  An adjustment is made for
+              the deprecated binary formats in which eight bytes of binary
+              header are used for the compression type.  In this case,
+              the eight bytes used for the compression type are subtracted
+              from the size, so that the same size will be reported
+              if the compression type is supplied in the MIME header.
+              Use of the MIME header is the recommended way to
+              supply the compression type.  In general, no portion of
+              the  binary header is included in the calculation of the size.
+
+              The X-Binary-Element-Type header specifies the type of
+              binary data in the octets, using the same descriptive
+              phrases as in <a href="#_array_structure.encoding_type">_array_structure.encoding_type</a>.  The default
+              value is 'unsigned 32-bit integer'.
+
+              An MD5 message digest may, optionally, be used. The 'RSA Data
+              Security, Inc. MD5 Message-Digest Algorithm' should be used.
+              No portion of the header is included in the calculation of the
+              message digest.
+
+              If the Transfer Encoding is 'X-BASE8', 'X-BASE10' or
+              'X-BASE16', the data are presented as octal, decimal or
+              hexadecimal data organized into lines or words.  Each word
+              is created by composing octets of data in fixed groups of
+              2, 3, 4, 6 or 8 octets, either in the order ...4321 ('big-
+              endian') or 1234... ('little-endian').  If there are fewer
+              than the specified number of octets to fill the last word,
+              then the missing octets are presented as '==' for each
+              missing octet.  Exactly two equal signs are used for each
+              missing octet even for octal and decimal encoding.
+              The format of lines is:
+
+              rnd xxxxxx xxxxxx xxxxxx
+
+              where r is 'H', 'O' or 'D' for hexadecimal, octal or
+              decimal, n is the number of octets per word and d is '&lt;'
+              or '&gt;' for the '...4321' and '1234...' octet orderings,
+              respectively.  The '==' padding for the last word should
+              be on the appropriate side to correspond to the missing
+              octets, e.g.
+
+              H4&lt; FFFFFFFF FFFFFFFF 07FFFFFF ====0000
+
+              or
+
+              H3&gt; FF0700 00====
+
+              For these hexadecimal, octal and decimal formats only,
+              comments beginning with '#' are permitted to improve
+              readability.
+
+              BASE64 encoding follows MIME conventions.  Octets are
+              in groups of three: c1, c2, c3.  The resulting 24 bits
+              are broken into four six-bit quantities, starting with
+              the high-order six bits (c1 &gt;&gt; 2) of the first octet, then
+              the low-order two bits of the first octet followed by the
+              high-order four bits of the second octet [(c1 &amp; 3)&lt;&lt;4 | (c2&gt;&gt;4)],
+              then the bottom four bits of the second octet followed by the
+              high-order two bits of the last octet [(c2 &amp; 15)&lt;&lt;2 | (c3&gt;&gt;6)],
+              then the bottom six bits of the last octet (c3 &amp; 63).  Each
+              of these four quantities is translated into an ASCII character
+              using the mapping:
+
+                        1         2         3         4         5         6
+              0123456789012345678901234567890123456789012345678901234567890123
+              |         |         |         |         |         |         |
+              ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/
+
+              with short groups of octets padded on the right with one '='
+              if c3 is missing, and with '==' if both c2 and c3 are missing.
+
+              X-BASE32K encoding is similar to BASE64 encoding, except that
+              sets of 15 octets are encoded as sets of 8 16-bit Unicode
+              characters, by breaking the 120 bits into 8 15-bit quantities.
+              256 is added to each 15-bit quantity to bring it into a
+              printable Unicode range.  When encoding, zero padding is used
+              to fill out the last 15-bit quantity.  If 8 or more bits of
+              padding are used, a single equals sign (hexadecimal 003D) is
+              appended.  Embedded whitespace and newlines are introduced
+              to produce lines of no more than 80 characters each.  On
+              decoding, all printable ASCII characters and ASCII whitespace
+              characters are ignored except for any trailing equals signs.
+              The number of trailing equals signs indicated the number of
+              trailing octets to be trimmed from the end of the decoded data
+              (see Darakev et al., 2006).
+
+              QUOTED-PRINTABLE encoding also follows MIME conventions, copying
+              octets without translation if their ASCII values are 32...38,
+              42, 48...57, 59, 60, 62, 64...126 and the octet is not a ';'
+              in column 1.  All other characters are translated to =nn, where
+              nn is the hexadecimal encoding of the octet.  All lines are
+              'wrapped' with a terminating '=' (i.e. the MIME conventions
+              for an implicit line terminator are never used).
+
+              The 'X-Binary-Element-Byte-Order' can specify either
+              'BIG_ENDIAN' or 'LITTLE_ENDIAN' byte order of the image
+              data.  Only LITTLE_ENDIAN is recommended.  Processors
+              may treat BIG_ENDIAN as a warning of data that can
+              only be processed by special software.
+
+              The 'X-Binary-Number-of-Elements' specifies the number of
+              elements (not the number of octets) in the decompressed,
+              decoded image.
+
+              The optional 'X-Binary-Size-Fastest-Dimension' specifies the
+              number of elements (not the number of octets) in one row of the
+              fastest changing dimension of the binary data array. This
+              information must be in the MIME header for proper operation of
+              some of the decompression algorithms.
+
+              The optional 'X-Binary-Size-Second-Dimension' specifies the
+              number of elements (not the number of octets) in one column of
+              the second-fastest changing dimension of the binary data array.
+              This information must be in the MIME header for proper operation
+              of some of the decompression algorithms.
+
+              The optional 'X-Binary-Size-Third-Dimension' specifies the
+              number of sections for the third-fastest changing dimension of
+              the binary data array.
+
+              The optional 'X-Binary-Size-Padding' specifies the size in
+              octets of an optional padding after the binary array data and
+              before the closing flags for a binary section.
+
+              Reference:
+
+              Darakev, G., Litchev, V., Mitev, K. Z. & Bernstein, H. J. (2006).
+              'Efficient Support of Binary Data in the XML Implementation of
+              the NeXus File Format', abstract W0165, ACA Summer Meeting,
+              Honolulu, HI, USA, July 2006.
+;
+    _item.name                  '<a href="#_array_data.data" >_array_data.data</a>'
+    _item.category_id             <a href="#array_data">array_data</a>
+    _item.mandatory_code          yes
+    _item_type.code               binary
+save_
+
+save_<a name="_array_data.external_data_id" >_array_data.external_data_id</a>
+    _item_description.description
+;             This item is a pointer to <a href="#_array_data_external_data.id" >_array_data_external_data.id</a> in the
+              <a href="#array_data_external_data">ARRAY_DATA_EXTERNAL_DATA</a> category.
+
+              If not given, then the actual array data should be specified as
+              the value of <a href="#_array_data.data" >_array_data.data</a>.  If
+              both values are given, the value on <a href="#_array_data.data" >_array_data.data</a> takes
+              precedence, and a warning of a possible conflict should be issued. 
+
+;
+    _item.name                  '<a href="#_array_data.external_data_id" >_array_data.external_data_id</a>'
+    _item.category_id             array_data
+    _item.mandatory_code          implicit
+    _item_default.value           1
+    _item_type.code               code
+     save_
+
+save_<a name="_array_data.header_contents" >_array_data.header_contents</a>
+    _item_description.description
+;             This item is a text field for use in minimal CBF files to carry
+              essential header information to be kept with image data
+              in <a href="#_array_data.data" >_array_data.data</a> when the tags that normally carry the
+              structured metadata for the image have not been populated.
+
+              Normally this data item should not appear when the full set
+              of tags has been populated and <a href="#_diffrn_data_frame.details">_diffrn_data_frame.details</a>
+              appears.
+;
+    _item.name                  '<a href="#_array_data.header_contents" >_array_data.header_contents</a>'
+    _item.category_id            <a href="#array_data">array_data</a>
+    _item.mandatory_code         no
+    _item_type.code              text
+     save_
+
+
+save_<a name="_array_data.header_convention" >_array_data.header_convention</a>
+    _item_description.description
+;             This item is an identifier for the convention followed in
+              constructing the contents of <a href="#_array_data.header_contents" >_array_data.header_contents</a>
+
+              The permitted values are of an image creator identifier
+              followed by an underscore and a version string.  To avoid
+              confusion about conventions, all creator identifiers
+              should be registered with the IUCr and the conventions
+              for all identifiers and versions should be posted on
+              the MEDSBIO.org web site.
+;
+    _item.name                  '<a href="#_array_data.header_convention" >_array_data.header_convention</a>'
+    _item.category_id            <a href="#array_data">array_data</a>
+    _item.mandatory_code         no
+    _item_type.code              code
+     save_
+
+
+save_<a name="_array_data.variant" >_array_data.variant</a>
+    _item_description.description
+;             The value of <a href="#_array_data.variant" >_array_data.variant</a> gives the variant
+              to which the given ARRAY_DATA row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to <a href="#_variant.variant" >_variant.variant</a> in the
+              <a href="#variant">VARIANT</a> category.
+;
+    _item.name                  '<a href="#_array_data.variant" >_array_data.variant</a>'
+    _item.category_id             array_data
+    _item.mandatory_code          implicit
+    _item_default.value           .
+    _item_type.code               code
+     save_
+
+############################
+# <a name="array_data_external_data">ARRAY_DATA_EXTERNAL_DATA</a> #
+############################
+
+
+save_ARRAY_DATA_EXTERNAL_DATA
+    _category.description
+;   Data items in the <a href="#array_data_external_data">ARRAY_DATA_EXTERNAL_DATA</a> category optionally
+    record the location and essential characteristics of arrays of data for use in 
+    <a href="#array_data">ARRAY_DATA</a> that are found external to the cif_img file.
+;
+    _category.id                   array_data_external_data
+    _category.mandatory_code       no
+<div id="print_NX_array_element_size" style="display:block">   #_category.NX_mapping_details in online version <a href="javascript:open_close2('online_NX_array_element_size','print_NX_array_element_size');">+/-</a>
+</div><div id="online_NX_array_element_size" style="display:none">    _category.NX_mapping_details                  #<a href="javascript:open_close2('online_NX_array_element_size','print_NX_array_element_size');">+/-</a>
+;
+
+    _array_data.array_id ARRAYID
+    _array_data.binary_id BINARYID
+    _array_data.external_data_id EXTERNAL_DATA_ID
+    _array_data.header_contents HEADER
+    _array_data.header_convention HEADERCONVENTION
+
+    _array_data_external_data.archive_format ARCHIVEFORMAT
+    _array_data_external_data.archive_path ARCHIVEPATH
+    _array_data_external_data.id EXTERNAL_DATA_ID
+    _array_data_external_data.format HDF5
+    _array_data_external_data.uri DATAURI
+    _array_data_external_data.path DATAPATH
+    _array_data_external_data.frame DATAFRAME
+
+
+    -->
+
+    /entry:NXentry
+     /data_ARRAYID_BINARYID:NXdata
+       data_ARRAYID_BINARYID --> DATAURI//DATAPATH
+     /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+           /data_ARRAYID_BINARYID -->
+                /entry/data_ARRAYID_BINARYID/data_ARRAYID_BINARYID
+            @CBF_array_id="ARRAYID"
+            @CBF_binary_id="BINARYID"
+            @CBF_header_contents="HEADER"
+            @CBF_header_convention="HEADERCONVENTION"
+            @CBF_external_data_archive_format="ARCHIVEFORMAT"
+            @CBF_external_data_archive_path="ARCHIVEPATH""
+            @CBF_external_data_uri="DATAURI"
+            @CBF_external_data_path="DATAPATH"
+            @CBF_external_data_frame="DATAFRAME"
+;
+</div>
+    _category_key.name             '<a href="#_array_data_external_data.id" >_array_data_external_data.id</a>'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'array_data_group'
+     save_
+
+
+save_<a name="_array_data_external_data.archive_format" >_array_data_external_data.archive_format</a>
+    _item_description.description
+;
+
+    The type of single-file archive in which image data or multi-image
+    inage containers have been encapsulated, if any. The archive is 
+    located at <a href="#_array_data_external_data.uri" >_array_data_external_data.uri</a>.
+
+;
+
+    _item.name                 '<a href="#_array_data_external_data.archive_format" >_array_data_external_data.archive_format</a>'
+    _item.category_id            <a href="#array_data_external_data">array_data_external_data</a>
+    _item.type_code              code
+    _item_default.value          .
+
+    loop_
+    _item_enumeration.value
+    _item_enumeration.detail
+    ZIP           'A ZIP archive'
+    TGZ           'A Gzipped tar archive'
+    TBZ           'A Bzip2 tar archive'
+    .             'No compressed archive is present'
+save_
+
+
+save_<a name="_array_data_external_data.archive_path" >_array_data_external_data.archive_path</a>
+   _item_description.description
+
+;
+
+    The location of the image or multi-image image container, 
+    such as HDF5 or CBF, within an archive such as a tarball.
+
+;
+
+    _item.name                 '<a href="#_array_data_external_data.archive_path" >_array_data_external_data.archive_path</a>'
+    _item.category_id            <a href="#array_data_external_data">array_data_external_data</a>
+    _item_type.code              text
+
+    save_
+
+save_<a name="_array_data_external_data.frame" >_array_data_external_data.frame</a>
+    _item_description.description
+;
+
+    The position of the raw data array in what may possibly be a
+    multi-dimensional array of data referenced by   
+       <a href="#_array_data_external_data.uri" >_array_data_external_data.uri</a> and <a href="#_array_data_external_data.path" >_array_data_external_data.path</a>.
+    For many of the formats, data for a single frame is identified by that
+    reference.  If data for multiple frames or data for portions of
+    one or more frames is referenced, the desired portion can be
+    identified dimension by dimension as an array section identifier 
+    the form
+       ARRAYID(start1:end1:stride1,start2:end2:stride2, ...)
+    or other valid <a href="#array_structure_list_section">ARRAY_STRUCTURE_LIST_SECTION</a>
+    identifier.
+    
+    Note that the precendence ordering of dimensions varies, even within a
+    single specified format.  For example HDF5 supports both C slowest first
+    and Fortran fastest first, so it is essential to properly populate
+    <a href="#array_structure_list">ARRAY_STRUCTURE_LIST</a> category.
+    
+;
+    _item.name                 '<a href="#_array_data_external_data.frame" >_array_data_external_data.frame</a>'
+    _item.category_id            <a href="#array_data_external_data">array_data_external_data</a>
+    _item_type.code              code
+    _item_default.value          1
+    loop_
+    _item_examples.case
+    _item_examples.detail
+    4                           'The fourth frame in the referenced data array'
+
+    save_
+
+
+save_<a name="_array_data_external_data.format" >_array_data_external_data.format</a>
+    _item_description.description
+;
+    The format in which raw array data referenced by
+    <a href="#_array_data_external_data.uri" >_array_data_external_data.uri</a> and following archive extraction can be
+    accessed. Items in <a href="#array_structure" >array_structure</a> and <a href="#array_structure_list" >array_structure_list</a> refer
+    to the data after any decompressions and other transformations
+    performed by standard libraries associated with the format as
+    described in the description of each format below.
+
+    Note that, if a single file archive, such as a zip or tarball
+    has been specified at <a href="#_array_data_external_data.uri" >_array_data_external_data.uri</a>
+    then the format of the archive, as contrasted with the format of
+    the image or the multi-image image container such as CBF or
+    HDF5 is specified by <a href="#_array_data_external_data.archive_format" >_array_data_external_data.archive_format</a>
+    and the particular image is specified by the combination of
+    <a href="#_array_data_external_data.archive_path" >_array_data_external_data.archive_path</a>,
+    <a href="#_array_data_external_data.format" >_array_data_external_data.format</a>,
+    <a href="#_array_data_external_data.path" >_array_data_external_data.path</a>, and
+    <a href="#_array_data_external_data.frame" >_array_data_external_data.frame</a> while
+    if no single file archive is used, so that a CBF, HDF5, TIFF or SMV is specified
+    at <a href="#_array_data_external_data.uri" >_array_data_external_data.uri</a>, then
+    the particular image is specified by the combination of 
+    <a href="#_array_data_external_data.format" >_array_data_external_data.format</a>,
+    <a href="#_array_data_external_data.path" >_array_data_external_data.path</a>, and
+    <a href="#_array_data_external_data.frame" >_array_data_external_data.frame</a> directly.
+
+;
+
+    _item.name                 '<a href="#_array_data_external_data.format" >_array_data_external_data.format</a>'
+    _item.category_id            <a href="#array_data_external_data">array_data_external_data</a>
+    _item.mandatory_code         no
+    _item.type_code              code
+
+    loop_
+    _item_enumeration.value
+    _item_enumeration.detail
+    CBF
+;
+    The contents of _array_data.data in a single-frame imgCBF file. Other
+    datanames in the external file are ignored.
+;
+    SMV
+;
+    An unprocessed sequence of bytes contained in a file conforming to the SMV 
+    format as used by ADSC and other CCD manufacturers.
+;
+    HDF5
+;
+    An array of numbers contained in a dataset in an HDF5 file as returned by HDF5 
+    library functions.  '<a href="#_array_data_external_data.path" >_array_data_external_data.path</a>' is the
+    internal HDF5 path.  In an HDF5 file, the path typically identifies a dataset
+    with multiple images.
+;
+    MAR
+;
+    An array of numbers corresponding to a decompressed single frame contained
+    within a MARCCD file (TIFF format).
+;
+    Bruker
+;
+    An array of numbers corresponding to a decompressed single frame from a 
+    data file generated by Bruker equipment.
+;
+
+
+    loop_
+      _item_examples.case
+      _item_examples.detail
+;
+    loop_
+    <a href="#_array_data.array_id" >_array_data.array_id</a>
+    <a href="#_array_data.binary_id" >_array_data.binary_id</a>
+    <a href="#_array_data.external_data_id" >_array_data.external_data_id</a>
+    1 1 1
+    1 2 2
+    loop_
+    <a href="#_array_data_external_data.id" >_array_data_external_data.id</a>
+    <a href="#_array_data_external_data.format" >_array_data_external_data.format</a>
+    <a href="#_array_data_external_data.uri" >_array_data_external_data.uri</a>
+    <a href="#_array_data_external_data.path" >_array_data_external_data.path</a>
+    <a href="#_array_data_external_data.frame" >_array_data_external_data.frame<a>
+    1 HDF5 https://zenodo.org/record/12345/files/tartaric.h5 /entry1/detector1/data 1
+    2 HDF5 https://zenodo.org/record/12345/files/tartaric.h5 /entry1/detector1/data 2
+    ...
+;
+;
+    The frames are contained in a single HDF5-format file accessible
+    at https://zenodo.org/record/12345/files/tartaric.h5. An array of 2D
+    images is found at HDF5 location entry1/detector1/data
+;
+
+;
+    loop_
+    <a href="#_array_data.array_id" >_array_data.array_id</a>
+    <a href="#_array_data.binary_id" >_array_data.binary_id</a>
+    <a href="#_array_data.external_data_id" >_array_data.external_data_id</a>
+    1 1 1
+    1 2 2
+    loop_
+    <a href="#_array_data_external_data.id" >_array_data_external_data.id</a>
+    <a href="#_array_data_external_data.format" >_array_data_external_data.format</a>
+    <a href="#_array_data_external_data.version" >_array_data_external_data.version</a>
+    <a href="#_array_data_external_data.uri" >_array_data_external_data.uri</a>
+    1 Bruker Smart6000 https://uni_repo.edu/5341/run1/tartaric.001 
+    2 Bruker Smart6000 https://uni_repo.edu/5341/run1/tartaric.002
+    ...
+;
+;
+    Frames are contained in individual Smart6000 Bruker-format files
+    accessible using https://uni_repo.edu/5341 in subdirectory run1.
+;
+
+;
+    loop_
+    <a href="#_array_data.array_id" >_array_data.array_id</a>
+    <a href="#_array_data.binary_id" >_array_data.binary_id</a>
+    <a href="#_array_data.external_data_id" >_array_data.external_data_id</a>
+    1 1 1
+    1 2 2
+    loop_
+    <a href="#_array_data_external_data.id" >_array_data_external_data.id</a>
+    <a href="#_array_data_external_data.format" >_array_data_external_data.format</a>
+    <a href="#_array_data_external_data.uri" >_array_data_external_data.uri</a>
+    <a href="#_array_data_external_data.archive_format" >_array_data_external_data.archive_format</a>
+    <a href="#_array_data_external_data.path" >_array_data_external_data.archive_path</a>
+    1 SMV
+        https://data.proteindiffraction.org/ssgcid/MyulA_01062_a_B12-sddc0001574_7k69.tar.bz2
+        TBZ
+        MyulA_01062_a_B12-sddc0001574_7k69/data/317895h4_y_0001.img
+    2 SMV
+        https://data.proteindiffraction.org/ssgcid/MyulA_01062_a_B12-sddc0001574_7k69.tar.bz2
+        TBZ
+        MyulA_01062_a_B12-sddc0001574_7k69/data/317895h4_y_0002.img
+;
+;
+    Frames with SMV format are contained at data.proteindiffraction.org in a tarred
+    archive compressed with bzip2.   
+;
+    save_
+
+save_<a name="_array_data_external_data.id" >_array_data_external_data.id</a>
+    _item_description.description
+;             The value of <a href="#_array_data_external_data.id" >_array_data_external_data.id</a> must uniquely identify
+              each item of array_data_external_data.              
+
+              This item has been made implicit and given a default value of 1
+              as a convenience in writing miniCBF files.  Normally an
+              explicit name with useful content should be used.
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+             '<a href="#_array_data_external_data.id" >_array_data_external_data.id</a>'    array_data_external_data      implicit
+             '<a href="#_array_data.external_data_id" >_array_data.external_data_id</a>'    array_data                    implicit
+
+
+    _item_default.value           1
+    _item_type.code               code
+     loop_
+    _item_linked.child_name    _item_linked.parent_name
+             '<a href="#_array_data.external_data_id" >_array_data.external_data_id</a>'
+                      '<a href="#_array_data_external_data.id" >_array_data_external_data.id</a>'
+     save_
+
+save_<a name="_array_data_external_data.path" >_array_data_external_data.path</a>
+   _item_description.description
+
+;
+
+    An optional format-dependent path that is used to locate the
+    external image or images within the object referenced by the combination of
+    <a href="#_array_data_external_data.uri" >_array_data_external_data.uri</a>, 
+    <a href="#_array_data_external_data.archive_path" >_array_data_external_data.archive_path</a>
+    in the case that <a href="#_array_data_external_data.archive_format" >_array_data_external_data.archive_format</a>
+    specifies a non-null single-file archive format, such as zip or a 
+    tarball.  When a single-file archive format is not used, then
+    <a href="#_array_data_external_data.path" >_array_data_external_data.path</a>
+    locates the external image or images  within the object referenced by
+    <a href="#_array_data_external_data.uri" >_array_data_external_data.uri</a>.
+    In both cases, the specific image within an array of multiple images is
+    identified by <a href="#_array_data_external_data.frame" >_array_data_external_data.frame</a>.
+ 
+
+;
+
+    _item.name                 '<a href="#_array_data_external_data.path" >_array_data_external_data.path</a>'
+    _item.category_id            <a href="#array_data_external_data">array_data_external_data</a>
+    _item_type.code              text
+
+    save_
+
+save_<a name="_array_data_external_data.uri" >_array_data_external_data.uri</a>
+    _item_description.description
+;
+    A URI describing the location of an image external to the current data block
+;
+    _item.name                '<a href="#_array_data_external_data.uri" >_array_data_external_data.uri</a>'
+    _item.category_id           <a href="#array_data">array_data_external_data</a>
+    _item_type.code             code
+
+    save_
+
+save_<a name="_array_data_external_data.variant" >_array_data_external_data.variant</a>
+    _item_description.description
+;             The value of <a href="#_array_data_external_data.variant" >_array_data_external_data.variant</a> gives the variant
+              to which the given ARRAY_DATA_EXTERNAL_DATA row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to <a href="#_variant.variant" >_variant.variant</a> in the
+              <a href="#variant">VARIANT</a> category.
+;
+    _item.name                  '<a href="#_array_data_external_data.variant" >_array_data_external_data.variant</a>'
+    _item.category_id             array_data_external_data
+    _item.mandatory_code          implicit
+    _item_default.value           .
+    _item_type.code               code
+     save_
+
+save_<a name="_array_data_external_data.version" >_array_data_external_data.version</a>
+    _item_description.description
+;
+    An identifier for the version of the file format described by '<a href="#array_data_external_data.format" >_array_data_external_data.format</a>'. 
+;
+
+    _item.name              '<a href="#_array_data_external_data.version" >_array_data_external_data.version</a>'
+    _item.category_id         <a href="#array_data">array_data_external_data</a>
+    _item_type.code           code
+
+    save_
+
+
+######################
+# <a name="array_element_size">ARRAY_ELEMENT_SIZE</a> #
+######################
+
+
+save_ARRAY_ELEMENT_SIZE
+    _category.description
+;   Data items in the <a href="#array_element_size">ARRAY_ELEMENT_SIZE</a> category record the physical
+    size of array elements along each array dimension.
+;
+    _category.id                   array_element_size
+    _category.mandatory_code       no
+<div id="print_NX_array_element_size" style="display:block">   #_category.NX_mapping_details in online version <a href="javascript:open_close2('online_NX_array_element_size','print_NX_array_element_size');">+/-</a>
+</div><div id="online_NX_array_element_size" style="display:none">    _category.NX_mapping_details                  #<a href="javascript:open_close2('online_NX_array_element_size','print_NX_array_element_size');">+/-</a>
+;
+
+    _array_element_size.array_id ARRAYID 
+    _array_element_size.index INDEX   (See _array_element_size.array_id)
+    _array_element_size.size SIZE
+
+    -->
+
+    /entry:NXentry
+     /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+          /data_ARRAYID_BINARYID -->
+                /entry/data_ARRAYID_BINARYID/data_ARRAYID_BINARYID
+          /?_pixel_size_ARRAYID=SIZE
+            @CBF_array_id="ARRAYID"
+    where "?" is "x", "y", "z" for
+    _array_element_size.index == 1,2, or 3 respectively
+
+;
+</div>
+     loop_
+    _category_key.name             '<a href="#_array_element_size.array_id" >_array_element_size.array_id</a>'
+                                   '<a href="#_array_element_size.index" >_array_element_size.index</a>'
+                                   '<a href="#_array_element_size.variant" >_array_element_size.variant</a>'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'array_data_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;      Example 1. A regular 2D array with a uniform element dimension
+                    of 1220 nanometres.
+;
+;
+        loop_
+       <a href="#_array_element_size.array_id" >_array_element_size.array_id</a>
+       <a href="#_array_element_size.index" >_array_element_size.index</a>
+       <a href="#_array_element_size.size" >_array_element_size.size</a>
+        image_1   1    1.22e-6
+        image_1   2    1.22e-6
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save_<a name="_array_element_size.array_id" >_array_element_size.array_id</a>
+    _item_description.description
+;             This item is a pointer to <a href="#_array_structure.id" >_array_structure.id</a> in the
+              <a href="#array_structure">ARRAY_STRUCTURE</a> category.
+;
+    _item.name                  '<a href="#_array_element_size.array_id" >_array_element_size.array_id</a>'
+    _item.category_id             array_element_size
+    _item.mandatory_code          implicit
+    _item_type.code               code
+     save_
+
+
+save_<a name="_array_element_size.index" >_array_element_size.index</a>
+    _item_description.description
+;             This item is a pointer to <a href="#_array_structure_list.index" >_array_structure_list.index</a> in
+              the ARRAY_STRUCTURE_LIST category.
+;
+    _item.name                  '<a href="#_array_element_size.index" >_array_element_size.index</a>'
+    _item.category_id             array_element_size
+    _item.mandatory_code          yes
+    _item_type.code               int
+     save_
+
+
+save_<a name="_array_element_size.size" >_array_element_size.size</a>
+    _item_description.description
+;             The size in metres of an image element in this
+              dimension. This supposes that the elements are arranged
+              on a regular grid.
+;
+    _item.name               '<a href="#_array_element_size.size" >_array_element_size.size</a>'
+    _item.category_id          array_element_size
+    _item.mandatory_code       yes
+    _item_type.code            float
+    _item_units.code           'metres'
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0.0
+     save_
+
+
+save_<a name="_array_element_size.variant" >_array_element_size.variant</a>
+    _item_description.description
+;             The value of <a href="#_array_element_size.variant" >_array_element_size.variant</a> gives the variant
+              to which the given ARRAY_ELEMENT_SIZE row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to <a href="#_variant.variant" >_variant.variant</a> in the
+              <a href="#variant">VARIANT</a> category.
+;
+    _item.name                  '<a href="#_array_element_size.variant" >_array_element_size.variant</a>'
+    _item.category_id             array_element_size
+    _item.mandatory_code          implicit
+    _item_default.value           .
+    _item_type.code               code
+     save_
+
+
+#####################
+# <a name="array_intensities">ARRAY_INTENSITIES</a> #
+#####################
+
+
+save_ARRAY_INTENSITIES
+    _category.description
+;   Data items in the <a href="#array_intensities">ARRAY_INTENSITIES</a> category record the
+    information required to recover the intensity data from
+    the set of data values stored in the <a href="#array_data">ARRAY_DATA</a> category.
+
+    The detector may have a complex relationship
+    between the raw intensity values and the number of
+    incident photons.  In most cases, the number stored
+    in the final array will have a simple linear relationship
+    to the actual number of incident photons, given by
+    <a href="#_array_intensities.gain">_array_intensities.gain</a>.  If raw, uncorrected values
+    are presented (e.g. for calibration experiments), the
+    value of <a href="#_array_intensities.linearity">_array_intensities.linearity</a> will be 'raw'
+    and <a href="#_array_intensities.gain">_array_intensities.gain</a> will not be used.
+;
+    _category.id                   array_intensities
+    _category.mandatory_code       no
+<div id="print_NX_array_intensities" style="display:block">   #_category.NX_mapping_details in online version <a href="javascript:open_close2('online_NX_array_intensities','print_NX_array_intensities');">+/-</a>
+</div><div id="online_NX_array_intensities" style="display:none">    _category.NX_mapping_details                  #<a href="javascript:open_close2('online_NX_array_intensities','print_NX_array_intensities');">+/-</a>
+;
+
+    _array_intensities.array_id ARRAYID
+    _array_intensities.binary_id BINARYID
+    _array_intensities.details DETAILS
+    _array_intensities.gain GAIN
+    _array_intensities.gain_esd GAINESD
+    _array_intensities.linearity LINEARITY
+    _array_intensities.offset OFFSET
+    _array_intensities.scaling SCALING
+    _array_intensities.overload OVERLOAD
+    _array_intensities.undefined_value UNDEFVAL
+    _array_intensities.underload UNDERLOAD
+    _array_intensities.pixel_fast_bin_size FBINSIZE
+    _array_intensities.pixel_slow_bin_size SBINSIZE
+    _array_intensities.pixel_binning_method METHOD
+
+
+    -->
+
+      /entry:NXentry
+        /data_ARRAYID_BINARYID:NXdata
+          /data_ARRAYID_BINARYID
+              @CBF_array_id="ARRAYID"
+              @CBF_binary_id="BINARYID"
+              @details="DETAILS"
+              @gain=[GAIN]          
+              @gain_esd=[GAINESD]
+              @linearity="LINEARITY"          
+              @offset=[OFFSET]
+              @saturation_value=[OVERLOAD]
+              @scaling_factor=[SCALING]
+              @undefined_value=[UNDEFVAL]
+              @underload_value=[UNDERLOAD]
+              @CBF_array_intensities__pixel_fast_bin_size=[FBINSIZE]
+              @CBF_array_intensities__pixel_slow_bin_size=[SBINSIZE]
+              @CBF_array_intensities__pixel_binning_method="METHOD"
+       /instrument:NXinstrument
+         /DETECTORNAME:NXdetector_group
+         /DETECTORELEMENTNAME:NXdetector
+           /data_ARRAYID_BINARYID -->
+                /entry/data_ARRAYID_BINARYID/data_ARRAYID_BINARYID
+
+    The argument has been made that these attributes are not needed
+    because NeXus files are supposed to have 'true values' stored.
+    In many cases that is true and then none of these attributes
+    are needed.  However, with some detectors and some experiments
+    there are good technical and scientific reasons to bring in values
+    that will need processing later to derive 'true values', and in
+    those case some or all of these attributes will be needed.  They
+    are provided for such cases.
+
+    The same attributes could be used as fields in the case of a single
+    data array, but in that case links for all the fields would be needed
+    from NXdata to NXdetector, so it is preferable to use attributes even
+    in the case of a single data array.  The reverse mapping will support
+    both uses.
+
+
+;
+</div>
+     loop_
+    _category_key.name             '<a href="#_array_intensities.array_id" >_array_intensities.array_id</a>'
+                                   '<a href="#_array_intensities.binary_id" >_array_intensities.binary_id</a>'
+                                   '<a href="#_array_intensities.variant" >_array_intensities.variant</a>'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'array_data_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+        Example 1
+;
+;
+        loop_
+        <a href="#_array_intensities.array_id" >_array_intensities.array_id</a>
+        <a href="#_array_intensities.linearity" >_array_intensities.linearity</a>
+        <a href="#_array_intensities.gain" >_array_intensities.gain</a>
+        <a href="#_array_intensities.overload" >_array_intensities.overload</a>
+        <a href="#_array_intensities.undefined_value" >_array_intensities.undefined_value</a>
+        <a href="#_array_intensities.pixel_fast_bin_size" >_array_intensities.pixel_fast_bin_size</a>
+        <a href="#_array_intensities.pixel_slow_bin_size" >_array_intensities.pixel_slow_bin_size</a>
+        <a href="#_array_intensities.pixel_binning_method" >_array_intensities.pixel_binning_method</a>
+        image_1   linear  1.2    655535   0   2   2    hardware
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save_<a name="_array_intensities.array_id" >_array_intensities.array_id</a>
+    _item_description.description
+;             This item is a pointer to <a href="#_array_structure.id" >_array_structure.id</a> in the
+              <a href="#array_structure">ARRAY_STRUCTURE</a> category.
+;
+    _item.name                  '<a href="#_array_intensities.array_id" >_array_intensities.array_id</a>'
+    _item.category_id             array_intensities
+    _item.mandatory_code          implicit
+    _item_type.code               code
+     save_
+
+
+save_<a name="_array_intensities.binary_id" >_array_intensities.binary_id</a>
+    _item_description.description
+;             This item is a pointer to <a href="#_array_data.binary_id" >_array_data.binary_id</a> in the
+              <a href="#array_data">ARRAY_DATA</a> category.
+;
+    _item.name                  '<a href="#_array_intensities.binary_id" >_array_intensities.binary_id</a>'
+    _item.category_id             array_intensities
+    _item.mandatory_code          implicit
+    _item_type.code               int
+     save_
+
+
+save_<a name="_array_intensities.details" >_array_intensities.details</a>
+    _item_description.description
+;             A description of special aspects of the calculation of array 
+              intensities.
+;
+    _item.name                  '<a href="#_array_intensities.details" >_array_intensities.details</a>'
+    _item.category_id             array_intensities
+    _item.mandatory_code          no
+    _item_type.code                   text
+    _item_examples.case         'Gain_setting: low gain (vrf = -0.300)'
+     save_
+
+
+save_<a name="_array_intensities.gain" >_array_intensities.gain</a>
+    _item_description.description
+;             Detector 'gain'. The factor by which linearized
+              intensity count values should be divided to produce
+              true photon counts.
+;
+    _item.name              '<a href="#_array_intensities.gain" >_array_intensities.gain</a>'
+    _item.category_id          array_intensities
+    _item.mandatory_code       yes
+    _item_type.code            float
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0.0
+    _item_units.code           'counts_per_photon'
+     loop_
+    _item_related.related_name
+    _item_related.function_code  '<a href="#_array_intensities.gain_esd" >_array_intensities.gain_esd</a>'
+                                 'associated_value'
+     save_
+
+
+save_<a name="_array_intensities.gain_esd" >_array_intensities.gain_esd</a>
+    _item_description.description
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of detector 'gain'.
+;
+    _item.name              '<a href="#_array_intensities.gain_esd" >_array_intensities.gain_esd</a>'
+    _item.category_id          array_intensities
+    _item.mandatory_code       yes
+    _item_type.code            float
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0.0
+
+    _item_units.code          'counts_per_photon'
+     loop_
+    _item_related.related_name
+    _item_related.function_code  '<a href="#_array_intensities.gain" >_array_intensities.gain</a>'
+                                 'associated_esd'
+     save_
+
+
+save_<a name="_array_intensities.linearity" >_array_intensities.linearity</a>
+    _item_description.description
+;             The intensity linearity scaling method used to convert
+              from the raw intensity to the stored element value:
+
+             'linear' is linear.
+
+             'offset'  means that the value defined by
+             <a href="#_array_intensities.offset" >_array_intensities.offset</a> should be added to each
+             element value.
+
+             'scaling' means that the value defined by
+             <a href="#_array_intensities.scaling">_array_intensities.scaling</a> should be multiplied with each
+             element value.
+
+             'scaling_offset' is the combination of the two previous cases,
+             with the scale factor applied before the offset value.
+
+             'sqrt_scaled' means that the square root of raw
+             intensities multiplied by <a href="#_array_intensities.scaling">_array_intensities.scaling</a> is
+             calculated and stored, perhaps rounded to the nearest
+             integer. Thus, linearization involves dividing the stored
+             values by <a href="#_array_intensities.scaling">_array_intensities.scaling</a> and squaring the
+             result.
+
+             'logarithmic_scaled' means that the logarithm base 10 of
+             raw intensities multiplied by <a href="#_array_intensities.scaling">_array_intensities.scaling</a>
+             is calculated and stored, perhaps rounded to the nearest
+             integer. Thus, linearization involves dividing the stored
+             values by <a href="#_array_intensities.scaling">_array_intensities.scaling</a> and calculating 10
+             to the power of this number.
+
+             'raw' means that the data are a set of raw values straight
+             from the detector.
+;
+
+    _item.name               '<a href="#_array_intensities.linearity" >_array_intensities.linearity</a>'
+    _item.category_id          array_intensities
+    _item.mandatory_code       yes
+    _item_type.code            code
+     loop_
+    _item_enumeration.value
+    _item_enumeration.detail
+                              'linear' .
+                              'offset'
+;            The value defined by  <a href="#_array_intensities.offset" >_array_intensities.offset</a> should
+             be added to each element value.
+;
+                              'scaling'
+;            The value defined by <a href="#_array_intensities.scaling">_array_intensities.scaling</a> should be
+             multiplied with each element value.
+;
+                              'scaling_offset'
+;            The combination of the scaling and offset
+             with the scale factor applied before the offset value.
+;
+                              'sqrt_scaled'
+;            The square root of raw intensities multiplied by
+             <a href="#_array_intensities.scaling">_array_intensities.scaling</a> is calculated and stored,
+             perhaps rounded to the nearest integer. Thus,
+             linearization involves dividing the stored
+             values by <a href="#_array_intensities.scaling">_array_intensities.scaling</a> and squaring the
+             result.
+;
+                              'logarithmic_scaled'
+;            The logarithm base 10 of raw intensities multiplied by
+             <a href="#_array_intensities.scaling">_array_intensities.scaling</a>  is calculated and stored,
+             perhaps rounded to the nearest integer. Thus,
+             linearization involves dividing the stored values by
+             <a href="#_array_intensities.scaling">_array_intensities.scaling</a> and calculating 10 to the
+             power of this number.
+;
+                              'raw'
+;            The array consists of raw values to which no corrections have
+             been applied.  While the handling of the data is similar to
+             that given for 'linear' data with no offset, the meaning of
+             the data differs in that the number of incident photons is
+             not necessarily linearly related to the number of counts
+             reported.  This value is intended for use either in
+             calibration experiments or to allow for handling more
+             complex data-fitting algorithms than are allowed for by
+             this data item.
+;
+
+     save_
+
+
+save_<a name="_array_intensities.offset" >_array_intensities.offset</a>
+    _item_description.description
+;             Offset value to add to array element values in the manner
+              described by the item <a href="#_array_intensities.linearity" >_array_intensities.linearity</a>.
+;
+    _item.name                 '<a href="#_array_intensities.offset" >_array_intensities.offset</a>'
+    _item.category_id          array_intensities
+    _item.mandatory_code       no
+    _item_type.code            float
+     save_
+
+
+save_<a name="_array_intensities.overload" >_array_intensities.overload</a>
+    _item_description.description
+;             The saturation intensity level for this data array, i.e. the
+              value above which correct intensities may not be recorded.
+
+              The valid pixel values are those less than
+              <a href="#_array_intensities.overload" >_array_intensities.overload</a> and greater than or equal to 
+              <a href="#_array_intensities.underload" >_array_intensities.underload</a>
+;
+    _item.name                 '<a href="#_array_intensities.overload" >_array_intensities.overload</a>'
+    _item.category_id          array_intensities
+    _item.mandatory_code       no
+    _item_type.code            float
+    _item_units.code          'counts'
+     save_
+
+
+save_<a name="_array_intensities.pixel_fast_bin_size" >_array_intensities.pixel_fast_bin_size</a>
+    _item_description.description
+;             The value of <a href=#_array_intensities.pixel_fast_bin_size" >_array_intensities.pixel_fast_bin_size</a> specifies
+              the number of pixels that compose one element in the direction
+              of the most rapidly varying array dimension.
+
+              Typical values are 1, 2, 4 or 8.  When there is 1 pixel per
+              array element in both directions, the value given for
+              <a href="#_array_intensities.pixel_binning_method" >_array_intensities.pixel_binning_method</a> normally should be
+              'none'.
+
+              It is specified as a float to allow for binning algorithms that
+              create array elements that are not integer multiples of the 
+              detector pixel size.
+;
+    _item.name              '<a href="#_array_intensities.pixel_fast_bin_size" >_array_intensities.pixel_fast_bin_size</a>'
+    _item.category_id          array_intensities
+    _item.mandatory_code       implicit
+    _item_type.code            float
+    _item_default.value        1.
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0.0
+    _item_units.code           'pixels_per_element'
+     save_
+
+
+save_<a name="_array_intensities.pixel_slow_bin_size" >_array_intensities.pixel_slow_bin_size</a>
+    _item_description.description
+;             The value of <a href=#_array_intensities.pixel_slow_bin_size" >_array_intensities.pixel_slow_bin_size</a> specifies
+              the number of pixels that compose one element in the direction
+              of the second most rapidly varying array dimension.
+
+              Typical values are 1, 2, 4 or 8.  When there is 1 pixel per
+              array element in both directions, the value given for
+              <a href="#_array_intensities.pixel_binning_method" >_array_intensities.pixel_binning_method</a> normally should be
+              'none'.
+
+              It is specified as a float to allow for binning algorithms that
+              create array elements that are not integer multiples of the
+              detector pixel size.
+;
+    _item.name              '<a href="#_array_intensities.pixel_slow_bin_size" >_array_intensities.pixel_slow_bin_size</a>'
+    _item.category_id          array_intensities
+    _item.mandatory_code       implicit
+    _item_type.code            float
+    _item_default.value        1.
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0.0
+    _item_units.code           'pixels_per_element'
+     save_
+
+
+save_<a name="_array_intensities.pixel_binning_method" >_array_intensities.pixel_binning_method</a>
+    _item_description.description
+;             The value of <a href="#_array_intensities.pixel_binning_method">_array_intensities.pixel_binning_method</a> specifies
+              the method used to derive array elements from multiple pixels.
+;
+    _item.name              '<a href="#_array_intensities.pixel_binning_method" >_array_intensities.pixel_binning_method</a>'
+    _item.category_id          array_intensities
+    _item.mandatory_code       implicit
+    _item_type.code            code
+     loop_
+    _item_enumeration.value
+    _item_enumeration.detail
+                               'hardware'
+;              The element intensities were derived from the raw data of one
+               or more pixels by use of hardware in the detector, e.g. by use
+               of shift registers in a CCD to combine pixels into super-pixels.
+;
+                               'software'
+;              The element intensities were derived from the raw data of more
+               than one pixel by use of software.
+;
+                               'combined'
+;              The element intensities were derived from the raw data of more
+               than one pixel by use of both hardware and software, as when
+               hardware binning is used in one direction and software in the
+               other.
+;
+                               'none'
+;              In both directions, the data have not been binned.  The
+               number of pixels is equal to the number of elements.
+
+               When the value of <a href="#_array_intensities.pixel_binning_method" >_array_intensities.pixel_binning_method</a> is
+               'none' the values of <a href="#_array_intensities.pixel_fast_bin_size" >_array_intensities.pixel_fast_bin_size</a>
+               and <a href="#_array_intensities.pixel_slow_bin_size" >_array_intensities.pixel_slow_bin_size</a> both must be 1.
+;
+                               'unspecified'
+;              The method used to derive element intensities is not specified.
+;
+    _item_default.value        'unspecified'
+     save_
+
+
+save_<a name="_array_intensities.scaling" >_array_intensities.scaling</a>
+    _item_description.description
+;             Multiplicative scaling value to be applied to array data
+              in the manner described by the item
+              <a href="#_array_intensities.linearity" >_array_intensities.linearity</a>.
+;
+    _item.name                 '<a href="#_array_intensities.scaling" >_array_intensities.scaling</a>'
+    _item.category_id          array_intensities
+    _item.mandatory_code       no
+    _item_type.code            float
+     save_
+
+
+save_<a name="_array_intensities.undefined_value" >_array_intensities.undefined_value</a>
+    _item_description.description
+;             A value to be substituted for undefined values in
+              the data array.
+;
+    _item.name                 '<a href="#_array_intensities.undefined_value" >_array_intensities.undefined_value</a>'
+    _item.category_id          array_intensities
+    _item.mandatory_code       no
+    _item_type.code            float
+     save_
+
+
+save_<a name="_array_intensities.underload" >_array_intensities.underload</a>
+    _item_description.description
+;             The lowest value at which pixels for this detector are
+              measured.
+
+              The valid pixel values are those less than 
+              <a href="#_array_intensities.overload" >_array_intensities.overload</a> and greater than or equal to 
+              <a href="#_array_intensities.underload" >_array_intensities.underload</a>
+
+;
+    _item.name                 '<a href="#_array_intensities.underload" >_array_intensities.underload</a>'
+    _item.category_id          array_intensities
+    _item.mandatory_code       no
+    _item_type.code            float
+    _item_units.code          'counts'
+     save_    
+
+
+save_<a name="_array_intensities.variant" >_array_intensities.variant</a>
+    _item_description.description
+;             The value of <a href="#_array_intensities.variant" >_array_intensities.variant</a> gives the variant
+              to which the given ARRAY_INTENSITIES row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to <a href="#_variant.variant" >_variant.variant</a> in the
+              <a href="#variant">VARIANT</a> category.
+;
+    _item.name                  '<a href="#_array_intensities.variant" >_array_intensities.variant</a>'
+    _item.category_id             array_intensities
+    _item.mandatory_code          implicit
+    _item_default.value           .
+    _item_type.code               code
+     save_
+
+
+###################
+# <a name="array_structure">ARRAY_STRUCTURE</a> #
+###################
+
+
+save_ARRAY_STRUCTURE
+    _category.description
+;   Data items in the <a href="#array_structure">ARRAY_STRUCTURE</a> category record the organization and
+    encoding of array data that may be stored in the <a href="#array_data">ARRAY_DATA</a> category.
+;
+    _category.id                   array_structure
+    _category.mandatory_code       no
+<div id="print_NX_array_structure" style="display:block">   #_category.NX_mapping_details in online version <a href="javascript:open_close2('online_NX_array_structure','print_NX_array_structure');">+/-</a>
+</div><div id="online_NX_array_structure" style="display:none">    _category.NX_mapping_details                  #<a href="javascript:open_close2('online_NX_array_structure','print_NX_array_structure');">+/-</a>
+;
+    Note that this is essentially a type that may apply to multiple
+    binary images, and corresponds to some of the detailed HDF5
+    information about an array.   The following mapping is a placeholder
+    for the names given for future reference, if needed.
+
+    The information in this category is the byte order, the compression
+    information, and the encoding, which is carried in and retrievable
+    from the HDF5 types, properties lists, etc.  
+
+    At present NeXus does not expose this information.  This should be
+    discussed.
+
+;
+</div>
+     loop_
+    _category_key.name             '<a href="#_array_structure.id" >_array_structure.id</a>'
+                                   '<a href="#_array_structure.variant" >_array_structure.variant</a>'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'array_data_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;   Example 1.
+;
+;
+     loop_
+    _array_structure.id
+    _array_structure.encoding_type
+    _array_structure.compression_type
+    _array_structure.byte_order
+     image_1       "unsigned 16-bit integer"  none  little_endian
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save_<a name="_array_structure.byte_order" >_array_structure.byte_order</a>
+    _item_description.description
+;             The order of bytes for integer values which require more
+              than 1 byte.
+
+              (IBM-PCs and compatibles, and DEC VAXs use low-byte-first
+              ordered integers, whereas Hewlett Packard 700
+              series, Sun-4 and Silicon Graphics use high-byte-first
+              ordered integers.  DEC Alphas can produce/use either
+              depending on a compiler switch.)
+;
+
+    _item.name                     '<a href="#_array_structure.byte_order" >_array_structure.byte_order</a>'
+    _item.category_id               array_structure
+    _item.mandatory_code            yes
+    _item_type.code                 ucode
+     loop_
+    _item_enumeration.value
+    _item_enumeration.detail
+                                   'big_endian'
+;       The first byte in the byte stream of the bytes which make up an
+        integer value is the most significant byte of an integer.
+;
+                                   'little_endian'
+;       The last byte in the byte stream of the bytes which make up an
+        integer value is the most significant byte of an integer.
+;
+     save_
+
+
+save_<a name="_array_structure.compression_type" >_array_structure.compression_type</a>
+    _item_description.description
+;             Type of data-compression method used to compress the array
+              data.
+;
+    _item.name                   '<a href="#_array_structure.compression_type" >_array_structure.compression_type</a>'
+    _item.category_id             array_structure
+    _item.mandatory_code          no
+    _item_type.code               ucode
+    _item_default.value           'none'
+     loop_
+    _item_enumeration.value
+    _item_enumeration.detail
+                                  'byte_offset'
+;       Using the 'byte_offset' compression scheme as per A. Hammersley
+        and the CBFlib manual, section 3.3.3
+;
+                                  'canonical'
+;       Using the 'canonical' compression scheme (International Tables
+        for Crystallography Volume G, Section 5.6.3.1) and CBFlib
+        manual section 3.3.1
+;
+                                  'nibble_offset'
+;       Using the 'nibble_offset' compression scheme as per H. Bernstein
+        and the CBFlib manual, section 3.3.4
+;
+                                  'none'
+;       Data are stored in normal format as defined by
+        <a href="#_array_structure.encoding_type" >_array_structure.encoding_type</a> and
+        <a href="#_array_structure.byte_order" >_array_structure.byte_order</a>.
+;
+                                  'packed'
+;       Using the 'packed' compression scheme, a CCP4-style packing
+        as per J. P. Abrahams pack_c.c and CBFlib manual, section 3.3.2.
+;
+                                  'packed_v2'
+;       Using the 'packed' compression scheme, version 2, as per
+        J. P. Abrahams pack_c.c and CBFlib manual, section 3.3.2.
+;
+     save_
+
+
+save_<a name="_array_structure.compression_type_flag" >_array_structure.compression_type_flag</a>
+    _item_description.description
+;             Flags modifying the type of data-compression method used to 
+              compress the arraydata.
+;
+    _item.name                   '<a href="#_array_structure.compression_type_flag" >_array_structure.compression_type_flag</a>'
+    _item.category_id             array_structure
+    _item.mandatory_code          no
+    _item_type.code               ucode
+     loop_
+    _item_enumeration.value
+    _item_enumeration.detail
+                                  'uncorrelated_sections'
+;       When applying packed or packed_v2 compression on an array with
+        uncorrelated sections, do not average in points from the prior
+        section.
+;
+                                  'flat'
+;       When applying packed or packed_v2 compression on an array that
+        treats the entire image as a single line set the maximum number
+        of bits for an offset to 65 bits.
+
+        The flag is included for compatibility with software prior to
+        CBFlib_0.7.7, and should not be used for new data sets.
+;
+     save_
+
+
+save_<a name="_array_structure.encoding_type" >_array_structure.encoding_type</a>
+    _item_description.description
+;             Data encoding of a single element of array data.
+
+              The type 'unsigned 1-bit integer' is used for
+              packed Boolean arrays for masks.  Each element
+              of the array corresponds to a single bit
+              packed in unsigned 8-bit data.
+
+              In several cases, the IEEE format is referenced.
+              See IEEE Standard 754-1985 (IEEE, 1985).
+
+              Reference: IEEE (1985). IEEE Standard for Binary Floating-Point
+              Arithmetic. ANSI/IEEE Std 754-1985. New York: Institute of
+              Electrical and Electronics Engineers.
+;
+
+    _item.name                '<a href="#_array_structure.encoding_type" >_array_structure.encoding_type</a>'
+    _item.category_id          array_structure
+    _item.mandatory_code       yes
+    _item_type.code            uline
+     loop_
+    _item_enumeration.value
+                              'unsigned 1-bit integer'
+                              'unsigned 8-bit integer'
+                              'signed 8-bit integer'
+                              'unsigned 16-bit integer'
+                              'signed 16-bit integer'
+                              'unsigned 32-bit integer'
+                              'signed 32-bit integer'
+                              'signed 32-bit real IEEE'
+                              'signed 64-bit real IEEE'
+                              'signed 32-bit complex IEEE'
+     save_
+
+
+save_<a name="_array_structure.id" >_array_structure.id</a>
+    _item_description.description
+;             The value of <a href="#_array_structure.id" >_array_structure.id</a> must uniquely identify
+              each item of array data.              
+
+              This item has been made implicit and given a default value of 1
+              as a convenience in writing miniCBF files.  Normally an
+              explicit name with useful content should be used.
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+             '<a href="#_array_structure.id" >_array_structure.id</a>'              array_structure      implicit
+             '<a href="#_array_data.array_id" >_array_data.array_id</a>'             array_data           implicit
+             '<a href="#_array_structure_list.array_id" >_array_structure_list.array_id</a>'   array_structure_list implicit
+             '<a href="#_array_structure_list_section.array_id" >_array_structure_list_section.array_id</a>'
+                                        array_structure_list_section implicit
+             '<a href="#_array_intensities.array_id" >_array_intensities.array_id</a>'      array_intensities    implicit
+             '<a href="#_diffrn_data_frame.array_id" >_diffrn_data_frame.array_id</a>'      diffrn_data_frame    implicit
+
+
+    _item_default.value           1
+    _item_type.code               code
+     loop_
+    _item_linked.child_name
+    _item_linked.parent_name
+             '<a href="#_array_data.array_id" >_array_data.array_id</a>'
+                      '<a href="#_array_structure.id" >_array_structure.id</a>'
+             '<a href="#_array_structure_list.array_id" >_array_structure_list.array_id</a>'
+                      '<a href="#_array_structure.id" >_array_structure.id</a>'
+             '<a href="#_array_structure_list_section.array_id" >_array_structure_list_section.array_id</a>'
+                      '<a href="#_array_structure.id" >_array_structure.id</a>'
+             '<a href="#_array_intensities.array_id" >_array_intensities.array_id</a>'
+                      '<a href="#_array_structure.id" >_array_structure.id</a>'
+             '<a href="#_diffrn_data_frame.array_id" >_diffrn_data_frame.array_id</a>'
+                      '<a href="#_array_structure.id" >_array_structure.id</a>'
+
+     save_
+
+
+save_<a name="_array_structure.variant" >_array_structure.variant</a>
+    _item_description.description
+;             The value of <a href="#_array_structure.variant" >_array_structure.variant</a> gives the variant
+              to which the given ARRAY_STRUCTURE row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to <a href="#_variant.variant" >_variant.variant</a> in the
+              <a href="#variant">VARIANT</a> category.
+;
+    _item.name                  '<a href="#_array_structure.variant" >_array_structure.variant</a>'
+    _item.category_id             array_structure
+    _item.mandatory_code          implicit
+    _item_default.value           .
+    _item_type.code               code
+     save_
+
+
+########################
+# <a name="array_structure_list">ARRAY_STRUCTURE_LIST</a> #
+########################
+
+
+save_ARRAY_STRUCTURE_LIST
+    _category.description
+;    Data items in the <a href="#array_structure_list">ARRAY_STRUCTURE_LIST</a> category record the size
+     and organization of each array dimension.
+
+     The relationship to physical axes may be given.
+;
+    _category.id                   array_structure_list
+    _category.mandatory_code       no
+<div id="print_NX_array_structure_list" style="display:block">   #_category.NX_mapping_details in online version <a href="javascript:open_close2('online_NX_array_structure_list','print_NX_array_structure_list');">+/-</a>
+</div><div id="online_NX_array_structure_list" style="display:none">    _category.NX_mapping_details                  #<a href="javascript:open_close2('online_NX_array_structure_list','print_NX_array_structure_list');">+/-</a>
+;
+
+    _array_structure_list.axis_set_id AXISSETID
+    _array_structure_list.array_id ARRAYID
+    _array_structure_list.array_section_id ARRAYSECTIONID
+    _array_structure_list.dimension DIM
+    _array_structure_list.direction DIR
+    _array_structure_list.index INDEX
+    _array_structure_list.precedence PRECEDENCE
+
+    _array_structure_list_section.array_id ARRAYID -->
+    _array_structure_list_section.id ARRAYSECTIONID -->
+    _array_structure_list_section.index PRECEDENCE-->
+    _array_structure_list_section.end END -->
+    _array_structure_list_section.start START -->
+    _array_structure_list_section.stride STRIDE -->
+
+
+     loop_
+    _array_structure_list_axis.axis_id 
+    _array_structure_list_axis.axis_set_id 
+    _array_structure_list_axis.angle 
+    _array_structure_list_axis.angle_increment 
+    _array_structure_list_axis.displacement 
+    _array_structure_list_axis.fract_displacement  
+    _array_structure_list_axis.displacement_increment 
+    _array_structure_list_axis.fract_displacement_increment 
+    _array_structure_list_axis.angular_pitch  
+    _array_structure_list_axis.reference_angle 
+    _array_structure_list_axis.reference_displacement REFDISP
+    AXISID1 AXISSETID ANGLE1 ANGLEINC1 DISP1 FRACTDISP1
+         DISPINC1 FRACTINC1 ANGPITCH1 REFANG1
+    AXISID2 AXISSETID ANGLE2 ANGLEINC2 DISP2 FRACTDISP2
+         DISPINC2 FRACTINC2 ANGPITCH2 REFANG2
+    AXISID3 AXISSETID ANGLE3 ANGLEINC3 DISP3 FRACTDISP3
+         DISPINC3 FRACTINC3 ANGPITCH3 REFANG3
+
+    _diffrn_data_frame.array_id ARRAYID
+    _diffrn_data_frame.binary_id BINARYID
+    _diffrn_data_frame.center_fast CENF
+    _diffrn_data_frame.center_slow CENS
+    _diffrn_data_frame.center_derived CENDERIVED
+    _diffrn_data_frame.center_units UNITS
+    _diffrn_data_frame.detector_element_id ELEMENTID
+    _diffrn_data_frame.id FRAMEID
+    _diffrn_data_frame.details DETAILS
+
+    -->
+
+    ...
+
+
+   /entry:NXentry
+     /data_ARRAYID_BINARYID:NXdata
+        @signal="data_ARRAYID_BINARY_ID"
+        /data_ARRAYID_BINARYID[ the data for the array ARRAYID,
+                                binary BINARYID, all sections,
+                                all FRAMES]
+        @axes=[...,AXISID1,...] with AXISID1 inserted at PRECEDENCE-1
+        @AXISID1_indices=[PRECEDENCE-1]
+        @AXISID2_indices=[PRECEDENCE-1]
+        @AXISID3_indices=[PRECEDENCE-1]
+        @AXISID1_origins=[origin1]  (default 0)
+        @AXISID2_origins=[origin2]  (default 0)
+        @AXISID3_origins=[origin3]  (default 0)
+        @AXISID1_sizes=[size1]
+        @AXISID2_sizes=[size2]
+        @AXISID3_sizes=[size3]
+        @AXISID1_strides=[stride1]
+        @AXISID2_strides=[stride2]
+        @AXISID3_strides=[stride3]
+
+        ...
+        /AXISID1 -->
+            /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID1
+        /AXISID2 -->
+            /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID2
+        /AXISID2 -->
+            /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID3
+        ...
+
+     /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+           /data_ARRAYID_BINARYID -->
+                /entry/data_ARRAYID_BINARYID/data_ARRAYID_BINARYID
+           /AXISID1 -->
+                /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID1
+           /AXISID2 -->
+                /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID2
+           /AXISID2 -->
+                /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID3
+           /ARRAYSECTIONID:NXdetector_module
+             /data_origin=[...] -- the 0-based origins indices of ARRAYSECTIONID
+             /data_size=[...] the sizes in pixels of ARRAYSECTIONID
+             /data_stride[...] the strides of ARRAYSECTIONID
+               .. 
+           /transformations:NXtransformations
+             /AXISID1=[DISP1,DISP1+DISPINC1,...]   
+                  (or using angles where appropriate)
+                @depends_on=...   determined from AXIS definitions
+                @equipment="detector"
+                @offset=[...] determined from AXIS definitions
+                @offset_units="mm"
+                @transformation_type="..." from AXIS definitions
+                @units="mm"
+                @vector=[...] determined from AXIS definitions
+                @CBF_array_structure_list_axis__axis_id="AXISID1"
+                @CBF_array_structure_list_axis__axis_set_id="AXISSETID"
+                @CBF_array_structure_list_axis__angle=ANGLE1
+                @CBF_array_structure_list_axis__angle_increment=ANGLEINC1
+                @CBF_array_structure_list_axis__displacement=DISP1
+                @CBF_array_structure_list_axis__displacement=FRACTDISP1
+                @CBF_array_structure_list_axis__displacement_increment=DISPINC1
+                @CBF_array_structure_list_axis__fract_displacement_increment
+                  =FRACTINC1
+                @CBF_array_structure_list_axis__angular_pitch=ANGPITCH1
+                @CBF_array_structure_list_axis__radial_pitch=RADPITCH1
+                @CBF_array_structure_list_axis__reference_angle=REFANG1
+                @CBF_array_structure_list_axis__reference_displacement=REFDISP1
+             /AXISID2=[DISP2,DISP2+DISPINC2,...]
+                  (or using angles where appropriate)
+                @depends_on=...   determined from AXIS definitions
+                @equipment="detector"
+                @offset=[...] determined from AXIS definitions
+                @offset_units="mm"
+                @transformation_type="..." from AXIS definitions
+                @units="mm"
+                @vector=[...] determined from AXIS definitions
+                @CBF_array_structure_list_axis__axis_id="AXISID2"
+                @CBF_array_structure_list_axis__axis_set_id="AXISSETID"
+                @CBF_array_structure_list_axis__angle=ANGLE2
+                @CBF_array_structure_list_axis__angle_increment=ANGLEINC2
+                @CBF_array_structure_list_axis__displacement=DISP2
+                @CBF_array_structure_list_axis__displacement=FRACTDISP2
+                @CBF_array_structure_list_axis__displacement_increment=DISPINC2
+                @CBF_array_structure_list_axis__fract_displacement_increment
+                  =FRACTINC2
+                @CBF_array_structure_list_axis__angular_pitch=ANGPITCH2
+                @CBF_array_structure_list_axis__radial_pitch=RADPITCH2
+                @CBF_array_structure_list_axis__reference_angle=REFANG2
+                @CBF_array_structure_list_axis__reference_displacement=REFDISP2
+             /AXISID3=[DISP3,DISP3+DISPINC3,...]
+                  (or using angles where appropriate)
+                @depends_on=...   determined from AXIS definitions
+                @equipment="detector"
+                @offset=[...] determined from AXIS definitions
+                @offset_units="mm"
+                @transformation_type="..." from AXIS definitions
+                @units="mm"
+                @vector=[...] determined from AXIS definitions
+                @CBF_array_structure_list_axis__axis_id="AXISID3"
+                @CBF_array_structure_list_axis__axis_set_id="AXISSETID"
+                @CBF_array_structure_list_axis__angle=ANGLE3
+                @CBF_array_structure_list_axis__angle_increment=ANGLEINC3
+                @CBF_array_structure_list_axis__displacement=DISP3
+                @CBF_array_structure_list_axis__displacement=FRACTDISP3
+                @CBF_array_structure_list_axis__displacement_increment=DISPINC3
+                @CBF_array_structure_list_axis__fract_displacement_increment
+                  =FRACTINC3
+                @CBF_array_structure_list_axis__angular_pitch=ANGPITCH3
+                @CBF_array_structure_list_axis__radial_pitch=RADPITCH3
+                @CBF_array_structure_list_axis__reference_angle=REFANG3
+                @CBF_array_structure_list_axis__reference_displacement=REFDISP3
+
+    Notes: The same axis AXISIDn may appear in multiple axis sets for different
+           values of PRECEDENCE of the data array, in which case the values
+           in AXISIDn_indices will be the sorted list of PRECEDENCE-1 values
+           and the array section information will be organized by the
+           same ordering.
+;
+</div>
+     loop_
+    _category_key.name             '<a href="#_array_structure_list.array_id" >_array_structure_list.array_id</a>'
+                                   '<a href="#_array_structure_list.index" >_array_structure_list.index</a>'
+                                   '<a href="#_array_structure_list.variant" >_array_structure_list.variant</a>'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'array_data_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;       Example 1. An image array of 1300 x 1200 elements.  The raster
+                    order of the image is left to right (increasing) in the
+                    first dimension and bottom to top (decreasing) in
+                    the second dimension.
+;
+;
+        loop_
+       <a href="#_array_structure_list.array_id" >_array_structure_list.array_id</a>
+       <a href="#_array_structure_list.index" >_array_structure_list.index</a>
+       <a href="#_array_structure_list.dimension" >_array_structure_list.dimension</a>
+       <a href="#_array_structure_list.precedence" >_array_structure_list.precedence</a>
+       <a href="#_array_structure_list.direction" >_array_structure_list.direction</a>
+       <a href="#_array_structure_list.axis_set_id" >_array_structure_list.axis_set_id</a>
+        image_1   1    1300    1     increasing  ELEMENT_X
+        image_1   2    1200    2     decreasing  ELEMENY_Y
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save_<a name="_array_structure_list.array_id" >_array_structure_list.array_id</a>
+    _item_description.description
+;             This item is a pointer to <a href="#_array_structure.id" >_array_structure.id</a> in the
+              <a href="#array_structure">ARRAY_STRUCTURE</a> category.
+;
+    _item.name                  '<a href="#_array_structure_list.array_id" >_array_structure_list.array_id</a>'
+    _item.category_id             array_structure_list
+    _item.mandatory_code          implicit
+    _item_type.code               code
+save_
+
+save_<a name="_array_structure_list.array_section_id" >_array_structure_list.array_section_id</a>
+    _item_description.description
+;             This item is a pointer to <a href="#_array_structure_list_section.id" >_array_structure_list_section.id</a> in the
+              <a href="#array_structure">ARRAY_STRUCTURE_LIST_SECTION</a> category.
+;
+    _item.name                  '<a href="#_array_structure_list.array_section_id" >_array_structure_list.array_section_id</a>'
+    _item.category_id             array_structure_list
+    _item.mandatory_code          implicit
+    _item_type.code               code
+save_
+
+
+save_<a name="_array_structure_list.axis_set_id" >_array_structure_list.axis_set_id</a>
+    _item_description.description
+;             This is a descriptor for the physical axis or set of axes
+              corresponding to an array index.
+
+              This data item is related to the axes of the detector
+              itself given in <a href="#diffrn_detector_axis">DIFFRN_DETECTOR_AXIS</a>, but usually differs
+              in that the axes in this category are the axes of the
+              coordinate system of reported data points, while the axes in
+              <a href="#diffrn_detector_axis">DIFFRN_DETECTOR_AXIS</a> are the physical axes
+              of the detector describing the 'poise' of the detector as an
+              overall physical object.
+
+              If there is only one axis in the set, the identifier of
+              that axis should be used as the identifier of the set.
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+           '<a href="#_array_structure_list.axis_set_id" >_array_structure_list.axis_set_id</a>'
+                                  array_structure_list            yes
+           '<a href="#_array_structure_list_axis.axis_set_id" >_array_structure_list_axis.axis_set_id</a>'
+                                  array_structure_list_axis       implicit
+    _item_type.code               code
+     loop_
+    _item_linked.child_name
+    _item_linked.parent_name
+           '<a href="#_array_structure_list_axis.axis_set_id" >_array_structure_list_axis.axis_set_id</a>'
+                               '<a href="#_array_structure_list.axis_set_id" >_array_structure_list.axis_set_id</a>'
+     save_
+
+
+save_<a name="_array_structure_list.dimension" >_array_structure_list.dimension</a>
+    _item_description.description
+;             The number of elements stored in the array structure in 
+              this dimension.
+;
+    _item.name                '<a href="#_array_structure_list.dimension" >_array_structure_list.dimension</a>'
+    _item.category_id          array_structure_list
+    _item.mandatory_code       yes
+    _item_type.code            int
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            1  1
+                            .  1
+     save_
+
+
+save_<a name="_array_structure_list.direction" >_array_structure_list.direction</a>
+    _item_description.description
+;             Identifies the direction in which this array index changes.
+;
+    _item.name                '<a href="#_array_structure_list.direction" >_array_structure_list.direction</a>'
+    _item.category_id          array_structure_list
+    _item.mandatory_code       yes
+    _item_type.code            code
+     loop_
+    _item_enumeration.value
+    _item_enumeration.detail
+
+                              'increasing'
+;       Indicates the index changes from 1 to the maximum dimension.
+;
+                              'decreasing'
+;       Indicates the index changes from the maximum dimension to 1.
+;
+     save_
+
+
+save_<a name="_array_structure_list.index" >_array_structure_list.index</a>
+    _item_description.description
+;             Identifies the one-based index of the row or column in the
+              array structure.
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+           '<a href="#_array_structure_list.index" >_array_structure_list.index</a>'        array_structure_list   yes
+           '<a href="#_array_structure_list.precedence" >_array_structure_list.precedence</a>'   array_structure_list   yes
+           '<a href="#_array_element_size.index" >_array_element_size.index</a>'          array_element_size     yes
+
+    _item_type.code            int
+
+     loop_
+    _item_linked.child_name
+    _item_linked.parent_name
+          '<a href="#_array_structure_list_section.index" >_array_structure_list_section.index</a>'
+                        '<a href="#_array_structure_list.index" >_array_structure_list.index</a>'
+          '<a href="#_array_element_size.index" >_array_element_size.index</a>'
+                        '<a href="#_array_structure_list.index" >_array_structure_list.index</a>'
+
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            1  1
+                            .  1
+     save_
+
+
+save_<a name="_array_structure_list.precedence" >_array_structure_list.precedence</a>
+    _item_description.description
+;             Identifies the rank order in which this array index changes
+              with respect to other array indices.  The precedence of 1
+              indicates the index which changes fastest.
+;
+    _item.name                '<a href="#_array_structure_list.precedence" >_array_structure_list.precedence</a>'
+    _item.category_id          array_structure_list
+    _item.mandatory_code       yes
+    _item_type.code            int
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            1  1
+                            .  1
+     save_
+
+
+save_<a name="_array_structure_list.variant" >_array_structure_list.variant</a>
+    _item_description.description
+;             The value of <a href="#_array_structure_list.variant" >_array_structure_list.variant</a> gives the variant
+              to which the given ARRAY_STRUCTURE_LIST row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to <a href="#_variant.variant" >_variant.variant</a> in the
+              <a href="#variant">VARIANT</a> category.
+;
+    _item.name                  '<a href="#_array_structure_list.variant" >_array_structure_list.variant</a>'
+    _item.category_id             array_structure_list
+    _item.mandatory_code          implicit
+    _item_default.value           .
+    _item_type.code               code
+     save_
+
+
+################################
+# <a name="array_structure_list_section">ARRAY_STRUCTURE_LIST_SECTION</a> #
+################################
+
+
+save_ARRAY_STRUCTURE_LIST_SECTION
+    _category.description
+;   Data items in the <a href="#array_structure_list_section">ARRAY_STRUCTURE_LIST_SECTION</a> category identify
+    the dimension-by-dimension start, end and stride of each section of an
+    array that is to be referenced.
+
+    For any array with identifier ARRAYID, array section ids of the form
+    ARRAYID(start1:end1:stride1,start2:end2:stride2, ...) are defined
+    by default.
+
+    For the given index, the elements in the section are of indices:
+    <a href="#_array_structure_list_section.start">_array_structure_list_section.start</a>,
+    <a href="#_array_structure_list_section.start">_array_structure_list_section.start</a> + <a href="#_array_structure_list_section.stride">_array_structure_list_section.stride</a>,
+    <a href="#_array_structure_list_section.start">_array_structure_list_section.start</a> + 2*<a href="#_array_structure_list_section.stride">_array_structure_list_section.stride</a>,
+    ...
+
+    stopping either when the indices leave the limits of the indices
+    of that dimension or 
+    [min(<a href="#_array_structure_list_section.start">_array_structure_list_section.start</a>, <a href="#_array_structure_list_section.end">_array_structure_list_section.end</a>),
+     max(<a href="#_array_structure_list_section.start">_array_structure_list_section.start</a>, <a href="#_array_structure_list_section.end">_array_structure_list_section.end</a>)].
+
+
+    The ordering of these elements is determined by the overall ordering of
+    <a href="#_array_structure_list_section.array_id">_array_structure_list_section.array_id</a> and not by the ordering implied
+    by the stride.
+;
+    _category.id                   array_structure_list_section
+    _category.mandatory_code       no
+<div id="print_NX_array_structure_list_section" style="display:block">   #_category.NX_mapping_details in online version <a href="javascript:open_close2('online_NX_array_structure_list_section','print_NX_array_structure_list_section');">+/-</a>
+</div><div id="online_NX_array_structure_list_section" style="display:none">    _category.NX_mapping_details                  #<a href="javascript:open_close2('online_NX_array_structure_list_section','print_NX_array_structure_list_section');">+/-</a>
+;
+
+    _array_structure_list_section.array_id ARRAYID -->
+    _array_structure_list_section.id SECTIONID -->
+    _array_structure_list_section.index INDEX-->
+    _array_structure_list_section.end END -->
+    _array_structure_list_section.start START -->
+    _array_structure_list_section.stride STRIDE -->
+    /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+           /data_ARRAYID_BINARYID -->
+                /entry/data_ARRAYID_BINARYID/data_ARRAYID_BINARYID
+           /AXISID1 -->
+                /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID1
+           /AXISID2 -->
+                /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID2
+           /AXISID2 -->
+                /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID3
+           /ARRAYSECTIONID:NXdetector_module
+             /data_origin=[...] -- the 0-based origins indices of ARRAYSECTIONID
+             /data_size=[...] the sizes in pixels of ARRAYSECTIONID
+             /data_stride[...] the strides of ARRAYSECTIONID
+
+;
+</div>
+     loop_
+    _category_key.name             '<a href="#_array_structure_list_section.id" >_array_structure_list_section.id</a>'
+                                   '<a href="#_array_structure_list_section.array_id" >_array_structure_list_section.array_id</a>'
+                                   '<a href="#_array_structure_list_section.index" >_array_structure_list_section.index</a>'
+                                   '<a href="#_array_structure_list_section.variant" >_array_structure_list_section.variant</a>'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'array_data_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;       Example 1. An image array, myarray, of 1300 x 1200 elements, and
+                    700 frames is defined in ARRAY_STRUCTURE_LIST, and
+                    the array section identifier
+
+                    "myarray(101:1200,101:1100,1:700:10)"
+
+                    is explicitly defined taking every 10th frame and
+                    removing a 100 pixel border.  Note that even though
+                    the slow index high is 700, the last frame that
+                    will actually be included is only 691.
+;
+;
+
+     loop_
+    <a href="#_array_structure_list.array_id">_array_structure_list.array_id</a>
+    <a href="#_array_structure_list.index">_array_structure_list.index</a>
+    <a href="#_array_structure_list.dimension">_array_structure_list.dimension</a>
+    <a href="#_array_structure_list.precedence">_array_structure_list.precedence</a>
+    <a href="#_array_structure_list.direction">_array_structure_list.direction</a>
+    <a href="#_array_structure_list.axis_set_id">_array_structure_list.axis_set_id</a>
+    myarray   1    1300    1     increasing  ELEMENT_X
+    myarray   2    1200    2     increasing  ELEMENT_Y
+    myarray   3    700     3     increasing  FRAME_NO
+
+     loop_
+    <a href="#_array_structure_list_section.id">_array_structure_list_section.id</a>
+    <a href="#_array_structure_list_section.array_id">_array_structure_list_section.array_id</a>
+    <a href="#_array_structure_list_section.index">_array_structure_list_section.index</a>
+    <a href="#_array_structure_list_section.start">_array_structure_list_section.start</a>
+    <a href="#_array_structure_list_section.end">_array_structure_list_section.end</a>
+    <a href="#_array_structure_list_section.stride">_array_structure_list_section.stride</a>
+    "myarray(101:1200,101:1100,1:700:10)"  myarray 1 101 1200   .
+    "myarray(101:1200,101:1100,1:700:10)"  myarray 2 101 1100   .
+    "myarray(101:1200,101:1100,1:700:10)"  myarray 3   1  700  10
+
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save_<a name="_array_structure_list_section.array_id" >_array_structure_list_section.array_id</a>
+    _item_description.description
+;             This item is a pointer to <a href="#_array_structure.id" >_array_structure.id</a> in the
+              <a href="#array_structure">ARRAY_STRUCTURE</a> category.
+;
+    _item.name                  '<a href="#_array_structure_list_section.array_id" >_array_structure_list_section.array_id</a>'
+    _item.category_id             array_structure_list_section
+    _item.mandatory_code          implicit
+    _item_type.code               code
+save_
+
+
+save_<a name="_array_structure_list_section.end" >_array_structure_list_section.end</a>
+    _item_description.description
+;             Identifies the ending ordinal, numbered from 1, for an array
+              element of index <a href="#_array_structure_list_section.index">_array_structure_list_section.index</a> in the
+              section.
+
+              The value defaults to the dimension for index
+              <a href="#_array_structure_list_section.index">_array_structure_list_section.index</a>
+              of the array.
+
+              Note that this agrees with the Fortran convention, rather than
+              the Python convention in that, if compatible with the stride,
+              the end element is included in the section as in Fortran, rather
+              than being one beyond the section as in Python.
+;
+
+    _item.name               '<a href="_array_structure_list_section.end" >_array_structure_list_section.end</a>'
+    _item.category_id          array_structure_list_section
+    _item.mandatory_code       implicit
+    _item_type.code            int
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            1  1
+                            .  1
+     save_
+
+
+save_<a name="_array_structure_list_section.id" >_array_structure_list_section.id</a>
+    _item_description.description
+;             Uniquely identifies the array section chosen.
+
+              To avoid confusion array section IDs that contain parentheses
+              should conform to the default syntax
+
+              ARRAYID(start1:end1:stride1,start2:end2:stride2, ...)
+;
+    _item.name                  '<a href="#_array_structure_list_section.id" >_array_structure_list_section.id</a>'
+    _item.category_id             array_structure_list_section
+    _item.mandatory_code          yes
+    _item_type.code               code
+
+     loop_
+    _item_linked.child_name
+    _item_linked.parent_name
+                            '<a href="#_diffrn_data_frame.array_section_id" >_diffrn_data_frame.array_section_id</a>'
+                              '<a href="#_array_structure_list_section.id" >_array_structure_list_section.id</a>'
+                            '<a href="#_map_segment.array_section_id" >_map_segment.array_section_id</a>'
+                              '<a href="#_array_structure_list_section.id" >_array_structure_list_section.id</a>'
+
+save_
+
+
+save_<a name="_array_structure_list_section.index" >_array_structure_list_section.index</a>
+    _item_description.description
+;             This item is a pointer to <a href="#_array_structure_list.index" >_array_structure_list.index</a>
+              in the <a href="#array_structure_list">ARRAY_STRUCTURE_LIST</a> category.
+
+              Identifies the one-based index of the row, column, sheet ...
+              the <a href="#array_structure_list">ARRAY_STRUCTURE_LIST</a> category.
+
+              For a multidimensional array, a value must be explicitly given.
+
+              If an index is omitted from a section then all elements for that
+              index are assumed to be included in the section.
+;
+    _item.name                 '<a href="_array_structure_list_section.index" >_array_structure_list_section.index</a>'
+    _item.category_id          array_structure_list_section
+    _item.mandatory_code       implicit
+    _item_type.code            int
+     save_
+
+
+save_<a name="_array_structure_list_section.start" >_array_structure_list_section.start</a>
+    _item_description.description
+;             Identifies the starting ordinal, numbered from 1,
+              for an array element of index <a href="#_array_structure_list_section.index">_array_structure_list_section.index</a>
+              in the section.
+
+              The value defaults to 1.   For the given index, the elements in
+              the section are of indices:
+              <a href="#_array_structure_list_section.start">_array_structure_list_section.start</a>,
+              <a href="#_array_structure_list_section.start">_array_structure_list_section.start</a>
+                 + <a href="#_array_structure_list_section.stride">_array_structure_list_section.stride</a>,
+              <a href="#_array_structure_list_section.start">_array_structure_list_section.start</a>
+                 + 2*<a href="#_array_structure_list_section.stride">_array_structure_list_section.stride</a>,
+                  ...
+
+              stopping either when the indices leave the limits of the indices
+              of that dimension or 
+              [min(<a href="#_array_structure_list_section.start">_array_structure_list_section.start</a>,
+                  <a href="#_array_structure_list_section.end">_array_structure_list_section.end</a>),
+               max(<a href="#_array_structure_list_section.start">_array_structure_list_section.start</a>,
+                  <a href="#_array_structure_list_section.end">_array_structure_list_section.end</a>)].
+
+
+              The ordering of these elements is determined by the overall
+              ordering of <a href="#_array_structure_list_section.array_id">_array_structure_list_section.array_id</a> and not by
+              the ordering implied by the stride.
+;
+    _item.name                 '<a href="_array_structure_list_section.start" >_array_structure_list_section.start</a>'
+    _item.category_id          array_structure_list_section
+    _item.mandatory_code       implicit
+    _item_type.code            int
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            1  1
+                            .  1
+     save_
+
+
+save_<a name="_array_structure_list_section.stride" >_array_structure_list_section.stride</a>
+    _item_description.description
+;             Identifies the incremental steps to be taken when moving
+              element to element in the section in that particular
+              dimension.  The value of <a href="#_array_structure_list_section.stride">_array_structure_list_section.stride</a>
+              may be positive or negative.  If the stride is zero, the section
+              is just defined by <a href="#_array_structure_list_section.start">_array_structure_list_section.start</a>.
+;
+    _item.name                '<a href="#_array_structure_list_section.stride" >_array_structure_list_section.stride</a>'
+    _item.category_id          array_structure_list_section
+    _item.mandatory_code       no
+    _item_default.value        1
+    _item_type.code            int
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            1  1
+                            .  1
+     save_
+
+
+save_<a name="_array_structure_list_section.variant" >_array_structure_list_section.variant</a>
+    _item_description.description
+;             The value of <a href="#_array_structure_list_section.variant" >_array_structure_list_section.variant</a> gives the
+              variant to which the given ARRAY_STRUCTURE_LIST_SECTION row
+              is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to <a href="#_variant.variant" >_variant.variant</a> in the
+              <a href="#variant">VARIANT</a> category.
+;
+    _item.name                  '<a href="#_array_structure_list_section.variant" >_array_structure_list_section.variant</a>'
+    _item.category_id             array_structure_list_section
+    _item.mandatory_code          implicit
+    _item_default.value           .
+    _item_type.code               code
+     save_
+
+
+#############################
+# <a name="array_structure_list_axis">ARRAY_STRUCTURE_LIST_AXIS</a> #
+#############################
+
+save_ARRAY_STRUCTURE_LIST_AXIS
+    _category.description
+;   Data items in the <a href="#array_structure_list_axis">ARRAY_STRUCTURE_LIST_AXIS</a> category describe
+    the physical settings of sets of axes for the centres of pixels that
+    correspond to data points described in the
+    <a href="#array_structure_list">ARRAY_STRUCTURE_LIST</a> category.
+
+    In the simplest cases, the physical increments of a single axis correspond
+    to the increments of a single array index.  More complex organizations,
+    e.g. spiral scans, may require coupled motions along multiple axes.
+
+    Note that a spiral scan uses two coupled axes: one for the angular
+    direction and one for the radial direction.  This differs from a
+    cylindrical scan for which the two axes are not coupled into one 
+    set.
+
+    Axes may be specified either for an entire array or for just a section
+    of an array.
+;
+    _category.id                   array_structure_list_axis
+    _category.mandatory_code       no
+<div id="print_NX_array_structure_list_axis" style="display:block">   #_category.NX_mapping_details in online version <a href="javascript:open_close2('online_NX_array_structure_list_axis','print_NX_array_structure_list_axis');">+/-</a>
+</div><div id="online_NX_array_structure_list_axis" style="display:none">    _category.NX_mapping_details                  #<a href="javascript:open_close2('online_NX_array_structure_list_axis','print_NX_array_structure_list_axis');">+/-</a>
+;
+
+    _array_structure_list.axis_set_id AXISSETID
+    _array_structure_list.array_id ARRAYID
+    _array_structure_list.array_section_id ARRAYSECTIONID
+    _array_structure_list.dimension DIM
+    _array_structure_list.direction DIR
+    _array_structure_list.index INDEX
+    _array_structure_list.precedence PRECEDENCE
+
+    _array_structure_list_section.array_id ARRAYID -->
+    _array_structure_list_section.id ARRAYSECTIONID -->
+    _array_structure_list_section.index PRECEDENCE-->
+    _array_structure_list_section.end END -->
+    _array_structure_list_section.start START -->
+    _array_structure_list_section.stride STRIDE -->
+
+
+     loop_
+    _array_structure_list_axis.axis_id 
+    _array_structure_list_axis.axis_set_id 
+    _array_structure_list_axis.angle 
+    _array_structure_list_axis.angle_increment 
+    _array_structure_list_axis.displacement 
+    _array_structure_list_axis.fract_displacement  
+    _array_structure_list_axis.displacement_increment 
+    _array_structure_list_axis.fract_displacement_increment 
+    _array_structure_list_axis.angular_pitch  
+    _array_structure_list_axis.reference_angle 
+    _array_structure_list_axis.reference_displacement REFDISP
+    AXISID1 AXISSETID ANGLE1 ANGLEINC1 DISP1 FRACTDISP1
+         DISPINC1 FRACTINC1 ANGPITCH1 REFANG1
+    AXISID2 AXISSETID ANGLE2 ANGLEINC2 DISP2 FRACTDISP2
+         DISPINC2 FRACTINC2 ANGPITCH2 REFANG2
+    AXISID3 AXISSETID ANGLE3 ANGLEINC3 DISP3 FRACTDISP3
+         DISPINC3 FRACTINC3 ANGPITCH3 REFANG3
+
+    _diffrn_data_frame.array_id ARRAYID
+    _diffrn_data_frame.binary_id BINARYID
+    _diffrn_data_frame.center_fast CENF
+    _diffrn_data_frame.center_slow CENS
+    _diffrn_data_frame.center_units UNITS
+    _diffrn_data_frame.detector_element_id ELEMENTID
+    _diffrn_data_frame.id FRAMEID
+    _diffrn_data_frame.details DETAILS
+
+    -->
+
+    ...
+
+
+   /entry:NXentry
+     /data_ARRAYID_BINARYID:NXdata
+        @signal="data_ARRAYID_BINARY_ID"
+        /data_ARRAYID_BINARYID[ the data for the array ARRAYID,
+                                binary BINARYID, all sections,
+                                all FRAMES]
+        @axes=[...,AXISID1,...] with AXISID1 inserted at PRECEDENCE-1
+        @AXISID1_indices=[PRECEDENCE-1]
+        @AXISID2_indices=[PRECEDENCE-1]
+        @AXISID3_indices=[PRECEDENCE-1]
+        @AXISID1_origins=[origin1]  (default 0)
+        @AXISID2_origins=[origin2]  (default 0)
+        @AXISID3_origins=[origin3]  (default 0)
+        @AXISID1_sizes=[size1]
+        @AXISID2_sizes=[size2]
+        @AXISID3_sizes=[size3]
+        @AXISID1_strides=[stride1]
+        @AXISID2_strides=[stride2]
+        @AXISID3_strides=[stride3]
+
+        ...
+        /AXISID1 -->
+            /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID1
+        /AXISID2 -->
+            /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID2
+        /AXISID2 -->
+            /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID3
+        ...
+
+     /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+           /data_ARRAYID_BINARYID -->
+                /entry/data_ARRAYID_BINARYID/data_ARRAYID_BINARYID
+           /AXISID1 -->
+                /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID1
+           /AXISID2 -->
+                /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID2
+           /AXISID2 -->
+                /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID3
+           /ARRAYSECTIONID:NXdetector_module
+             /data_origin=[...] -- the 0-based origins indices of ARRAYSECTIONID
+             /data_size=[...] the sizes in pixels of ARRAYSECTIONID
+             /data_stride[...] the strides of ARRAYSECTIONID
+               .. 
+           /transformations:NXtransformations
+             /AXISID1=[DISP1,DISP1+DISPINC1,...]   (or using angles where appropriate)
+                @depends_on=...   determined from AXIS definitions
+                @equipment="detector"
+                @offset=[...] determined from AXIS definitions
+                @offset_units="mm"
+                @transformation_type="..." from AXIS definitions
+                @units="mm"
+                @vector=[...] determined from AXIS definitions
+                @CBF_array_structure_list_axis__axis_id="AXISID1"
+                @CBF_array_structure_list_axis__axis_set_id="AXISSETID"
+                @CBF_array_structure_list_axis__angle=ANGLE1
+                @CBF_array_structure_list_axis__angle_increment=ANGLEINC1
+                @CBF_array_structure_list_axis__displacement=DISP1
+                @CBF_array_structure_list_axis__displacement=FRACTDISP1
+                @CBF_array_structure_list_axis__displacement_increment=DISPINC1
+                @CBF_array_structure_list_axis__fract_displacement_increment=FRACTINC1
+                @CBF_array_structure_list_axis__angular_pitch=ANGPITCH1
+                @CBF_array_structure_list_axis__radial_pitch=RADPITCH1
+                @CBF_array_structure_list_axis__reference_angle=REFANG1
+                @CBF_array_structure_list_axis__reference_displacement=REFDISP1
+             /AXISID2=[DISP2,DISP2+DISPINC2,...]   (or using angles where appropriate)
+                @depends_on=...   determined from AXIS definitions
+                @equipment="detector"
+                @offset=[...] determined from AXIS definitions
+                @offset_units="mm"
+                @transformation_type="..." from AXIS definitions
+                @units="mm"
+                @vector=[...] determined from AXIS definitions
+                @CBF_array_structure_list_axis__axis_id="AXISID2"
+                @CBF_array_structure_list_axis__axis_set_id="AXISSETID"
+                @CBF_array_structure_list_axis__angle=ANGLE2
+                @CBF_array_structure_list_axis__angle_increment=ANGLEINC2
+                @CBF_array_structure_list_axis__displacement=DISP2
+                @CBF_array_structure_list_axis__displacement=FRACTDISP2
+                @CBF_array_structure_list_axis__displacement_increment=DISPINC2
+                @CBF_array_structure_list_axis__fract_displacement_increment=FRACTINC2
+                @CBF_array_structure_list_axis__angular_pitch=ANGPITCH2
+                @CBF_array_structure_list_axis__radial_pitch=RADPITCH2
+                @CBF_array_structure_list_axis__reference_angle=REFANG2
+                @CBF_array_structure_list_axis__reference_displacement=REFDISP2
+             /AXISID3=[DISP3,DISP3+DISPINC3,...]   (or using angles where appropriate)
+                @depends_on=...   determined from AXIS definitions
+                @equipment="detector"
+                @offset=[...] determined from AXIS definitions
+                @offset_units="mm"
+                @transformation_type="..." from AXIS definitions
+                @units="mm"
+                @vector=[...] determined from AXIS definitions
+                @CBF_array_structure_list_axis__axis_id="AXISID3"
+                @CBF_array_structure_list_axis__axis_set_id="AXISSETID"
+                @CBF_array_structure_list_axis__angle=ANGLE3
+                @CBF_array_structure_list_axis__angle_increment=ANGLEINC3
+                @CBF_array_structure_list_axis__displacement=DISP3
+                @CBF_array_structure_list_axis__displacement=FRACTDISP3
+                @CBF_array_structure_list_axis__displacement_increment=DISPINC3
+                @CBF_array_structure_list_axis__fract_displacement_increment=FRACTINC3
+                @CBF_array_structure_list_axis__angular_pitch=ANGPITCH3
+                @CBF_array_structure_list_axis__radial_pitch=RADPITCH3
+                @CBF_array_structure_list_axis__reference_angle=REFANG3
+                @CBF_array_structure_list_axis__reference_displacement=REFDISP3
+
+    Notes: The same axis AXISIDn may appear in multiple axis sets for different
+           values of PRECEDENCE of the data array, in which case the values
+           in AXISIDn_indices will be the sorted list of PRECEDENCE-1 values
+           and the array section information will be organized by the
+           same ordering.
+;
+</div>
+     loop_
+    _category_key.name
+                                  '<a href="#_array_structure_list_axis.axis_set_id" >_array_structure_list_axis.axis_set_id</a>'
+                                  '<a href="#_array_structure_list_axis.axis_id" >_array_structure_list_axis.axis_id</a>'
+                                  '<a href="#_array_structure_list_axis.variant" >_array_structure_list_axis.variant</a>'
+     loop_
+    _category_group.id           'inclusive_group'
+                                 'array_data_group'
+     save_
+
+
+save_<a name="_array_structure_list_axis.axis_id" >_array_structure_list_axis.axis_id</a>
+    _item_description.description
+;             The value of this data item is the identifier of one of
+              the axes in the set of axes for which settings are being
+              specified.
+
+              Multiple axes may be specified for the same value of
+              <a href="#_array_structure_list_axis.axis_set_id" >_array_structure_list_axis.axis_set_id</a>.
+
+              This item is a pointer to <a href="#_axis.id" >_axis.id</a> in the
+              <a href="#AXIS">AXIS</a> category.
+;
+    _item.name                 '<a href="#_array_structure_list_axis.axis_id" >_array_structure_list_axis.axis_id</a>'
+    _item.category_id          array_structure_list_axis
+    _item.mandatory_code       yes
+    _item_type.code            code
+     save_
+
+
+save_<a name="_array_structure_list_axis.axis_set_id" >_array_structure_list_axis.axis_set_id</a>
+    _item_description.description
+;             The value of this data item is the identifier of the
+               set of axes for which axis settings are being specified.
+
+               Multiple axes may be specified for the same value of
+               <a href="#_array_structure_list_axis.axis_set_id" >_array_structure_list_axis.axis_set_id</a>.
+
+               This item is a pointer to
+               <a href="#_array_structure_list.axis_set_id" >_array_structure_list.axis_set_id</a>
+               in the <a href="#array_structure_list">ARRAY_STRUCTURE_LIST</a> category.
+
+               If this item is not specified, it defaults to the corresponding
+               axis identifier.
+;
+    _item.name                 '<a href="#_array_structure_list_axis.axis_set_id" >_array_structure_list_axis.axis_set_id</a>'
+    _item.category_id          array_structure_list_axis
+    _item.mandatory_code       implicit
+    _item_type.code            code
+     save_
+
+
+save_<a name="_array_structure_list_axis.angle" >_array_structure_list_axis.angle</a>
+    _item_description.description
+;             The setting of the specified axis in degrees for the first
+               data point of the array index with the corresponding value
+               of <a href="#_array_structure_list.axis_set_id">_array_structure_list.axis_set_id</a>.  If the index is
+               specified as 'increasing', this will be the centre of the
+               pixel with index value 1.  If the index is specified as
+             'decreasing', this will be the centre of the pixel with
+               maximum index value.
+;
+    _item.name                 '<a href="#_array_structure_list_axis.angle" >_array_structure_list_axis.angle</a>'
+    _item.category_id          array_structure_list_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'degrees'
+     save_
+
+
+save_<a name="_array_structure_list_axis.angle_increment">_array_structure_list_axis.angle_increment</a>
+    _item_description.description
+;             The pixel-centre-to-pixel-centre increment in the angular
+               setting of the specified axis in degrees.  This is not
+               meaningful in the case of 'constant velocity' spiral scans
+               and should not be specified for this case.
+
+               See <a href="#_array_structure_list_axis.angular_pitch">_array_structure_list_axis.angular_pitch</a>.
+
+;
+    _item.name                 '<a href="#_array_structure_list_axis.angle_increment">_array_structure_list_axis.angle_increment</a>'
+    _item.category_id          array_structure_list_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'degrees'
+     save_
+
+
+save_<a name="_array_structure_list_axis.displacement" >_array_structure_list_axis.displacement</a>
+    _item_description.description
+;             The setting of the specified axis in millimetres for the first
+               data point of the array index with the corresponding value
+               of <a href="#_array_structure_list.axis_set_id">_array_structure_list.axis_set_id</a>.  If the index is
+               specified as 'increasing', this will be the centre of the
+               pixel with index value 1.  If the index is specified as
+             'decreasing', this will be the centre of the pixel with
+               maximum index value.
+;
+    _item.name               '<a href="#_array_structure_list_axis.displacement" >_array_structure_list_axis.displacement</a>'
+    _item.category_id          array_structure_list_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save_<a name="_array_structure_list_axis.fract_displacement" >_array_structure_list_axis.fract_displacement</a>
+    _item_description.description
+;             The setting of the specified axis as a decimal fraction of 
+               the axis unit vector for the first data point of the array 
+               index with the corresponding value of 
+               <a href="#_array_structure_list.axis_set_id">_array_structure_list.axis_set_id</a>.  
+
+               If the index is specified as 'increasing', this will be the 
+               centre of the pixel with index value 1.  If the index is 
+               specified as 'decreasing', this will be the centre of the 
+               pixel with maximum index value.
+;
+    _item.name               '<a href="#_array_structure_list_axis.fract_displacement" >_array_structure_list_axis.fract_displacement</a>'
+    _item.category_id          array_structure_list_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+     save_
+
+
+save_<a name="_array_structure_list_axis.displacement_increment">_array_structure_list_axis.displacement_increment</a>
+    _item_description.description
+;             The pixel-centre-to-pixel-centre increment for the displacement
+               setting of the specified axis in millimetres.
+;
+    _item.name
+        '<a href="#_array_structure_list_axis.displacement_increment">_array_structure_list_axis.displacement_increment</a>'
+    _item.category_id          array_structure_list_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save_<a name="_array_structure_list_axis.fract_displacement_increment">_array_structure_list_axis.fract_displacement_increment</a>
+    _item_description.description
+;             The pixel-centre-to-pixel-centre increment for the displacement
+               setting of the specified axis as a decimal fraction of the
+               axis unit vector.
+;
+    _item.name
+        '<a href="#_array_structure_list_axis.fract_displacement_increment">_array_structure_list_axis.fract_displacement_increment</a>'
+    _item.category_id          array_structure_list_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save_<a name="_array_structure_list_axis.angular_pitch">_array_structure_list_axis.angular_pitch</a>
+    _item_description.description
+;             The pixel-centre-to-pixel-centre distance for a one-step
+               change in the setting of the specified axis in millimetres.
+
+               This is meaningful only for 'constant velocity' spiral scans
+               or for uncoupled angular scans at a constant radius
+               (cylindrical scans) and should not be specified for cases
+               in which the angle between pixels (rather than the distance
+               between pixels) is uniform.
+
+               See <a href="#_array_structure_list_axis.angle_increment">_array_structure_list_axis.angle_increment</a>.
+;
+    _item.name               '<a href="#_array_structure_list_axis.angular_pitch">_array_structure_list_axis.angular_pitch</a>'
+    _item.category_id          array_structure_list_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save_<a name="_array_structure_list_axis.radial_pitch">_array_structure_list_axis.radial_pitch</a>
+    _item_description.description
+;             The radial distance from one 'cylinder' of pixels to the
+               next in millimetres.  If the scan is a 'constant velocity'
+               scan with differing angular displacements between pixels,
+               the value of this item may differ significantly from the
+               value of <a href="#_array_structure_list_axis.displacement_increment">_array_structure_list_axis.displacement_increment</a>.
+;
+    _item.name               '<a href="#_array_structure_list_axis.radial_pitch">_array_structure_list_axis.radial_pitch</a>'
+    _item.category_id          array_structure_list_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save_<a name="_array_structure_list_axis.reference_angle">_array_structure_list_axis.reference_angle</a>
+    _item_description.description
+;             The value of _array_structure_list_axis.reference_angle
+               specifies the setting of the angle of this axis used for 
+               determining a reference beam centre and a reference detector 
+               distance.  It is normally expected to be identical to the 
+               value of _array_structure_list_axis.angle.
+
+;
+    _item.name '<a href="#_array_structure_list_axis.reference_angle">_array_structure_list_axis.reference_angle</a>'
+    _item.category_id          array_structure_list_axis
+    _item.mandatory_code       implicit
+    _item_type.code            float
+    _item_units.code           'degrees'
+     save_
+
+
+save_<a name="_array_structure_list_axis.reference_displacement">_array_structure_list_axis.reference_displacement</a>
+    _item_description.description
+;             The value of _array_structure_list_axis.reference_displacement
+               specifies the setting of the displacement of this axis used 
+               for determining a reference beam centre and a reference detector
+               distance.  It is normally expected to be identical to the value
+               of _array_structure_list_axis.displacement.
+
+;
+    _item.name '<a href="#_array_structure_list_axis.reference_displacement">_array_structure_list_axis.reference_displacement</a>'
+    _item.category_id          array_structure_list_axis
+    _item.mandatory_code       implicit
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save_<a name="_array_structure_list_axis.variant" >_array_structure_list_axis.variant</a>
+    _item_description.description
+;            The value of <a href="#_array_structure_list_axis.variant" >_array_structure_list_axis.variant</a> gives the variant
+              to which the given ARRAY_STRUCTURE_LIST_AXIS row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to <a href="#_variant.variant" >_variant.variant</a> in the
+              <a href="#variant">VARIANT</a> category.
+;
+    _item.name                  '<a href="#_array_structure_list_axis.variant" >_array_structure_list_axis.variant</a>'
+    _item.category_id             array_structure_list_axis
+    _item.mandatory_code          implicit
+    _item_default.value           .
+    _item_type.code               code
+     save_
+
+
+########
+# <a name="axis">AXIS</a> #
+########
+
+save_AXIS
+    _category.description
+;   Data items in the <a href="#AXIS">AXIS</a> category record the information required
+     to describe the various goniometer, detector, source and other
+     axes needed to specify a data collection or the axes defining the
+     coordinate system of an image.  
+
+     The location of each axis is specified by two vectors: the axis 
+     itself, given by a unit vector in the direction of the axis, and 
+     an offset to the base of the unit vector.  
+
+     The vectors defining an axis are referenced to an appropriate
+     coordinate system, given in <a href=#_axis.system>_axis.system</a>.  The axis vector itself,
+       [<a href=#_axis.vector[1]>_axis.vector[1]</a>, <a href=#_axis.vector[2]>_axis.vector[2]</a>, <a href=#_axis.vector[3]>_axis.vector[3]</a>],
+     is a dimensionless unit vector.  Where meaningful, an offset vector
+       [<a href=#_axis.offset[1]>_axis.offset[1]</a>, <a href=#_axis.offset[2]>_axis.offset[2]</a>, <a href=#_axis.offset[3]>_axis.offset[3]</a>]
+     supplies the offsets to the base of a rotation or translation axis in
+     X, Y and Z.  This is appropriate for the imgCIF standard laboratory 
+     coordinate system, the NeXus/HDF5 McStas laboratory coordinate system 
+     and the last two Cartesian coordinate systems, but for the direct lattice, 
+     <b>X</b> corresponds to <b>a</b>, <b>Y</b> to <b>b</b> and <b>Z</b> to <b>c</b>, while for the reciprocal lattice,
+     <b>X</b> corresponds to <b>a*</b>, <b>Y</b> to <b>b*</b> and <b>Z</b> to <b>c*</b>.
+
+     For purposes of visualization, all the coordinate systems are 
+     taken as right-handed, i.e. using the convention that the extended 
+     thumb of a right hand could point along the first (<b>X</b>) axis, the 
+     straightened pointer finger could point along the second (<b>Y</b>) axis 
+     and the middle finger folded inward could point along the third (<b>Z</b>)
+     axis.  For a right-handed rotation axis, if the right hand is wrapped
+     around the axis with the thumb pointed in the direction of the axis,
+     the fingers point in the positive rotation direction, i.e. clockwise.  
+
+     <b>THE IMGCIF STANDARD LABORATORY COORDINATE SYSTEM</b> <a href="javascript:open_close('axis_category_imgcif');">+/-</a>
+<div id="axis_category_imgcif" style="display:none">
+
+     The imgCIF standard laboratory coordinate system is a right-handed   
+     orthogonal coordinate system similar to that used by MOSFLM,  
+     but imgCIF puts Z along the X-ray beam, rather than putting X along the
+     X-ray beam as in MOSFLM.
+
+     The vectors for the imgCIF standard laboratory coordinate system
+     form a right-handed Cartesian coordinate system with its origin
+     in the sample or specimen.  The origin of the axis system should,
+     if possible, be defined in terms of mechanically stable axes to be
+     both in the sample and in the beam.  If the sample goniometer or other
+     sample positioner has two axes the intersection of which defines a
+     unique point at which the sample should be mounted to be bathed
+     by the beam, that will be the origin of the axis system.  If no such
+     point is defined, then the midpoint of the line of intersection
+     between the sample and the centre of the beam will define the origin.
+     For this definition the sample positioning system will be set at 
+     its initial reference position for the experiment.
+
+
+                             | <b>Y</b> (to complete right-handed system)
+                             |
+                             |
+                             |
+                             |
+                             |
+                             |________________<b><b>X</b></b>
+                            /       principal goniometer axis
+                           /
+                          /
+                         /
+                        /
+                       /<b>Z</b> (to source)
+
+
+
+
+     Axis 1 (<b>X</b>): The <b>X</b>-axis is aligned to the mechanical axis pointing from
+     the sample or specimen along the  principal axis of the goniometer or
+     sample positioning system if the sample positioning system has an axis 
+     that intersects the origin and which forms an angle of more than 22.5 
+     degrees with the beam axis.
+
+     Axis 2 (<b>Y</b>): The <b>Y</b>-axis completes an orthogonal right-handed system
+     defined by the <b><b>X</b></b>-axis and the <b>Z</b>-axis (see below).
+
+     Axis 3 (<b>Z</b>): The <b>Z</b>-axis is derived from the source axis which goes from
+     the sample to the source.  The <b>Z</b>-axis is the component of the source axis
+     in the direction of the source orthogonal to the <b>X</b>-axis in the plane
+     defined by the <b>X</b>-axis and the source axis.
+
+     If the conditions for the <b>X</b>-axis can be met, the coordinate system
+     will be based on the goniometer or other sample positioning system
+     and the beam and not on the orientation of the detector, gravity etc.  
+     The vectors necessary to specify all other axes are given by sets of 
+     three components in the order (<b>X</b>, <b>Y</b>, <b>Z</b>).
+     If the axis involved is a rotation axis, it is right-handed, i.e. as
+     one views the object to be rotated from the origin (the tail) of the
+     unit vector, the rotation is clockwise.  If a translation axis is
+     specified, the direction of the unit vector specifies the sense of
+     positive translation.
+
+     In some experimental techniques, there is no goniometer or the principal
+     axis of the goniometer is at a small acute angle with respect to
+     the source axis.  In such cases, other reference axes are needed
+     to define a useful coordinate system.  The order of priority in
+     defining directions in such cases is to use the detector, then
+     gravity, then north.
+
+     If the <b>X</b>-axis cannot be defined as above, then the
+     direction (not the origin) of the X-axis should be parallel to the axis 
+     of the primary detector element corresponding to the most rapidly 
+     varying dimension of that detector element's data array, with its 
+     positive sense corresponding to increasing values of the index for 
+     that dimension.  If the detector is such that such a direction cannot 
+     be defined (as with a point detector) or that the direction forms an
+     angle of less than 22.5 degrees with respect to the source axis, then 
+     the <b>X</b>-axis should be chosen so that if the <b>Y</b>-axis is chosen 
+     in the direction of gravity, and the <b>Z</b>-axis is chosen to be along 
+     the source axis, a right-handed orthogonal coordinate system is chosen.  
+     In the case of a vertical source axis, as a last resort, the 
+     <b>X</b>-axis should be chosen to point north.
+
+     All rotations are given in degrees and all translations are given in mm.
+
+     Axes may be dependent on one another.  The <b>X</b>-axis is the only goniometer
+     axis the direction of which is strictly connected to the hardware.  All
+     other axes are specified by the positions they would assume when the
+     axes upon which they depend are at their zero points.
+
+     When specifying detector axes, the axis is given to the beam centre.
+     The location of the beam centre on the detector should be given in the
+     <a href="#DIFFRN_DETECTOR">DIFFRN_DETECTOR</a> category in distortion-corrected millimetres from
+     the (0,0) corner of the detector.
+
+     For convenience when describing detector element (module) placement,
+     an optional mounting rotation axis and rotation angle may be
+     specified.  In such cases, the mounting rotation axis and angle
+     of rotation around the mounting rotation axis are applied after
+     applying the transformations upon which the given axis depends.
+
+     It should be noted that many different origins arise in the definition
+     of an experiment.  In particular, as noted above, it is necessary to
+     specify the location of the beam centre on the detector in terms
+     of the origin of the detector, which is, of course, not coincident
+     with the centre of the sample.
+
+</div>     <b>THE NEXUS/HDF5 MCSTAS LABORATORY COORDINATE SYSTEM</b> <a href="javascript:open_close('axis_category_mcstas');">+/-</a>
+<div id="axis_category_mcstas" style="display:none">
+
+     The standard coordinate frame in NeXus is the McStas coordinate frame,
+     in which the Z-axis points in the direction of the incident beam, the
+     X-axis is orthogonal to the Z-axis in the horizontal plane and pointing
+     left as seen from the source and the Y-axis points upwards.  The
+     origin is in the sample.
+
+     Differences in Coordinate Frames
+
+     The standard coordinate frame in imgCIF/CBF aligns the X-axis to the
+     principal goniometer axis, and chooses the Z-axis to point from the sample
+     into the beam.  If the beam is not orthogonal to the X-axis, the Z-axis
+     is the component of the vector that points into the beam orthogonal to the
+     X-axis.  The Y-axis is chosen to complete a right-handed axis system.
+
+     Let us call the NeXus coordinate axes, X_nx, Y_nx and Z_nx, the
+     imgCIF/CBF coordinate axes, X_cbf, Y_cbf and Z_cbf and the direction
+     of gravity, Gravity.  In order to translate a vector v_nx = ( x, y, z)
+     from the NeXus coordinate system to the imgCIF coordinate system, we
+     also need two additional axes, as unit vectors, Gravity_cbf the downwards
+     direction, and  Beam_cbf, the direction of the beam, e.g. ( 0, 0, -1).   
+
+     In practice, the beam is not necessarily perfectly horizontal, so Y_nx
+     is not necessarily perfectly vertical. Therefore, in order to generate
+     X_nx, Y_nx and Z_nx some care is needed.  The cross product between two
+     vectors a and b is a new vector c orthogonal to both a and b,
+     chosen so that a, b, c is a right-handed system.  If a and b are
+     orthogonal unit vectors, this right-handed system is an orthonormal
+     coordinate system.
+
+     In the CBF coordinate frame, Z_nx is aligned to Beam_cbf:
+
+        Z_nx = Beam_cbf.
+
+     X_nx is defined as being horizontal at right angles to the beam,
+     pointing to the left when seen from the source.  Assuming the beam is
+     not vertical, we can compute X_nx as the normalized cross product of
+     the  beam and gravity:
+
+        X_nx = (Beam_cbf x Gravity_cbf)/||Beam_cbf x Gravity_cbf||.
+
+     To see that this satisfies the constraint of being horizontal and
+     pointing to the left, consider the case of Beam = ( 0, 0, -1 )
+     and Gravity = ( 0, 0, 1 ); then we would have X_nx = ( 1, 0, 0 )
+     from the cross product above.  The normalization is only necessary
+     if the beam is not horizontal.
+
+     Finally Y_nx is computed as the cross product of the beam and X_nx,
+     completing an orthonormal right-handed system with Y_nx pointing upwards
+
+        Y_nx = Beam_cbf x X_nx.
+
+     Then we know that in the imgCIF/CBF coordinate frame
+
+        v_nx = X.X_nx + Y.Y_nx + Z.Z_nx.
+
+     Thus, given the imgCIF/CBF vectors for the true direction of the beam
+     and the true direction of gravity, we have a linear transformation from
+     the NeXus coordinate frame to the imgCIF/CBF coordinate frame.   The
+     origins of the two frames agree.   The inverse linear transformation will
+     transform a vector in the imgCIF/CBF coordinate frame into the NeXus
+     coordinate frame.
+
+     In the common case in which the beam is orthogonal to the principal
+     goniometer axis so that Beam_cbf = ( 0, 0, -1 ) and the imgCIF/CBF
+     Y-axis points upwards, the transformation inverts the X and Z axes.
+     In the other common case in which the beam is orthogonal to the
+     principal goniometer axis and the imgCIF/CBF Y-axis points
+     downwards, the transformation inverts the Y and Z axes.
+
+     Mapping axes
+
+     There are two transformations needed:  coord_xform(v) which takes a vector,
+     v, in the CBF imgCIF Standard Laboratory Coordinate System and returns the
+     equivalent McStas coordinate vector, and offset_xform(o) which takes an
+     offset, o, in the CBF imgCIF Standard Laboratory Coordinate System and
+     returns the equivalent NeXus offset.
+
+     In imgCIF/CBF all the information about all axes other than their
+     settings are gathered in one AXIS category.  The closest equivalent
+     container in NeXus is the NXinstrument class.  We put the information
+     about detector axes into a
+     detector:NXdetector/transformations:NXtransformations NeXus class instance,
+     information about the goniometer into a
+     goniometer:NXgoniometer/transformations:NXtransformations NeXus
+     class instance, etc.  Additionally, in view of the general nature of
+     some axes, such as the coordinate frame axes and gravity, we add a
+     transformations:NXtransformation NeXus class instance under NXentry with
+     axis__gravity, axis__beam and other axes not tied to specific equipment.
+
+     We have applied the coordinate frame transformation changing
+     the CBF laboratory coordinates into McStas coordinates.  Notice that X and
+     Z have changed direction, but Y has not.   In other experimental setups,
+     other transformations may occur.   The offsets for dependent axes are
+     given relative to the total offset of axes on which that axis is dependent.
+     Note that the axis settings do not enter into this calculation, because the
+     offsets of dependent axes are given with all axes at their zero settings.
+
+
+     The cbf_location attribute gives a mapping back into the CBF AXIS category
+     in dotted notation.  The first component is the data block.  The second
+     component is "axis".  The third component is either "vector" or
+     "offset"  for information drawn from the AXIS.VECTOR[...] or
+     AXIS.OFFSET[...] respectively.  The last component is the CBF row number
+     to facilitate recovering the original CBF layout.
+
+
+</div>     <b>THE DIRECT LATTICE (FRACTIONAL COORDINATES)</b> <a href="javascript:open_close('axis_category_frac');">+/-</a>
+<div id="axis_category_frac" style="display:none">
+
+     The unit cell, reciprocal cell and crystallographic orthogonal 
+     Cartesian coordinate system are defined by the CELL and the matrices 
+     in the ATOM_SITES category.
+
+     The direct lattice coordinate system is a system of fractional
+     coordinates aligned to the crystal, rather than to the laboratory.
+     This is a natural coordinate system for maps and atomic coordinates.
+     It is the simplest coordinate system in which to apply symmetry.
+     The axes are determined by the cell edges, and are not necessarily
+     orthogonal.  This coordinate system is not uniquely defined and 
+     depends on the cell parameters in the CELL category and the
+     settings chosen to index the crystal. 
+
+     Molecules in a crystal studied by X-ray diffraction are organized
+     into a repeating regular array of unit cells.  Each unit cell is defined 
+     by three vectors, <b>a</b>, <b>b</b> and <b>c</b>.  To quote from Drenth (2001),
+
+
+     "The choice of the unit cell is not unique and therefore, guidelines
+     have been established for selecting the standard basis vectors and
+     the origin.  They are based on symmetry and metric considerations:
+
+      "(1)  The axial system should be right-handed.
+       (2)  The basis vectors should coincide as much as possible with
+       directions of highest symmetry.
+       (3)  The cell taken should be the smallest one that satisfies
+       condition (2)
+       (4)  Of all the lattice vectors, none is shorter than <b>a</b>.
+       (5)  Of those not directed along <b>a</b>, none is shorter than <b>b</b>.
+       (6)  Of those not lying in the <b>ab</b> plane, none is shorter than c.
+       (7)  The three angles between the basis vectors <b>a</b>, <b>b</b> and <b>c</b> are
+       either all acute (&lt;90 degrees) or all obtuse (&ge;90 degrees)."
+
+     These rules do not produce a unique result that is stable under
+     the assumption of experimental errors, and the resulting cell
+     may not be primitive.
+
+     In this coordinate system, the vector (.5, .5, .5) is in the middle
+     of the given unit cell.
+
+     Grid coordinates are an important variation on fractional coordinates
+     used when working with maps.  In imgCIF, the conversion from
+     fractional to grid coordinates is implicit in the array indexing
+     specified by _array_structure_list.dimension.  Note that this
+     implicit grid-coordinate scheme is 1-based, not zero-based, i.e.
+     the origin of the cell for axes along the cell edges with no
+     specified _array_structure_list_axis.displacement will have
+     grid coordinates of (1,1,1), i.e. array indices of (1,1,1).
+
+</div>     <b>THE ORTHOGONAL CARTESIAN COORDINATE SYSTEM (REAL SPACE)</b> <a href="javascript:open_close('axis_category_real');">+/-</a>
+<div id="axis_category_real" style="display:none">
+
+     The orthogonal Cartesian coordinate system is a transformation of
+     the direct lattice to the actual physical coordinates of atoms in
+     space.  It is similar to the laboratory coordinate system, but
+     is anchored to and moves with the crystal, rather than being
+     anchored to the laboratory.  The transformation from fractional
+     to orthogonal Cartesian coordinates is given by the
+              _atom_sites.Cartn_transf_matrix[i][j]  and
+              _atom_sites.Cartn_transf_vector[i]
+     tags.  A common choice for the matrix of the transformation is 
+     given in Protein Data Bank (1992):
+
+              | a      b cos \g   c cos \b                            |
+              | 0      b sin \g   c (cos \a - cos \b cos \g)/sin \g   |
+              | 0      0          V/(a b sin \g)                      |
+
+     This is a convenient coordinate system in which to do fitting
+     of models to maps and in which to understand the chemistry of
+     a molecule.
+
+</div>     <b>THE RECIPROCAL LATTICE</b> <a href="javascript:open_close('axis_category_recip');">+/-</a>
+<div id="axis_category_recip" style="display:none">
+
+     The reciprocal lattice coordinate system is used for diffraction
+     intensities.  It is based on the reciprocal cell, the dual of the cell,
+     in which reciprocal cell edges are derived from direct cell faces:
+
+        a* = bc sin \a /V  b* = ac sin \b /V  c* = ab sin \g /V
+        cos \a* = (cos \b  cos \g  - cos \a )/(sin \b sin \g )
+        cos \b* = (cos \a  cos \g  - cos \b )/(sin \a sin \g )
+        cos \g* = (cos \a  cos \b  - cos \g )/(sin \a sin \b )
+        V = abc (1 - cos^2^ \a 
+                       - cos^2^ \b
+                       - cos^2^ \g
+                       + 2 cos \a cos \b cos \g )^1/2^
+
+     In this form the dimensions of the reciprocal lattice are in reciprocal
+     \%angstr\"oms (\%A^-1^).  A dimensionless form can be obtained by 
+     multiplying by the wavelength.  Reflections are commonly indexed against
+     this coordinate system as (h, k, l) triples.
+
+</div>
+
+     References:
+
+     Drenth, J. (2001). Introduction to basic crystallography.
+     International tables for crystallography, Vol. F, Crystallography of
+     biological macromolecules, edited by M. G. Rossmann & E. Arnold,
+     1st ed., ch. 2.1, pp. 44--63. Dordrecht: Kluwer Academic Publishers.    
+
+     Leslie, A. G. W. & Powell, H. (2004). MOSFLM v6.11.
+     MRC Laboratory of Molecular Biology, Hills Road, Cambridge, England.
+     http://www.CCP4.ac.uk/dist/X-windows/Mosflm/.
+
+     Stout, G. H. & Jensen, L. H. (1989). X-ray structure determination,
+     2nd ed., 453 pp. New York: Wiley.
+
+     Protein Data Bank (1992). Atomic Coordinate and Bibliographic
+     Entry Format Description. Report, February 1992. Brookhaven, NY, USA:
+     Brookhaven National Laboratory.
+;
+    _category.id                   axis
+    _category.mandatory_code       no
+<div id="print_NX_axis" style="display:block">   #_category.NX_mapping_details in online version <a href="javascript:open_close2('online_NX_axis','print_NX_axis');">+/-</a>
+</div><div id="online_NX_axis" style="display:none">    _category.NX_mapping_details                  #<a href="javascript:open_close2('online_NX_axis','print_NX_axis');">+/-</a>
+;
+    _axis.id                  AXISID
+    _axis.type                AXISTYPE
+    _axis.equipment           AXISEQUIPMENT
+    _axis.equipment_component AXISEQUIPCOMP
+    _axis.depends_on          AXISDEPENDSON
+    _axis.rotation_axis       AXISROTAXIS
+    _axis.rotation            AXISROTATION
+    _axis.vector[1]           AXISV1
+    _axis.vector[2]           AXISV2
+    _axis.vector[3]           AXISV3
+    _axis.offset[1]           AXISO1
+    _axis.offset[2]           AXISO2
+    _axis.offset[3]           AXISO3
+    _axis.system              AXISSYSTEM
+
+    -->
+
+{     /entry:NXentry
+        /instrument:NXinstrument
+         /DETECTORELEMENTNAME:NXdetector
+for AXISEQUIPMENT=="detector"}
+{     /entry:NXentry
+        /sample:NXsample
+for AXISEQUIPMENT=="goniometer"}
+{     /entry:NXentry
+for AXISEQUIPMENT=="general"}
+          /transformations:NXtransformations
+            /AXISID=[]
+              @units="mm"  if AXISTYPE=="translation" 
+              or @units="degrees"  if AXISTYPE=="rotation"
+              @transformation_type="AXISTYPE"
+              @equipment_component="AXISEQUIPCOMP"
+              @depends_on="AXISDEPENDSON"
+              @rotation_axis="AXISROTAXIS"
+              @rotation=AXISROTATION
+              @rotation_units="degrees"
+              @offset=offsetxform([O1,O2,O3])
+              @offset_inits="mm"
+              @vector=coordxform([V1,V2,V3])
+
+
+
+
+
+;
+</div>
+     loop_
+    _category_key.name          '<a href="#_axis.id" >_axis.id</a>'
+                                '<a href="#_axis.equipment">_axis.equipment</a>'
+                                '<a href="#_axis.variant">_axis.variant</a>'
+     loop_
+    _category_group.id           'inclusive_group'
+                                 'axis_group'
+                                 'diffrn_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;      Example 1.
+
+        This example shows the axis specification of the axes of a
+        kappa-geometry goniometer [see Stout, G. H. & Jensen, L. H.
+        (1989). X-ray structure determination. A practical
+        guide, 2nd ed. p. 134. New York: Wiley Interscience].
+
+        There are three axes specified, and no offsets.  The outermost axis,
+        omega, is pointed along the <b>X</b> axis.  The next innermost axis, kappa,
+        is at a 50 degree angle to the <b>X</b> axis, pointed away from the source.
+        The innermost axis, phi, aligns with the <b>X</b> axis when omega and
+        phi are at their zero points.  If T-omega, T-kappa and T-phi
+        are the transformation matrices derived from the axis settings,
+        the complete transformation would be:
+            <b>X</b>' = (T-omega) (T-kappa) (T-phi) <b>X</b>
+;
+;
+         loop_
+        <a href="#_axis.id" >_axis.id</a>
+        <a href="#_axis.type" >_axis.type</a>
+        <a href="#_axis.equipment" >_axis.equipment</a>
+        <a href="#_axis.depends_on" >_axis.depends_on</a>
+        <a href="#_axis.vector[1]" >_axis.vector[1]</a> <a href="#_axis.vector[2]" >_axis.vector[2]</a> <a href="#_axis.vector[3]" >_axis.vector[3]</a>
+        omega rotation goniometer     .    1        0        0
+        kappa rotation goniometer omega    -.64279  0       -.76604
+        phi   rotation goniometer kappa    1        0        0
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;      Example 2.
+
+        This example shows the axis specification of the axes of a
+        detector, source and gravity.  The order has been changed as a
+        reminder that the ordering of presentation of tokens is not
+        significant.  The centre of rotation of the detector has been taken
+        to be 68 mm in the direction away from the source.
+;
+;
+        loop_
+        <a href="#_axis.id" >_axis.id</a>
+        <a href="#_axis.type" >_axis.type</a>
+        <a href="#_axis.equipment" >_axis.equipment</a>
+        <a href="#_axis.depends_on" >_axis.depends_on</a>
+        <a href="#_axis.vector[1]" >_axis.vector[1]</a> <a href="#_axis.vector[2]" >_axis.vector[2]</a> <a href="#_axis.vector[3]" >_axis.vector[3]</a>
+        <a href="#_axis.offset[1]">_axis.offset[1]</a> <a href="#_axis.offset[2]">_axis.offset[2]</a> <a href="#_axis.offset[3]">_axis.offset[3]</a>
+        source       .        source     .       0     0     1   . . .
+        gravity      .        gravity    .       0    -1     0   . . .
+        tranz     translation detector rotz      0     0     1   0 0 -68
+        twotheta  rotation    detector   .       1     0     0   . . .
+        roty      rotation    detector twotheta  0     1     0   0 0 -68
+        rotz      rotation    detector roty      0     0     1   0 0 -68
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;      Example 3.
+
+        This example shows the axis specification of the axes for a map,
+        using fractional coordinates.  Each cell edge has been divided
+        into a grid of 50 divisions in the ARRAY_STRUCTURE_LIST_AXIS 
+        category.  The map is using only the first octant of the grid
+        in the ARRAY_STRUCTURE_LIST category.
+
+        The fastest changing axis is along A, then along B,
+        and the slowest is along C. 
+
+        The map sampling is being done in the middle of each grid
+        division.
+
+;
+;
+        loop_
+        <a href="#_axis.id" >_axis.id</a>
+        <a href="#_axis.system">_axis.system</a>
+        <a href="#_axis.vector[1]" >_axis.vector[1]</a> <a href="#_axis.vector[2]" >_axis.vector[2]</a> <a href="#_axis.vector[3]" >_axis.vector[3]</a>
+        CELL_A_AXIS    fractional       1 0 0
+        CELL_B_AXIS    fractional       0 1 0
+        CELL_C_AXIS    fractional       0 0 1
+
+        loop_
+        _array_structure_list.array_id
+        _array_structure_list.index
+        _array_structure_list.dimension
+        _array_structure_list.precedence
+        _array_structure_list.direction
+        _array_structure_list.axis_set_id
+        map 1 25 1 increasing CELL_A_AXIS
+        map 1 25 2 increasing CELL_B_AXIS
+        map 1 25 3 increasing CELL_C_AXIS
+
+        loop_
+        _array_structure_list_axis.axis_id
+        _array_structure_list_axis.fract_displacement
+        _array_structure_list_axis.fract_displacement_increment
+        CELL_A_AXIS 0.01 0.02
+        CELL_B_AXIS 0.01 0.02
+        CELL_C_AXIS 0.01 0.02
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;      Example 4.
+
+        This example shows the axis specification of the axes for a map,
+        this time as orthogonal \%angstr\"oms, using the same coordinate system 
+        as for the atomic coordinates.  The map is sampling every 1.5
+        \%A (1.5e-7 mm) in a map segment 37.5 \%A on a side.
+;
+;
+        loop_
+        <a href="#_axis.id" >_axis.id</a>
+        <a href="#_axis.system">_axis.system</a>
+        <a href="#_axis.vector[1]" >_axis.vector[1]</a> <a href="#_axis.vector[2]" >_axis.vector[2]</a> <a href="#_axis.vector[3]" >_axis.vector[3]</a>
+        X    orthogonal       1 0 0
+        Y    orthogonal       0 1 0
+        Z    orthogonal       0 0 1
+
+                loop_
+        _array_structure_list.array_id
+        _array_structure_list.index
+        _array_structure_list.dimension
+        _array_structure_list.precedence
+        _array_structure_list.direction
+        _array_structure_list.axis_set_id
+        map 1 25 1 increasing X
+        map 2 25 2 increasing Y
+        map 3 25 3 increasing Z
+
+        loop_
+        _array_structure_list_axis.axis_id
+        _array_structure_list_axis.displacement
+        _array_structure_list_axis.displacement_increment
+        X 7.5e-8 1.5e-7
+        Y 7.5e-8 1.5e-7
+        Z 7.5e-8 1.5e-7
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;       Example 5.
+
+    This example shows an excerpt from the axis specification of an FEL detector
+    provided by N. Sauter and A. Brewster.
+
+    The detector is divided into 4 quadrants, each quadrant contains 8 sensors
+    and each sensor contains 2 ASICs.  We want to be able to refine the
+    placement of each of these elements, so we maintain the set of vectors
+    that places them.
+;
+;
+     loop_
+    _diffrn_detector_axis.detector_id
+    _diffrn_detector_axis.axis_id
+    CSPAD_FRONT AXIS_D0_X
+    CSPAD_FRONT AXIS_D0_Y
+    CSPAD_FRONT AXIS_D0_Z
+    CSPAD_FRONT AXIS_D0_R
+    CSPAD_FRONT FS_D0Q0
+    CSPAD_FRONT FS_D0Q0S0
+    CSPAD_FRONT FS_D0Q0S0A0
+    CSPAD_FRONT FS_D0Q0S0A1
+    CSPAD_FRONT FS_D0Q0S1
+    CSPAD_FRONT FS_D0Q0S1A0
+    CSPAD_FRONT FS_D0Q0S1A1
+    CSPAD_FRONT FS_D0Q0S2
+    CSPAD_FRONT FS_D0Q0S2A0
+    CSPAD_FRONT FS_D0Q0S2A1
+    CSPAD_FRONT FS_D0Q0S3
+    CSPAD_FRONT FS_D0Q0S3A0
+    CSPAD_FRONT FS_D0Q0S3A1
+    CSPAD_FRONT FS_D0Q0S4
+    CSPAD_FRONT FS_D0Q0S4A0
+    CSPAD_FRONT FS_D0Q0S4A1
+    CSPAD_FRONT FS_D0Q0S5
+    CSPAD_FRONT FS_D0Q0S5A0
+    CSPAD_FRONT FS_D0Q0S5A1
+    CSPAD_FRONT FS_D0Q0S6
+    CSPAD_FRONT FS_D0Q0S6A0
+    CSPAD_FRONT FS_D0Q0S6A1
+    CSPAD_FRONT FS_D0Q0S7
+    CSPAD_FRONT FS_D0Q0S7A0
+    CSPAD_FRONT FS_D0Q0S7A1
+    CSPAD_FRONT FS_D0Q1
+    CSPAD_FRONT FS_D0Q1S0
+    CSPAD_FRONT FS_D0Q1S0A0
+    CSPAD_FRONT FS_D0Q1S0A1
+    CSPAD_FRONT FS_D0Q1S1
+    CSPAD_FRONT FS_D0Q1S1A0
+    CSPAD_FRONT FS_D0Q1S1A1
+    CSPAD_FRONT FS_D0Q1S2
+    CSPAD_FRONT FS_D0Q1S2A0
+    CSPAD_FRONT FS_D0Q1S2A1
+    CSPAD_FRONT FS_D0Q1S3
+    CSPAD_FRONT FS_D0Q1S3A0
+    CSPAD_FRONT FS_D0Q1S3A1
+    CSPAD_FRONT FS_D0Q1S4
+    CSPAD_FRONT FS_D0Q1S4A0
+    CSPAD_FRONT FS_D0Q1S4A1
+    CSPAD_FRONT FS_D0Q1S5
+    CSPAD_FRONT FS_D0Q1S5A0
+    CSPAD_FRONT FS_D0Q1S5A1
+    CSPAD_FRONT FS_D0Q1S6
+    CSPAD_FRONT FS_D0Q1S6A0
+    CSPAD_FRONT FS_D0Q1S6A1
+    CSPAD_FRONT FS_D0Q1S7
+    CSPAD_FRONT FS_D0Q1S7A0
+    CSPAD_FRONT FS_D0Q1S7A1
+    CSPAD_FRONT FS_D0Q2
+    CSPAD_FRONT FS_D0Q2S0
+    CSPAD_FRONT FS_D0Q2S0A0
+    CSPAD_FRONT FS_D0Q2S0A1
+    CSPAD_FRONT FS_D0Q2S1
+    CSPAD_FRONT FS_D0Q2S1A0
+    CSPAD_FRONT FS_D0Q2S1A1
+    CSPAD_FRONT FS_D0Q2S2
+    CSPAD_FRONT FS_D0Q2S2A0
+    CSPAD_FRONT FS_D0Q2S2A1
+    CSPAD_FRONT FS_D0Q2S3
+    CSPAD_FRONT FS_D0Q2S3A0
+    CSPAD_FRONT FS_D0Q2S3A1
+    CSPAD_FRONT FS_D0Q2S4
+    CSPAD_FRONT FS_D0Q2S4A0
+    CSPAD_FRONT FS_D0Q2S4A1
+    CSPAD_FRONT FS_D0Q2S5
+    CSPAD_FRONT FS_D0Q2S5A0
+    CSPAD_FRONT FS_D0Q2S5A1
+    CSPAD_FRONT FS_D0Q2S6
+    CSPAD_FRONT FS_D0Q2S6A0
+    CSPAD_FRONT FS_D0Q2S6A1
+    CSPAD_FRONT FS_D0Q2S7
+    CSPAD_FRONT FS_D0Q2S7A0
+    CSPAD_FRONT FS_D0Q2S7A1
+    CSPAD_FRONT FS_D0Q3
+    CSPAD_FRONT FS_D0Q3S0
+    CSPAD_FRONT FS_D0Q3S0A0
+    CSPAD_FRONT FS_D0Q3S0A1
+    CSPAD_FRONT FS_D0Q3S1
+    CSPAD_FRONT FS_D0Q3S1A0
+    CSPAD_FRONT FS_D0Q3S1A1
+    CSPAD_FRONT FS_D0Q3S2
+    CSPAD_FRONT FS_D0Q3S2A0
+    CSPAD_FRONT FS_D0Q3S2A1
+    CSPAD_FRONT FS_D0Q3S3
+    CSPAD_FRONT FS_D0Q3S3A0
+    CSPAD_FRONT FS_D0Q3S3A1
+    CSPAD_FRONT FS_D0Q3S4
+    CSPAD_FRONT FS_D0Q3S4A0
+    CSPAD_FRONT FS_D0Q3S4A1
+    CSPAD_FRONT FS_D0Q3S5
+    CSPAD_FRONT FS_D0Q3S5A0
+    CSPAD_FRONT FS_D0Q3S5A1
+    CSPAD_FRONT FS_D0Q3S6
+    CSPAD_FRONT FS_D0Q3S6A0
+    CSPAD_FRONT FS_D0Q3S6A1
+    CSPAD_FRONT FS_D0Q3S7
+    CSPAD_FRONT FS_D0Q3S7A0
+    CSPAD_FRONT FS_D0Q3S7A1
+
+     loop_
+    _diffrn_detector_element.id
+    _diffrn_detector_element.detector_id
+    ELE_D0Q0S0A0 CSPAD_FRONT
+    ELE_D0Q0S0A1 CSPAD_FRONT
+    ELE_D0Q0S1A0 CSPAD_FRONT
+    ELE_D0Q0S1A1 CSPAD_FRONT
+    ELE_D0Q0S2A0 CSPAD_FRONT
+    ELE_D0Q0S2A1 CSPAD_FRONT
+    ELE_D0Q0S3A0 CSPAD_FRONT
+    ELE_D0Q0S3A1 CSPAD_FRONT
+    ELE_D0Q0S4A0 CSPAD_FRONT
+    ELE_D0Q0S4A1 CSPAD_FRONT
+    ELE_D0Q0S5A0 CSPAD_FRONT
+    ELE_D0Q0S5A1 CSPAD_FRONT
+    ELE_D0Q0S6A0 CSPAD_FRONT
+    ELE_D0Q0S6A1 CSPAD_FRONT
+    ELE_D0Q0S7A0 CSPAD_FRONT
+    ELE_D0Q0S7A1 CSPAD_FRONT
+    ELE_D0Q1S0A0 CSPAD_FRONT
+    ELE_D0Q1S0A1 CSPAD_FRONT
+    ELE_D0Q1S1A0 CSPAD_FRONT
+    ELE_D0Q1S1A1 CSPAD_FRONT
+    ELE_D0Q1S2A0 CSPAD_FRONT
+    ELE_D0Q1S2A1 CSPAD_FRONT
+    ELE_D0Q1S3A0 CSPAD_FRONT
+    ELE_D0Q1S3A1 CSPAD_FRONT
+    ELE_D0Q1S4A0 CSPAD_FRONT
+    ELE_D0Q1S4A1 CSPAD_FRONT
+    ELE_D0Q1S5A0 CSPAD_FRONT
+    ELE_D0Q1S5A1 CSPAD_FRONT
+    ELE_D0Q1S6A0 CSPAD_FRONT
+    ELE_D0Q1S6A1 CSPAD_FRONT
+    ELE_D0Q1S7A0 CSPAD_FRONT
+    ELE_D0Q1S7A1 CSPAD_FRONT
+    ELE_D0Q2S0A0 CSPAD_FRONT
+    ELE_D0Q2S0A1 CSPAD_FRONT
+    ELE_D0Q2S1A0 CSPAD_FRONT
+    ELE_D0Q2S1A1 CSPAD_FRONT
+    ELE_D0Q2S2A0 CSPAD_FRONT
+    ELE_D0Q2S2A1 CSPAD_FRONT
+    ELE_D0Q2S3A0 CSPAD_FRONT
+    ELE_D0Q2S3A1 CSPAD_FRONT
+    ELE_D0Q2S4A0 CSPAD_FRONT
+    ELE_D0Q2S4A1 CSPAD_FRONT
+    ELE_D0Q2S5A0 CSPAD_FRONT
+    ELE_D0Q2S5A1 CSPAD_FRONT
+    ELE_D0Q2S6A0 CSPAD_FRONT
+    ELE_D0Q2S6A1 CSPAD_FRONT
+    ELE_D0Q2S7A0 CSPAD_FRONT
+    ELE_D0Q2S7A1 CSPAD_FRONT
+    ELE_D0Q3S0A0 CSPAD_FRONT
+    ELE_D0Q3S0A1 CSPAD_FRONT
+    ELE_D0Q3S1A0 CSPAD_FRONT
+    ELE_D0Q3S1A1 CSPAD_FRONT
+    ELE_D0Q3S2A0 CSPAD_FRONT
+    ELE_D0Q3S2A1 CSPAD_FRONT
+    ELE_D0Q3S3A0 CSPAD_FRONT
+    ELE_D0Q3S3A1 CSPAD_FRONT
+    ELE_D0Q3S4A0 CSPAD_FRONT
+    ELE_D0Q3S4A1 CSPAD_FRONT
+    ELE_D0Q3S5A0 CSPAD_FRONT
+    ELE_D0Q3S5A1 CSPAD_FRONT
+    ELE_D0Q3S6A0 CSPAD_FRONT
+    ELE_D0Q3S6A1 CSPAD_FRONT
+    ELE_D0Q3S7A0 CSPAD_FRONT
+    ELE_D0Q3S7A1 CSPAD_FRONT
+
+
+     loop_
+    _axis.id
+    _axis.type
+    _axis.equipment
+    _axis.depends_on
+    _axis.vector[1]
+    _axis.vector[2]
+    _axis.vector[3]
+    _axis.offset[1]
+    _axis.offset[2]
+    _axis.offset[3]
+    _axis.equipment_component
+    _axis.rotation
+    _axis.rotation_axis
+    AXIS_SOURCE general source . 0 0 1 . . . . . .
+    AXIS_GRAVITY general gravity . 0 -1 0 . . . . . .
+    AXIS_D0_Z translation detector . 0 0 1 . . . detector_arm . .
+    AXIS_D0_Y translation detector AXIS_D0_Z 0 1 0 . . . detector_arm . .
+    AXIS_D0_X translation detector AXIS_D0_Y 1 0 0 . . . detector_arm . .
+    AXIS_D0_R rotation detector AXIS_D0_X 0 0 1 0.0 0.0 0.0 detector_arm . .
+    FS_D0Q0 rotation detector AXIS_D0_R 0 0 1 -49.860765625 41.643353125 0.0 detector_quadrant . .
+    FS_D0Q0S0 rotation detector FS_D0Q0 0.0 0.0 1.0 11.3696 -23.189925 0.0 detector_sensor . .
+    FS_D0Q0S0A0 rotation detector FS_D0Q0S0 0 0 1 -10.835 0.0 0.0 detector_asic 89.66181 FS_D0Q0S0
+    AXIS_D0Q0S0A0_F translation detector FS_D0Q0S0A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S0A0_S translation detector AXIS_D0Q0S0A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S0A1 rotation detector FS_D0Q0S0 0 0 1 10.835 0.0 0.0 detector_asic 89.66181 FS_D0Q0S0
+    AXIS_D0Q0S0A1_F translation detector FS_D0Q0S0A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S0A1_S translation detector AXIS_D0Q0S0A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S1 rotation detector FS_D0Q0 0.0 0.0 1.0 34.815 -23.309825 0.0 detector_sensor . .
+    FS_D0Q0S1A0 rotation detector FS_D0Q0S1 0 0 1 -10.835 0.0 0.0 detector_asic 90.00132 FS_D0Q0S1
+    AXIS_D0Q0S1A0_F translation detector FS_D0Q0S1A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S1A0_S translation detector AXIS_D0Q0S1A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S1A1 rotation detector FS_D0Q0S1 0 0 1 10.835 0.0 0.0 detector_asic 90.00132 FS_D0Q0S1
+    AXIS_D0Q0S1A1_F translation detector FS_D0Q0S1A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S1A1_S translation detector AXIS_D0Q0S1A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S2 rotation detector FS_D0Q0 -0.0 -0.0 -1.0 -23.5389 -10.921625 0.0 detector_sensor . .
+    FS_D0Q0S2A0 rotation detector FS_D0Q0S2 0 0 1 -10.835 0.0 0.0 detector_asic 359.68548 FS_D0Q0S2
+    AXIS_D0Q0S2A0_F translation detector FS_D0Q0S2A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S2A0_S translation detector AXIS_D0Q0S2A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S2A1 rotation detector FS_D0Q0S2 0 0 1 10.835 0.0 0.0 detector_asic 359.68548 FS_D0Q0S2
+    AXIS_D0Q0S2A1_F translation detector FS_D0Q0S2A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S2A1_S translation detector AXIS_D0Q0S2A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S3 rotation detector FS_D0Q0 0.0 0.0 1.0 -23.5499 -34.181125 0.0 detector_sensor . .
+    FS_D0Q0S3A0 rotation detector FS_D0Q0S3 0 0 1 -10.835 0.0 0.0 detector_asic 359.96513 FS_D0Q0S3
+    AXIS_D0Q0S3A0_F translation detector FS_D0Q0S3A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S3A0_S translation detector AXIS_D0Q0S3A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S3A1 rotation detector FS_D0Q0S3 0 0 1 10.835 0.0 0.0 detector_asic 359.96513 FS_D0Q0S3
+    AXIS_D0Q0S3A1_F translation detector FS_D0Q0S3A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S3A1_S translation detector AXIS_D0Q0S3A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S4 rotation detector FS_D0Q0 0.0 0.0 1.0 -11.2651 24.282775 0.0 detector_sensor . .
+    FS_D0Q0S4A0 rotation detector FS_D0Q0S4 0 0 1 -10.835 0.0 0.0 detector_asic 270.14738 FS_D0Q0S4
+    AXIS_D0Q0S4A0_F translation detector FS_D0Q0S4A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S4A0_S translation detector AXIS_D0Q0S4A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S4A1 rotation detector FS_D0Q0S4 0 0 1 10.835 0.0 0.0 detector_asic 270.14738 FS_D0Q0S4
+    AXIS_D0Q0S4A1_F translation detector FS_D0Q0S4A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S4A1_S translation detector AXIS_D0Q0S4A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S5 rotation detector FS_D0Q0 0.0 0.0 1.0 -34.7336 24.169475 0.0 detector_sensor . .
+    FS_D0Q0S5A0 rotation detector FS_D0Q0S5 0 0 1 -10.835 0.0 0.0 detector_asic 270.07896 FS_D0Q0S5
+    AXIS_D0Q0S5A0_F translation detector FS_D0Q0S5A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S5A0_S translation detector AXIS_D0Q0S5A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S5A1 rotation detector FS_D0Q0S5 0 0 1 10.835 0.0 0.0 detector_asic 270.07896 FS_D0Q0S5
+    AXIS_D0Q0S5A1_F translation detector FS_D0Q0S5A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S5A1_S translation detector AXIS_D0Q0S5A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S6 rotation detector FS_D0Q0 0.0 0.0 1.0 23.5488 33.320375 0.0 detector_sensor . .
+    FS_D0Q0S6A0 rotation detector FS_D0Q0S6 0 0 1 -10.835 0.0 0.0 detector_asic 359.78222 FS_D0Q0S6
+    AXIS_D0Q0S6A0_F translation detector FS_D0Q0S6A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S6A0_S translation detector AXIS_D0Q0S6A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S6A1 rotation detector FS_D0Q0S6 0 0 1 10.835 0.0 0.0 detector_asic 359.78222 FS_D0Q0S6
+    AXIS_D0Q0S6A1_F translation detector FS_D0Q0S6A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S6A1_S translation detector AXIS_D0Q0S6A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S7 rotation detector FS_D0Q0 0.0 0.0 1.0 23.3541 9.829875 0.0 detector_sensor . .
+    FS_D0Q0S7A0 rotation detector FS_D0Q0S7 0 0 1 -10.835 0.0 0.0 detector_asic 359.89604 FS_D0Q0S7
+    AXIS_D0Q0S7A0_F translation detector FS_D0Q0S7A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S7A0_S translation detector AXIS_D0Q0S7A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S7A1 rotation detector FS_D0Q0S7 0 0 1 10.835 0.0 0.0 detector_asic 359.89604 FS_D0Q0S7
+    AXIS_D0Q0S7A1_F translation detector FS_D0Q0S7A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S7A1_S translation detector AXIS_D0Q0S7A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1 rotation detector AXIS_D0_R 0 0 1 41.512521875 50.149653125 0.0 detector_quadrant . .
+    FS_D0Q1S0 rotation detector FS_D0Q1 -0.0 -0.0 -1.0 -23.1589875 -11.451825 0.0 detector_sensor . .
+    FS_D0Q1S0A0 rotation detector FS_D0Q1S0 0 0 1 -10.835 0.0 0.0 detector_asic 0.27238 FS_D0Q1S0
+    AXIS_D0Q1S0A0_F translation detector FS_D0Q1S0A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S0A0_S translation detector AXIS_D0Q1S0A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S0A1 rotation detector FS_D0Q1S0 0 0 1 10.835 0.0 0.0 detector_asic 0.27238 FS_D0Q1S0
+    AXIS_D0Q1S0A1_F translation detector FS_D0Q1S0A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S0A1_S translation detector AXIS_D0Q1S0A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S1 rotation detector FS_D0Q1 -0.0 -0.0 -1.0 -23.2073875 -34.782825 0.0 detector_sensor . .
+    FS_D0Q1S1A0 rotation detector FS_D0Q1S1 0 0 1 -10.835 0.0 0.0 detector_asic 0.00525999986641 FS_D0Q1S1
+    AXIS_D0Q1S1A0_F translation detector FS_D0Q1S1A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S1A0_S translation detector AXIS_D0Q1S1A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S1A1 rotation detector FS_D0Q1S1 0 0 1 10.835 0.0 0.0 detector_asic 0.00525999986641 FS_D0Q1S1
+    AXIS_D0Q1S1A1_F translation detector FS_D0Q1S1A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S1A1_S translation detector AXIS_D0Q1S1A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S2 rotation detector FS_D0Q1 0.0 0.0 1.0 -10.7311875 23.286175 0.0 detector_sensor . .
+    FS_D0Q1S2A0 rotation detector FS_D0Q1S2 0 0 1 -10.835 0.0 0.0 detector_asic 270.02545 FS_D0Q1S2
+    AXIS_D0Q1S2A0_F translation detector FS_D0Q1S2A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S2A0_S translation detector AXIS_D0Q1S2A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S2A1 rotation detector FS_D0Q1S2 0 0 1 10.835 0.0 0.0 detector_asic 270.02545 FS_D0Q1S2
+    AXIS_D0Q1S2A1_F translation detector FS_D0Q1S2A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S2A1_S translation detector AXIS_D0Q1S2A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S3 rotation detector FS_D0Q1 0.0 0.0 1.0 -34.1402875 23.344475 0.0 detector_sensor . .
+    FS_D0Q1S3A0 rotation detector FS_D0Q1S3 0 0 1 -10.835 0.0 0.0 detector_asic 270.03066 FS_D0Q1S3
+    AXIS_D0Q1S3A0_F translation detector FS_D0Q1S3A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S3A0_S translation detector AXIS_D0Q1S3A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S3A1 rotation detector FS_D0Q1S3 0 0 1 10.835 0.0 0.0 detector_asic 270.03066 FS_D0Q1S3
+    AXIS_D0Q1S3A1_F translation detector FS_D0Q1S3A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S3A1_S translation detector AXIS_D0Q1S3A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S4 rotation detector FS_D0Q1 0.0 0.0 1.0 24.0035125 11.407275 0.0 detector_sensor . .
+    FS_D0Q1S4A0 rotation detector FS_D0Q1S4 0 0 1 -10.835 0.0 0.0 detector_asic 179.96381 FS_D0Q1S4
+    AXIS_D0Q1S4A0_F translation detector FS_D0Q1S4A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S4A0_S translation detector AXIS_D0Q1S4A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S4A1 rotation detector FS_D0Q1S4 0 0 1 10.835 0.0 0.0 detector_asic 179.96381 FS_D0Q1S4
+    AXIS_D0Q1S4A1_F translation detector FS_D0Q1S4A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S4A1_S translation detector AXIS_D0Q1S4A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S5 rotation detector FS_D0Q1 0.0 0.0 1.0 24.0035125 34.876875 0.0 detector_sensor . .
+    FS_D0Q1S5A0 rotation detector FS_D0Q1S5 0 0 1 -10.835 0.0 0.0 detector_asic 180.02434 FS_D0Q1S5
+    AXIS_D0Q1S5A0_F translation detector FS_D0Q1S5A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S5A0_S translation detector AXIS_D0Q1S5A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S5A1 rotation detector FS_D0Q1S5 0 0 1 10.835 0.0 0.0 detector_asic 180.02434 FS_D0Q1S5
+    AXIS_D0Q1S5A1_F translation detector FS_D0Q1S5A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S5A1_S translation detector AXIS_D0Q1S5A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S6 rotation detector FS_D0Q1 0.0 0.0 1.0 33.2523125 -23.321925 0.0 detector_sensor . .
+    FS_D0Q1S6A0 rotation detector FS_D0Q1S6 0 0 1 -10.835 0.0 0.0 detector_asic 270.08027 FS_D0Q1S6
+    AXIS_D0Q1S6A0_F translation detector FS_D0Q1S6A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S6A0_S translation detector AXIS_D0Q1S6A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S6A1 rotation detector FS_D0Q1S6 0 0 1 10.835 0.0 0.0 detector_asic 270.08027 FS_D0Q1S6
+    AXIS_D0Q1S6A1_F translation detector FS_D0Q1S6A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S6A1_S translation detector AXIS_D0Q1S6A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S7 rotation detector FS_D0Q1 0.0 0.0 1.0 9.9785125 -23.358225 0.0 detector_sensor . .
+    FS_D0Q1S7A0 rotation detector FS_D0Q1S7 0 0 1 -10.835 0.0 0.0 detector_asic 270.15067 FS_D0Q1S7
+    AXIS_D0Q1S7A0_F translation detector FS_D0Q1S7A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S7A0_S translation detector AXIS_D0Q1S7A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S7A1 rotation detector FS_D0Q1S7 0 0 1 10.835 0.0 0.0 detector_asic 270.15067 FS_D0Q1S7
+    AXIS_D0Q1S7A1_F translation detector FS_D0Q1S7A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S7A1_S translation detector AXIS_D0Q1S7A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2 rotation detector AXIS_D0_R 0 0 1 49.596146875 -41.351371875 0.0 detector_quadrant . .
+    FS_D0Q2S0 rotation detector FS_D0Q2 -0.0 -0.0 -1.0 -11.3150125 23.1242 0.0 detector_sensor . .
+    FS_D0Q2S0A0 rotation detector FS_D0Q2S0 0 0 1 -10.835 0.0 0.0 detector_asic 90.04803 FS_D0Q2S0
+    AXIS_D0Q2S0A0_F translation detector FS_D0Q2S0A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S0A0_S translation detector AXIS_D0Q2S0A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S0A1 rotation detector FS_D0Q2S0 0 0 1 10.835 0.0 0.0 detector_asic 90.04803 FS_D0Q2S0
+    AXIS_D0Q2S0A1_F translation detector FS_D0Q2S0A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S0A1_S translation detector AXIS_D0Q2S0A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S1 rotation detector FS_D0Q2 -0.0 -0.0 -1.0 -34.6999125 23.155 0.0 detector_sensor . .
+    FS_D0Q2S1A0 rotation detector FS_D0Q2S1 0 0 1 -10.835 0.0 0.0 detector_asic 90.00592 FS_D0Q2S1
+    AXIS_D0Q2S1A0_F translation detector FS_D0Q2S1A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S1A0_S translation detector AXIS_D0Q2S1A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S1A1 rotation detector FS_D0Q2S1 0 0 1 10.835 0.0 0.0 detector_asic 90.00592 FS_D0Q2S1
+    AXIS_D0Q2S1A1_F translation detector FS_D0Q2S1A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S1A1_S translation detector AXIS_D0Q2S1A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S2 rotation detector FS_D0Q2 0.0 0.0 1.0 23.4746875 10.7811 0.0 detector_sensor . .
+    FS_D0Q2S2A0 rotation detector FS_D0Q2S2 0 0 1 -10.835 0.0 0.0 detector_asic 180.11318 FS_D0Q2S2
+    AXIS_D0Q2S2A0_F translation detector FS_D0Q2S2A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S2A0_S translation detector AXIS_D0Q2S2A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S2A1 rotation detector FS_D0Q2S2 0 0 1 10.835 0.0 0.0 detector_asic 180.11318 FS_D0Q2S2
+    AXIS_D0Q2S2A1_F translation detector FS_D0Q2S2A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S2A1_S translation detector AXIS_D0Q2S2A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S3 rotation detector FS_D0Q2 0.0 0.0 1.0 23.6220875 34.2221 0.0 detector_sensor . .
+    FS_D0Q2S3A0 rotation detector FS_D0Q2S3 0 0 1 -10.835 0.0 0.0 detector_asic 179.92104 FS_D0Q2S3
+    AXIS_D0Q2S3A0_F translation detector FS_D0Q2S3A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S3A0_S translation detector AXIS_D0Q2S3A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S3A1 rotation detector FS_D0Q2S3 0 0 1 10.835 0.0 0.0 detector_asic 179.92104 FS_D0Q2S3
+    AXIS_D0Q2S3A1_F translation detector FS_D0Q2S3A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S3A1_S translation detector AXIS_D0Q2S3A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S4 rotation detector FS_D0Q2 0.0 0.0 1.0 11.1953875 -23.9954 0.0 detector_sensor . .
+    FS_D0Q2S4A0 rotation detector FS_D0Q2S4 0 0 1 -10.835 0.0 0.0 detector_asic 89.63875 FS_D0Q2S4
+    AXIS_D0Q2S4A0_F translation detector FS_D0Q2S4A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S4A0_S translation detector AXIS_D0Q2S4A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S4A1 rotation detector FS_D0Q2S4 0 0 1 10.835 0.0 0.0 detector_asic 89.63875 FS_D0Q2S4
+    AXIS_D0Q2S4A1_F translation detector FS_D0Q2S4A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S4A1_S translation detector AXIS_D0Q2S4A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S5 rotation detector FS_D0Q2 0.0 0.0 1.0 34.5494875 -24.1901 0.0 detector_sensor . .
+    FS_D0Q2S5A0 rotation detector FS_D0Q2S5 0 0 1 -10.835 0.0 0.0 detector_asic 89.68154 FS_D0Q2S5
+    AXIS_D0Q2S5A0_F translation detector FS_D0Q2S5A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S5A0_S translation detector AXIS_D0Q2S5A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S5A1 rotation detector FS_D0Q2S5 0 0 1 10.835 0.0 0.0 detector_asic 89.68154 FS_D0Q2S5
+    AXIS_D0Q2S5A1_F translation detector FS_D0Q2S5A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S5A1_S translation detector AXIS_D0Q2S5A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S6 rotation detector FS_D0Q2 0.0 0.0 1.0 -23.4854125 -33.2552 0.0 detector_sensor . .
+    FS_D0Q2S6A0 rotation detector FS_D0Q2S6 0 0 1 -10.835 0.0 0.0 detector_asic 179.83473 FS_D0Q2S6
+    AXIS_D0Q2S6A0_F translation detector FS_D0Q2S6A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S6A0_S translation detector AXIS_D0Q2S6A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S6A1 rotation detector FS_D0Q2S6 0 0 1 10.835 0.0 0.0 detector_asic 179.83473 FS_D0Q2S6
+    AXIS_D0Q2S6A1_F translation detector FS_D0Q2S6A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S6A1_S translation detector AXIS_D0Q2S6A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S7 rotation detector FS_D0Q2 0.0 0.0 1.0 -23.3413125 -9.8417 0.0 detector_sensor . .
+    FS_D0Q2S7A0 rotation detector FS_D0Q2S7 0 0 1 -10.835 0.0 0.0 detector_asic 180.092 FS_D0Q2S7
+    AXIS_D0Q2S7A0_F translation detector FS_D0Q2S7A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S7A0_S translation detector AXIS_D0Q2S7A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S7A1 rotation detector FS_D0Q2S7 0 0 1 10.835 0.0 0.0 detector_asic 180.092 FS_D0Q2S7
+    AXIS_D0Q2S7A1_F translation detector FS_D0Q2S7A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S7A1_S translation detector AXIS_D0Q2S7A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3 rotation detector AXIS_D0_R 0 0 1 -41.247903125 -50.441634375 0.0 detector_quadrant . .
+    FS_D0Q3S0 rotation detector FS_D0Q3 0.0 0.0 1.0 23.1056375 11.6367625 0.0 detector_sensor . .
+    FS_D0Q3S0A0 rotation detector FS_D0Q3S0 0 0 1 -10.835 0.0 0.0 detector_asic 180.12436 FS_D0Q3S0
+    AXIS_D0Q3S0A0_F translation detector FS_D0Q3S0A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S0A0_S translation detector AXIS_D0Q3S0A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S0A1 rotation detector FS_D0Q3S0 0 0 1 10.835 0.0 0.0 detector_asic 180.12436 FS_D0Q3S0
+    AXIS_D0Q3S0A1_F translation detector FS_D0Q3S0A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S0A1_S translation detector AXIS_D0Q3S0A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S1 rotation detector FS_D0Q3 0.0 0.0 1.0 23.1298375 34.9864625 0.0 detector_sensor . .
+    FS_D0Q3S1A0 rotation detector FS_D0Q3S1 0 0 1 -10.835 0.0 0.0 detector_asic 180.00263 FS_D0Q3S1
+    AXIS_D0Q3S1A0_F translation detector FS_D0Q3S1A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S1A0_S translation detector AXIS_D0Q3S1A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S1A1 rotation detector FS_D0Q3S1 0 0 1 10.835 0.0 0.0 detector_asic 180.00263 FS_D0Q3S1
+    AXIS_D0Q3S1A1_F translation detector FS_D0Q3S1A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S1A1_S translation detector AXIS_D0Q3S1A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S2 rotation detector FS_D0Q3 -0.0 -0.0 -1.0 10.9572375 -23.5830375 0.0 detector_sensor . .
+    FS_D0Q3S2A0 rotation detector FS_D0Q3S2 0 0 1 -10.835 0.0 0.0 detector_asic 269.55191 FS_D0Q3S2
+    AXIS_D0Q3S2A0_F translation detector FS_D0Q3S2A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S2A0_S translation detector AXIS_D0Q3S2A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S2A1 rotation detector FS_D0Q3S2 0 0 1 10.835 0.0 0.0 detector_asic 269.55191 FS_D0Q3S2
+    AXIS_D0Q3S2A1_F translation detector FS_D0Q3S2A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S2A1_S translation detector AXIS_D0Q3S2A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S3 rotation detector FS_D0Q3 -0.0 -0.0 -1.0 34.4180375 -23.4818375 0.0 detector_sensor . .
+    FS_D0Q3S3A0 rotation detector FS_D0Q3S3 0 0 1 -10.835 0.0 0.0 detector_asic 269.74206 FS_D0Q3S3
+    AXIS_D0Q3S3A0_F translation detector FS_D0Q3S3A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S3A0_S translation detector AXIS_D0Q3S3A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S3A1 rotation detector FS_D0Q3S3 0 0 1 10.835 0.0 0.0 detector_asic 269.74206 FS_D0Q3S3
+    AXIS_D0Q3S3A1_F translation detector FS_D0Q3S3A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S3A1_S translation detector AXIS_D0Q3S3A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S4 rotation detector FS_D0Q3 0.0 0.0 1.0 -24.1283625 -11.5336375 0.0 detector_sensor . .
+    FS_D0Q3S4A0 rotation detector FS_D0Q3S4 0 0 1 -10.835 0.0 0.0 detector_asic 359.81971 FS_D0Q3S4
+    AXIS_D0Q3S4A0_F translation detector FS_D0Q3S4A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S4A0_S translation detector AXIS_D0Q3S4A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S4A1 rotation detector FS_D0Q3S4 0 0 1 10.835 0.0 0.0 detector_asic 359.81971 FS_D0Q3S4
+    AXIS_D0Q3S4A1_F translation detector FS_D0Q3S4A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S4A1_S translation detector AXIS_D0Q3S4A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S5 rotation detector FS_D0Q3 0.0 0.0 1.0 -24.1701625 -34.9548375 0.0 detector_sensor . .
+    FS_D0Q3S5A0 rotation detector FS_D0Q3S5 0 0 1 -10.835 0.0 0.0 detector_asic 359.99883 FS_D0Q3S5
+    AXIS_D0Q3S5A0_F translation detector FS_D0Q3S5A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S5A0_S translation detector AXIS_D0Q3S5A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S5A1 rotation detector FS_D0Q3S5 0 0 1 10.835 0.0 0.0 detector_asic 359.99883 FS_D0Q3S5
+    AXIS_D0Q3S5A1_F translation detector FS_D0Q3S5A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S5A1_S translation detector AXIS_D0Q3S5A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S6 rotation detector FS_D0Q3 -0.0 -0.0 -1.0 -33.3089625 23.4474625 0.0 detector_sensor . .
+    FS_D0Q3S6A0 rotation detector FS_D0Q3S6 0 0 1 -10.835 0.0 0.0 detector_asic 269.67299 FS_D0Q3S6
+    AXIS_D0Q3S6A0_F translation detector FS_D0Q3S6A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S6A0_S translation detector AXIS_D0Q3S6A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S6A1 rotation detector FS_D0Q3S6 0 0 1 10.835 0.0 0.0 detector_asic 269.67299 FS_D0Q3S6
+    AXIS_D0Q3S6A1_F translation detector FS_D0Q3S6A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S6A1_S translation detector AXIS_D0Q3S6A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S7 rotation detector FS_D0Q3 -0.0 -0.0 -1.0 -10.0032625 23.4826625 0.0 detector_sensor . .
+    FS_D0Q3S7A0 rotation detector FS_D0Q3S7 0 0 1 -10.835 0.0 0.0 detector_asic 269.67561 FS_D0Q3S7
+    AXIS_D0Q3S7A0_F translation detector FS_D0Q3S7A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S7A0_S translation detector AXIS_D0Q3S7A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S7A1 rotation detector FS_D0Q3S7 0 0 1 10.835 0.0 0.0 detector_asic 269.67561 FS_D0Q3S7
+    AXIS_D0Q3S7A1_F translation detector FS_D0Q3S7A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S7A1_S translation detector AXIS_D0Q3S7A1_F 0 -1 0 0 0 0.0 detector_asic . .
+
+
+;    
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;       Example 6.
+
+    This example shows an excerpt from the axis specification of an FEL detector
+    provided by N. Sauter and A. Brewster, using _axis.rotation_axis and
+    _axis.rotation to organize the positional dependencies.  The approach
+    in Example 5 is now preferred.
+
+    The detector is divided into 4 quadrants, each quadrant contains 8 sensors
+    and each sensor contains 2 ASICs.  We want to be able to refine the
+    placement of each of these elements, so we maintain the set of vectors
+    that places them.
+
+    To do this, the first vector of importance is an initial placement axis
+    that moves from the origin along the Z axis a distance equal to the
+    detector distance.  This is the origin for the rest of the axes and is
+    called AXIS_D0_ORIGIN.
+
+    Each subsequent movement involves a frame shift.  This is done by using
+    two imgCIF axes: a rotation axis and a translation axis.  The rotation
+    axis is listed first, and includes no offset or angle.  The actual frame
+    shift is done by using a translation axis.  An offset is used first in
+    the parent's frame, and then an angle is listed to rotate around the
+    rotation axis.
+
+    Example, sensor five of quadrant 2.  First a rotation axis is listed:
+
+    AXIS_D0Q2S5_ROT rotation detector AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    This defines a rotation axis around the z axis in the frame of quadrant 2.
+
+    Next a translation axis is listed:
+    AXIS_D0Q2S5 translation detector
+        AXIS_D0Q2 . . . 34.5494875 -24.1901 0.0 89.68154 AXIS_D0Q2S5_ROT
+    Here, in the frame of quadrant 2, we shift X by 34 and Y by -24 mm,
+    then rotate 89 degrees around the axis named AXIS_D0Q2S5_ROT.
+
+    And so forth.
+;
+;
+
+     loop_
+    _diffrn_detector_axis.detector_id
+    _diffrn_detector_axis.axis_id
+    CSPAD_FRONT AXIS_DETECTOR_X
+    CSPAD_FRONT AXIS_DETECTOR_Y
+    CSPAD_FRONT AXIS_DETECTOR_Z
+    CSPAD_FRONT AXIS_DETECTOR_PITCH
+
+     loop_
+    _diffrn_detector_element.id
+    _diffrn_detector_element.detector_id
+    ELE_D0Q0S0A0 CSPAD_FRONT
+    ELE_D0Q0S0A1 CSPAD_FRONT
+    ELE_D0Q0S1A0 CSPAD_FRONT
+    ELE_D0Q0S1A1 CSPAD_FRONT
+    ELE_D0Q0S2A0 CSPAD_FRONT
+    ELE_D0Q0S2A1 CSPAD_FRONT
+    ELE_D0Q0S3A0 CSPAD_FRONT
+    ELE_D0Q0S3A1 CSPAD_FRONT
+    ELE_D0Q0S4A0 CSPAD_FRONT
+    ELE_D0Q0S4A1 CSPAD_FRONT
+    ELE_D0Q0S5A0 CSPAD_FRONT
+    ELE_D0Q0S5A1 CSPAD_FRONT
+    ELE_D0Q0S6A0 CSPAD_FRONT
+    ELE_D0Q0S6A1 CSPAD_FRONT
+    ELE_D0Q0S7A0 CSPAD_FRONT
+    ELE_D0Q0S7A1 CSPAD_FRONT
+    ELE_D0Q1S0A0 CSPAD_FRONT
+    ELE_D0Q1S0A1 CSPAD_FRONT
+    ELE_D0Q1S1A0 CSPAD_FRONT
+    ELE_D0Q1S1A1 CSPAD_FRONT
+    ELE_D0Q1S2A0 CSPAD_FRONT
+    ELE_D0Q1S2A1 CSPAD_FRONT
+    ELE_D0Q1S3A0 CSPAD_FRONT
+    ELE_D0Q1S3A1 CSPAD_FRONT
+    ELE_D0Q1S4A0 CSPAD_FRONT
+    ELE_D0Q1S4A1 CSPAD_FRONT
+    ELE_D0Q1S5A0 CSPAD_FRONT
+    ELE_D0Q1S5A1 CSPAD_FRONT
+    ELE_D0Q1S6A0 CSPAD_FRONT
+    ELE_D0Q1S6A1 CSPAD_FRONT
+    ELE_D0Q1S7A0 CSPAD_FRONT
+    ELE_D0Q1S7A1 CSPAD_FRONT
+    ELE_D0Q2S0A0 CSPAD_FRONT
+    ELE_D0Q2S0A1 CSPAD_FRONT
+    ELE_D0Q2S1A0 CSPAD_FRONT
+    ELE_D0Q2S1A1 CSPAD_FRONT
+    ELE_D0Q2S2A0 CSPAD_FRONT
+    ELE_D0Q2S2A1 CSPAD_FRONT
+    ELE_D0Q2S3A0 CSPAD_FRONT
+    ELE_D0Q2S3A1 CSPAD_FRONT
+    ELE_D0Q2S4A0 CSPAD_FRONT
+    ELE_D0Q2S4A1 CSPAD_FRONT
+    ELE_D0Q2S5A0 CSPAD_FRONT
+    ELE_D0Q2S5A1 CSPAD_FRONT
+    ELE_D0Q2S6A0 CSPAD_FRONT
+    ELE_D0Q2S6A1 CSPAD_FRONT
+    ELE_D0Q2S7A0 CSPAD_FRONT
+    ELE_D0Q2S7A1 CSPAD_FRONT
+    ELE_D0Q3S0A0 CSPAD_FRONT
+    ELE_D0Q3S0A1 CSPAD_FRONT
+    ELE_D0Q3S1A0 CSPAD_FRONT
+    ELE_D0Q3S1A1 CSPAD_FRONT
+    ELE_D0Q3S2A0 CSPAD_FRONT
+    ELE_D0Q3S2A1 CSPAD_FRONT
+    ELE_D0Q3S3A0 CSPAD_FRONT
+    ELE_D0Q3S3A1 CSPAD_FRONT
+    ELE_D0Q3S4A0 CSPAD_FRONT
+    ELE_D0Q3S4A1 CSPAD_FRONT
+    ELE_D0Q3S5A0 CSPAD_FRONT
+    ELE_D0Q3S5A1 CSPAD_FRONT
+    ELE_D0Q3S6A0 CSPAD_FRONT
+    ELE_D0Q3S6A1 CSPAD_FRONT
+    ELE_D0Q3S7A0 CSPAD_FRONT
+    ELE_D0Q3S7A1 CSPAD_FRONT
+
+
+     loop_
+    _axis.id
+    _axis.type
+    _axis.equipment
+    _axis.depends_on
+    _axis.vector[1]
+    _axis.vector[2]
+    _axis.vector[3]
+    _axis.offset[1]
+    _axis.offset[2]
+    _axis.offset[3]
+    _axis.rotation
+    _axis.rotation_axis
+    AXIS_SOURCE general source   . 0 0 1 . . . . .
+    AXIS_GRAVITY general gravity . 0 -1 0 . . . . .
+    AXIS_DETECTOR_Z translation detector
+                                 . 0 0 1 0 0 0 . .
+    AXIS_DETECTOR_Y translation detector
+                   AXIS_DETECTOR_Z 0 1 0 0 0 0 . .
+    AXIS_DETECTOR_X translation detector
+                   AXIS_DETECTOR_Y 1 0 0 0 0 0 . .
+    AXIS_DETECTOR_PITCH rotation detector
+                   AXIS_DETECTOR_X 0 1 0 0 0 0 . .
+    AXIS_DETECTOR_ROT rotation detector
+               AXIS_DETECTOR_PITCH 0 0 1 0 0 0 . .
+    AXIS_D0_ORIGIN translation detector
+               AXIS_DETECTOR_PITCH 0 0 1 0 0 171.0104 . .
+    AXIS_D0_ROT rotation detector
+                    AXIS_D0_ORIGIN 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0 translation detector
+                    AXIS_D0_ORIGIN . . . 0.0 0.0 0.0 0.0 AXIS_D0_ROT
+    AXIS_D0Q0_ROT rotation detector
+                           AXIS_D0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0 translation detector
+                           AXIS_D0 . . . -49.860765625 41.643353125 0.0
+                                      0.0 AXIS_D0Q0_ROT
+    AXIS_D0Q0S0_ROT rotation detector
+                          AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S0 translation detector
+                          AXIS_D0Q0 . . . 11.3696 -23.189925 0.0
+                                      89.66181 AXIS_D0Q0S0_ROT
+    AXIS_D0Q0S0A0_ROT rotation detector
+                        AXIS_D0Q0S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S0A0 translation detector
+                        AXIS_D0Q0S0 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S0A0_ROT
+    AXIS_D0Q0S0A0_F translation detector
+                      AXIS_D0Q0S0A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S0A0_S translation detector
+                      AXIS_D0Q0S0A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S0A1_ROT rotation detector
+                        AXIS_D0Q0S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S0A1 translation detector
+                        AXIS_D0Q0S0 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S0A1_ROT
+    AXIS_D0Q0S0A1_F translation detector
+                      AXIS_D0Q0S0A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S0A1_S translation detector
+                      AXIS_D0Q0S0A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S1_ROT rotation detector
+                          AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S1 translation detector
+                          AXIS_D0Q0 . . . 34.815 -23.309825 0.0
+                                      90.00132 AXIS_D0Q0S1_ROT
+    AXIS_D0Q0S1A0_ROT rotation detector
+                        AXIS_D0Q0S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S1A0 translation detector
+                        AXIS_D0Q0S1 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S1A0_ROT
+    AXIS_D0Q0S1A0_F translation detector
+                      AXIS_D0Q0S1A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S1A0_S translation detector
+                      AXIS_D0Q0S1A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S1A1_ROT rotation detector
+                        AXIS_D0Q0S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S1A1 translation detector
+                        AXIS_D0Q0S1 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S1A1_ROT
+    AXIS_D0Q0S1A1_F translation detector
+                      AXIS_D0Q0S1A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S1A1_S translation detector
+                      AXIS_D0Q0S1A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S2_ROT rotation detector
+                          AXIS_D0Q0 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q0S2 translation detector
+                          AXIS_D0Q0 . . . -23.5389 -10.921625 0.0
+                                     359.68548 AXIS_D0Q0S2_ROT
+    AXIS_D0Q0S2A0_ROT rotation detector
+                        AXIS_D0Q0S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S2A0 translation detector
+                        AXIS_D0Q0S2 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S2A0_ROT
+    AXIS_D0Q0S2A0_F translation detector
+                        AXIS_D0Q0S2A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S2A0_S translation detector
+                        AXIS_D0Q0S2A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S2A1_ROT rotation detector
+                        AXIS_D0Q0S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S2A1 translation detector
+                        AXIS_D0Q0S2 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S2A1_ROT
+    AXIS_D0Q0S2A1_F translation detector
+                        AXIS_D0Q0S2A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S2A1_S translation detector
+                        AXIS_D0Q0S2A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S3_ROT rotation detector
+                        AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S3 translation detector
+                        AXIS_D0Q0 . . . -23.5499 -34.181125 0.0
+                                   359.96513 AXIS_D0Q0S3_ROT
+    AXIS_D0Q0S3A0_ROT rotation detector
+                        AXIS_D0Q0S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S3A0 translation detector
+                        AXIS_D0Q0S3 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S3A0_ROT
+    AXIS_D0Q0S3A0_F translation detector
+                        AXIS_D0Q0S3A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S3A0_S translation detector
+                        AXIS_D0Q0S3A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S3A1_ROT rotation detector
+                        AXIS_D0Q0S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S3A1 translation detector
+                        AXIS_D0Q0S3 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S3A1_ROT
+    AXIS_D0Q0S3A1_F translation detector
+                        AXIS_D0Q0S3A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S3A1_S translation detector
+                        AXIS_D0Q0S3A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S4_ROT rotation detector
+                        AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S4 translation detector
+                        AXIS_D0Q0 . . . -11.2651 24.282775 0.0
+                                   270.14738 AXIS_D0Q0S4_ROT
+    AXIS_D0Q0S4A0_ROT rotation detector
+                        AXIS_D0Q0S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S4A0 translation detector
+                        AXIS_D0Q0S4 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S4A0_ROT
+    AXIS_D0Q0S4A0_F translation detector
+                        AXIS_D0Q0S4A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S4A0_S translation detector
+                        AXIS_D0Q0S4A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S4A1_ROT rotation detector
+                        AXIS_D0Q0S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S4A1 translation detector
+                        AXIS_D0Q0S4 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S4A1_ROT
+    AXIS_D0Q0S4A1_F translation detector
+                        AXIS_D0Q0S4A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S4A1_S translation detector
+                        AXIS_D0Q0S4A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S5_ROT rotation detector
+                        AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S5 translation detector
+                        AXIS_D0Q0 . . . -34.7336 24.169475 0.0
+                                   270.07896 AXIS_D0Q0S5_ROT
+    AXIS_D0Q0S5A0_ROT rotation detector
+                        AXIS_D0Q0S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S5A0 translation detector
+                        AXIS_D0Q0S5 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S5A0_ROT
+    AXIS_D0Q0S5A0_F translation detector
+                        AXIS_D0Q0S5A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S5A0_S translation detector
+                        AXIS_D0Q0S5A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S5A1_ROT rotation detector
+                        AXIS_D0Q0S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S5A1 translation detector
+                        AXIS_D0Q0S5 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S5A1_ROT
+    AXIS_D0Q0S5A1_F translation detector
+                        AXIS_D0Q0S5A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S5A1_S translation detector
+                        AXIS_D0Q0S5A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S6_ROT rotation detector
+                        AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S6 translation detector
+                        AXIS_D0Q0 . . . 23.5488 33.320375 0.0
+                                   359.78222 AXIS_D0Q0S6_ROT
+    AXIS_D0Q0S6A0_ROT rotation detector
+                        AXIS_D0Q0S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S6A0 translation detector
+                        AXIS_D0Q0S6 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S6A0_ROT
+    AXIS_D0Q0S6A0_F translation detector
+                        AXIS_D0Q0S6A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S6A0_S translation detector
+                        AXIS_D0Q0S6A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S6A1_ROT rotation detector
+                        AXIS_D0Q0S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S6A1 translation detector
+                        AXIS_D0Q0S6 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S6A1_ROT
+    AXIS_D0Q0S6A1_F translation detector
+                        AXIS_D0Q0S6A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S6A1_S translation detector
+                        AXIS_D0Q0S6A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S7_ROT rotation detector
+                        AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S7 translation detector
+                        AXIS_D0Q0 . . . 23.3541 9.829875 0.0
+                                   359.89604 AXIS_D0Q0S7_ROT
+    AXIS_D0Q0S7A0_ROT rotation detector
+                        AXIS_D0Q0S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S7A0 translation detector
+                        AXIS_D0Q0S7 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S7A0_ROT
+    AXIS_D0Q0S7A0_F translation detector
+                        AXIS_D0Q0S7A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S7A0_S translation detector
+                        AXIS_D0Q0S7A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S7A1_ROT rotation detector
+                        AXIS_D0Q0S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S7A1 translation detector
+                        AXIS_D0Q0S7 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S7A1_ROT
+    AXIS_D0Q0S7A1_F translation detector
+                        AXIS_D0Q0S7A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S7A1_S translation detector
+                        AXIS_D0Q0S7A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1_ROT rotation detector
+                        AXIS_D0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1 translation detector
+                        AXIS_D0 . . . 41.512521875 50.149653125 0.0
+                                   0.0 AXIS_D0Q1_ROT
+    AXIS_D0Q1S0_ROT rotation detector
+                        AXIS_D0Q1 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q1S0 translation detector
+                        AXIS_D0Q1 . . . -23.1589875 -11.451825 0.0
+                                     0.27238 AXIS_D0Q1S0_ROT
+    AXIS_D0Q1S0A0_ROT rotation detector
+                        AXIS_D0Q1S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S0A0 translation detector
+                        AXIS_D0Q1S0 . . . -10.835 0.0 0.0
+                                       0.0 AXIS_D0Q1S0A0_ROT
+    AXIS_D0Q1S0A0_F translation detector
+                        AXIS_D0Q1S0A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S0A0_S translation detector
+                        AXIS_D0Q1S0A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S0A1_ROT rotation detector
+                        AXIS_D0Q1S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S0A1 translation detector
+                        AXIS_D0Q1S0 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S0A1_ROT
+    AXIS_D0Q1S0A1_F translation detector
+                        AXIS_D0Q1S0A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S0A1_S translation detector
+                        AXIS_D0Q1S0A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S1_ROT rotation detector
+                        AXIS_D0Q1 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q1S1 translation detector
+                        AXIS_D0Q1 . . . -23.2073875 -34.782825 0.0
+                                     0.00525999986641 AXIS_D0Q1S1_ROT
+    AXIS_D0Q1S1A0_ROT rotation detector
+                        AXIS_D0Q1S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S1A0 translation detector
+                        AXIS_D0Q1S1 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S1A0_ROT
+    AXIS_D0Q1S1A0_F translation detector
+                        AXIS_D0Q1S1A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S1A0_S translation detector
+                        AXIS_D0Q1S1A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S1A1_ROT rotation detector
+                        AXIS_D0Q1S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S1A1 translation detector
+                        AXIS_D0Q1S1 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S1A1_ROT
+    AXIS_D0Q1S1A1_F translation detector
+                        AXIS_D0Q1S1A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S1A1_S translation detector
+                        AXIS_D0Q1S1A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S2_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S2 translation detector
+                        AXIS_D0Q1 . . . -10.7311875 23.286175 0.0
+                                   270.02545 AXIS_D0Q1S2_ROT
+    AXIS_D0Q1S2A0_ROT rotation detector
+                        AXIS_D0Q1S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S2A0 translation detector
+                        AXIS_D0Q1S2 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S2A0_ROT
+    AXIS_D0Q1S2A0_F translation detector
+                        AXIS_D0Q1S2A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S2A0_S translation detector
+                        AXIS_D0Q1S2A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S2A1_ROT rotation detector
+                        AXIS_D0Q1S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S2A1 translation detector
+                        AXIS_D0Q1S2 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S2A1_ROT
+    AXIS_D0Q1S2A1_F translation detector
+                        AXIS_D0Q1S2A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S2A1_S translation detector
+                        AXIS_D0Q1S2A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S3_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S3 translation detector
+                        AXIS_D0Q1 . . . -34.1402875 23.344475 0.0
+                                   270.03066 AXIS_D0Q1S3_ROT
+    AXIS_D0Q1S3A0_ROT rotation detector
+                        AXIS_D0Q1S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S3A0 translation detector
+                        AXIS_D0Q1S3 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S3A0_ROT
+    AXIS_D0Q1S3A0_F translation detector
+                        AXIS_D0Q1S3A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S3A0_S translation detector
+                        AXIS_D0Q1S3A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S3A1_ROT rotation detector
+                        AXIS_D0Q1S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S3A1 translation detector
+                        AXIS_D0Q1S3 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S3A1_ROT
+    AXIS_D0Q1S3A1_F translation detector
+                        AXIS_D0Q1S3A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S3A1_S translation detector
+                        AXIS_D0Q1S3A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S4_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S4 translation detector
+                        AXIS_D0Q1 . . . 24.0035125 11.407275 0.0
+                                    179.96381 AXIS_D0Q1S4_ROT
+    AXIS_D0Q1S4A0_ROT rotation detector
+                        AXIS_D0Q1S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S4A0 translation detector
+                        AXIS_D0Q1S4 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S4A0_ROT
+    AXIS_D0Q1S4A0_F translation detector
+                        AXIS_D0Q1S4A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S4A0_S translation detector
+                        AXIS_D0Q1S4A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S4A1_ROT rotation detector
+                        AXIS_D0Q1S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S4A1 translation detector
+                        AXIS_D0Q1S4 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S4A1_ROT
+    AXIS_D0Q1S4A1_F translation detector
+                        AXIS_D0Q1S4A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S4A1_S translation detector
+                        AXIS_D0Q1S4A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S5_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S5 translation detector
+                        AXIS_D0Q1 . . . 24.0035125 34.876875 0.0
+                                   180.02434 AXIS_D0Q1S5_ROT
+    AXIS_D0Q1S5A0_ROT rotation detector
+                        AXIS_D0Q1S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S5A0 translation detector
+                        AXIS_D0Q1S5 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S5A0_ROT
+    AXIS_D0Q1S5A0_F translation detector
+                        AXIS_D0Q1S5A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S5A0_S translation detector
+                        AXIS_D0Q1S5A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S5A1_ROT rotation detector
+                        AXIS_D0Q1S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S5A1 translation detector
+                        AXIS_D0Q1S5 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S5A1_ROT
+    AXIS_D0Q1S5A1_F translation detector
+                        AXIS_D0Q1S5A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S5A1_S translation detector
+                        AXIS_D0Q1S5A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S6_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S6 translation detector
+                        AXIS_D0Q1 . . . 33.2523125 -23.321925 0.0
+                                   270.08027 AXIS_D0Q1S6_ROT
+    AXIS_D0Q1S6A0_ROT rotation detector
+                        AXIS_D0Q1S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S6A0 translation detector
+                        AXIS_D0Q1S6 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S6A0_ROT
+    AXIS_D0Q1S6A0_F translation detector
+                        AXIS_D0Q1S6A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S6A0_S translation detector
+                        AXIS_D0Q1S6A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S6A1_ROT rotation detector
+                        AXIS_D0Q1S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S6A1 translation detector
+                        AXIS_D0Q1S6 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S6A1_ROT
+    AXIS_D0Q1S6A1_F translation detector
+                        AXIS_D0Q1S6A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S6A1_S translation detector
+                        AXIS_D0Q1S6A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S7_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S7 translation detector
+                        AXIS_D0Q1 . . . 9.9785125 -23.358225 0.0
+                                   270.15067 AXIS_D0Q1S7_ROT
+    AXIS_D0Q1S7A0_ROT rotation detector
+                        AXIS_D0Q1S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S7A0 translation detector
+                        AXIS_D0Q1S7 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S7A0_ROT
+    AXIS_D0Q1S7A0_F translation detector
+                        AXIS_D0Q1S7A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S7A0_S translation detector
+                        AXIS_D0Q1S7A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S7A1_ROT rotation detector
+                        AXIS_D0Q1S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S7A1 translation detector
+                        AXIS_D0Q1S7 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S7A1_ROT
+    AXIS_D0Q1S7A1_F translation detector
+                        AXIS_D0Q1S7A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S7A1_S translation detector
+                        AXIS_D0Q1S7A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2_ROT rotation detector
+                        AXIS_D0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2 translation detector
+                        AXIS_D0 . . . 49.596146875 -41.351371875 0.0
+                                   0.0 AXIS_D0Q2_ROT
+    AXIS_D0Q2S0_ROT rotation detector
+                        AXIS_D0Q2 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q2S0 translation detector
+                        AXIS_D0Q2 . . . -11.3150125 23.1242 0.0
+                                    90.04803 AXIS_D0Q2S0_ROT
+    AXIS_D0Q2S0A0_ROT rotation detector
+                        AXIS_D0Q2S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S0A0 translation detector
+                        AXIS_D0Q2S0 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q2S0A0_ROT
+    AXIS_D0Q2S0A0_F translation detector
+                        AXIS_D0Q2S0A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S0A0_S translation detector
+                        AXIS_D0Q2S0A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S0A1_ROT rotation detector
+                        AXIS_D0Q2S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S0A1 translation detector
+                        AXIS_D0Q2S0 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S0A1_ROT
+    AXIS_D0Q2S0A1_F translation detector
+                        AXIS_D0Q2S0A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S0A1_S translation detector
+                        AXIS_D0Q2S0A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S1_ROT rotation detector
+                        AXIS_D0Q2 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q2S1 translation detector
+                        AXIS_D0Q2 . . . -34.6999125 23.155 0.0
+                                    90.00592 AXIS_D0Q2S1_ROT
+    AXIS_D0Q2S1A0_ROT rotation detector
+                        AXIS_D0Q2S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S1A0 translation detector
+                        AXIS_D0Q2S1 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q2S1A0_ROT
+    AXIS_D0Q2S1A0_F translation detector
+                        AXIS_D0Q2S1A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S1A0_S translation detector
+                        AXIS_D0Q2S1A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S1A1_ROT rotation detector
+                        AXIS_D0Q2S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S1A1 translation detector
+                        AXIS_D0Q2S1 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S1A1_ROT
+    AXIS_D0Q2S1A1_F translation detector
+                        AXIS_D0Q2S1A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S1A1_S translation detector
+                        AXIS_D0Q2S1A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S2_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S2 translation detector
+                        AXIS_D0Q2 . . . 23.4746875 10.7811 0.0
+                                    180.11318 AXIS_D0Q2S2_ROT
+    AXIS_D0Q2S2A0_ROT rotation detector
+                        AXIS_D0Q2S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S2A0 translation detector
+                        AXIS_D0Q2S2 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q2S2A0_ROT
+    AXIS_D0Q2S2A0_F translation detector
+                        AXIS_D0Q2S2A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S2A0_S translation detector
+                        AXIS_D0Q2S2A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S2A1_ROT rotation detector
+                        AXIS_D0Q2S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S2A1 translation detector
+                        AXIS_D0Q2S2 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S2A1_ROT
+    AXIS_D0Q2S2A1_F translation detector
+                        AXIS_D0Q2S2A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S2A1_S translation detector
+                        AXIS_D0Q2S2A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S3_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S3 translation detector
+                        AXIS_D0Q2 . . . 23.6220875 34.2221 0.0
+                                   179.92104 AXIS_D0Q2S3_ROT
+    AXIS_D0Q2S3A0_ROT rotation detector
+                        AXIS_D0Q2S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S3A0 translation detector
+                        AXIS_D0Q2S3 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q2S3A0_ROT
+    AXIS_D0Q2S3A0_F translation detector
+                        AXIS_D0Q2S3A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S3A0_S translation detector
+                        AXIS_D0Q2S3A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S3A1_ROT rotation detector
+                        AXIS_D0Q2S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S3A1 translation detector
+                        AXIS_D0Q2S3 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S3A1_ROT
+    AXIS_D0Q2S3A1_F translation detector
+                        AXIS_D0Q2S3A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S3A1_S translation detector
+                        AXIS_D0Q2S3A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S4_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S4 translation detector
+                        AXIS_D0Q2 . . . 11.1953875 -23.9954 0.0
+                                      89.63875 AXIS_D0Q2S4_ROT
+    AXIS_D0Q2S4A0_ROT rotation detector
+                        AXIS_D0Q2S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S4A0 translation detector
+                        AXIS_D0Q2S4 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q2S4A0_ROT
+    AXIS_D0Q2S4A0_F translation detector
+                        AXIS_D0Q2S4A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S4A0_S translation detector
+                        AXIS_D0Q2S4A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S4A1_ROT rotation detector
+                        AXIS_D0Q2S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S4A1 translation detector
+                        AXIS_D0Q2S4 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S4A1_ROT
+    AXIS_D0Q2S4A1_F translation detector
+                        AXIS_D0Q2S4A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S4A1_S translation detector
+                        AXIS_D0Q2S4A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S5_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S5 translation detector
+                        AXIS_D0Q2 . . . 34.5494875 -24.1901 0.0
+                                    89.68154 AXIS_D0Q2S5_ROT
+    AXIS_D0Q2S5A0_ROT rotation detector
+                        AXIS_D0Q2S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S5A0 translation detector
+                        AXIS_D0Q2S5 . . . -10.835 0.0 0.0
+                                       0.0 AXIS_D0Q2S5A0_ROT
+    AXIS_D0Q2S5A0_F translation detector
+                        AXIS_D0Q2S5A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S5A0_S translation detector
+                        AXIS_D0Q2S5A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S5A1_ROT rotation detector
+                        AXIS_D0Q2S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S5A1 translation detector
+                        AXIS_D0Q2S5 . . . 10.835 0.0 0.0
+                                       0.0 AXIS_D0Q2S5A1_ROT
+    AXIS_D0Q2S5A1_F translation detector
+                        AXIS_D0Q2S5A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S5A1_S translation detector
+                        AXIS_D0Q2S5A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S6_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S6 translation detector
+                        AXIS_D0Q2 . . . -23.4854125 -33.2552 0.0
+                                   179.83473 AXIS_D0Q2S6_ROT
+    AXIS_D0Q2S6A0_ROT rotation detector
+                        AXIS_D0Q2S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S6A0 translation detector
+                        AXIS_D0Q2S6 . . . -10.835 0.0 0.0
+                                       0.0 AXIS_D0Q2S6A0_ROT
+    AXIS_D0Q2S6A0_F translation detector
+                        AXIS_D0Q2S6A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S6A0_S translation detector
+                        AXIS_D0Q2S6A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S6A1_ROT rotation detector
+                        AXIS_D0Q2S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S6A1 translation detector
+                        AXIS_D0Q2S6 . . . 10.835 0.0 0.0
+                                       0.0 AXIS_D0Q2S6A1_ROT
+    AXIS_D0Q2S6A1_F translation detector
+                        AXIS_D0Q2S6A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S6A1_S translation detector
+                        AXIS_D0Q2S6A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S7_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S7 translation detector
+                        AXIS_D0Q2 . . . -23.3413125 -9.8417 0.0
+                                   180.092 AXIS_D0Q2S7_ROT
+    AXIS_D0Q2S7A0_ROT rotation detector
+                        AXIS_D0Q2S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S7A0 translation detector
+                        AXIS_D0Q2S7 . . . -10.835 0.0 0.0
+                                       0.0 AXIS_D0Q2S7A0_ROT
+    AXIS_D0Q2S7A0_F translation detector
+                        AXIS_D0Q2S7A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S7A0_S translation detector
+                        AXIS_D0Q2S7A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S7A1_ROT rotation detector
+                        AXIS_D0Q2S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S7A1 translation detector
+                        AXIS_D0Q2S7 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S7A1_ROT
+    AXIS_D0Q2S7A1_F translation detector
+                        AXIS_D0Q2S7A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S7A1_S translation detector
+                        AXIS_D0Q2S7A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3_ROT rotation detector
+                        AXIS_D0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3 translation detector
+                        AXIS_D0 . . . -41.247903125 -50.441634375 0.0
+                                   0.0 AXIS_D0Q3_ROT
+    AXIS_D0Q3S0_ROT rotation detector
+                        AXIS_D0Q3 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q3S0 translation detector
+                        AXIS_D0Q3 . . . 23.1056375 11.6367625 0.0
+                                   180.12436 AXIS_D0Q3S0_ROT
+    AXIS_D0Q3S0A0_ROT rotation detector
+                        AXIS_D0Q3S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S0A0 translation detector
+                        AXIS_D0Q3S0 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S0A0_ROT
+    AXIS_D0Q3S0A0_F translation detector
+                        AXIS_D0Q3S0A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S0A0_S translation detector
+                        AXIS_D0Q3S0A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S0A1_ROT rotation detector
+                        AXIS_D0Q3S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S0A1 translation detector
+                        AXIS_D0Q3S0 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S0A1_ROT
+    AXIS_D0Q3S0A1_F translation detector
+                        AXIS_D0Q3S0A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S0A1_S translation detector
+                        AXIS_D0Q3S0A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S1_ROT rotation detector
+                        AXIS_D0Q3 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q3S1 translation detector
+                        AXIS_D0Q3 . . . 23.1298375 34.9864625 0.0
+                                   180.00263 AXIS_D0Q3S1_ROT
+    AXIS_D0Q3S1A0_ROT rotation detector
+                        AXIS_D0Q3S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S1A0 translation detector
+                        AXIS_D0Q3S1 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S1A0_ROT
+    AXIS_D0Q3S1A0_F translation detector
+                        AXIS_D0Q3S1A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S1A0_S translation detector
+                        AXIS_D0Q3S1A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S1A1_ROT rotation detector
+                        AXIS_D0Q3S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S1A1 translation detector
+                        AXIS_D0Q3S1 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S1A1_ROT
+    AXIS_D0Q3S1A1_F translation detector
+                        AXIS_D0Q3S1A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S1A1_S translation detector
+                        AXIS_D0Q3S1A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S2_ROT rotation detector
+                        AXIS_D0Q3 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q3S2 translation detector
+                        AXIS_D0Q3 . . . 10.9572375 -23.5830375 0.0
+                                   269.55191 AXIS_D0Q3S2_ROT
+    AXIS_D0Q3S2A0_ROT rotation detector
+                        AXIS_D0Q3S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S2A0 translation detector
+                        AXIS_D0Q3S2 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S2A0_ROT
+    AXIS_D0Q3S2A0_F translation detector
+                        AXIS_D0Q3S2A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S2A0_S translation detector
+                        AXIS_D0Q3S2A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S2A1_ROT rotation detector
+                        AXIS_D0Q3S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S2A1 translation detector
+                        AXIS_D0Q3S2 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S2A1_ROT
+    AXIS_D0Q3S2A1_F translation detector
+                        AXIS_D0Q3S2A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S2A1_S translation detector
+                        AXIS_D0Q3S2A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S3_ROT rotation detector
+                        AXIS_D0Q3 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q3S3 translation detector
+                        AXIS_D0Q3 . . . 34.4180375 -23.4818375 0.0
+                                   269.74206 AXIS_D0Q3S3_ROT
+    AXIS_D0Q3S3A0_ROT rotation detector
+                        AXIS_D0Q3S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S3A0 translation detector
+                        AXIS_D0Q3S3 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S3A0_ROT
+    AXIS_D0Q3S3A0_F translation detector
+                        AXIS_D0Q3S3A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S3A0_S translation detector
+                        AXIS_D0Q3S3A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S3A1_ROT rotation detector
+                        AXIS_D0Q3S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S3A1 translation detector
+                        AXIS_D0Q3S3 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S3A1_ROT
+    AXIS_D0Q3S3A1_F translation detector
+                        AXIS_D0Q3S3A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S3A1_S translation detector
+                        AXIS_D0Q3S3A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S4_ROT rotation detector
+                        AXIS_D0Q3 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q3S4 translation detector
+                        AXIS_D0Q3 . . . -24.1283625 -11.5336375 0.0
+                                   359.81971 AXIS_D0Q3S4_ROT
+    AXIS_D0Q3S4A0_ROT rotation detector
+                        AXIS_D0Q3S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S4A0 translation detector
+                        AXIS_D0Q3S4 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S4A0_ROT
+    AXIS_D0Q3S4A0_F translation detector
+                        AXIS_D0Q3S4A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S4A0_S translation detector
+                        AXIS_D0Q3S4A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S4A1_ROT rotation detector
+                        AXIS_D0Q3S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S4A1 translation detector
+                        AXIS_D0Q3S4 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S4A1_ROT
+    AXIS_D0Q3S4A1_F translation detector
+                        AXIS_D0Q3S4A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S4A1_S translation detector
+                        AXIS_D0Q3S4A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S5_ROT rotation detector
+                        AXIS_D0Q3 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q3S5 translation detector
+                        AXIS_D0Q3 . . . -24.1701625 -34.9548375 0.0
+                                   359.99883 AXIS_D0Q3S5_ROT
+    AXIS_D0Q3S5A0_ROT rotation detector
+                        AXIS_D0Q3S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S5A0 translation detector
+                        AXIS_D0Q3S5 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S5A0_ROT
+    AXIS_D0Q3S5A0_F translation detector
+                        AXIS_D0Q3S5A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S5A0_S translation detector
+                        AXIS_D0Q3S5A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S5A1_ROT rotation detector
+                        AXIS_D0Q3S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S5A1 translation detector
+                        AXIS_D0Q3S5 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S5A1_ROT
+    AXIS_D0Q3S5A1_F translation detector
+                        AXIS_D0Q3S5A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S5A1_S translation detector
+                        AXIS_D0Q3S5A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S6_ROT rotation detector
+                        AXIS_D0Q3 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q3S6 translation detector
+                        AXIS_D0Q3 . . . -33.3089625 23.4474625 0.0
+                                   269.67299 AXIS_D0Q3S6_ROT
+    AXIS_D0Q3S6A0_ROT rotation detector
+                        AXIS_D0Q3S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S6A0 translation detector
+                        AXIS_D0Q3S6 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S6A0_ROT
+    AXIS_D0Q3S6A0_F translation detector
+                        AXIS_D0Q3S6A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S6A0_S translation detector
+                        AXIS_D0Q3S6A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S6A1_ROT rotation detector
+                        AXIS_D0Q3S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S6A1 translation detector
+                        AXIS_D0Q3S6 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S6A1_ROT
+    AXIS_D0Q3S6A1_F translation detector
+                        AXIS_D0Q3S6A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S6A1_S translation detector
+                        AXIS_D0Q3S6A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S7_ROT rotation detector
+                        AXIS_D0Q3 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q3S7 translation detector
+                        AXIS_D0Q3 . . . -10.0032625 23.4826625 0.0
+                                   269.67561 AXIS_D0Q3S7_ROT
+    AXIS_D0Q3S7A0_ROT rotation detector
+                        AXIS_D0Q3S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S7A0 translation detector
+                        AXIS_D0Q3S7 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S7A0_ROT
+    AXIS_D0Q3S7A0_F translation detector
+                        AXIS_D0Q3S7A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S7A0_S translation detector
+                        AXIS_D0Q3S7A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S7A1_ROT rotation detector
+                        AXIS_D0Q3S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S7A1 translation detector
+                        AXIS_D0Q3S7 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S7A1_ROT
+    AXIS_D0Q3S7A1_F translation detector
+                        AXIS_D0Q3S7A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S7A1_S translation detector
+                        AXIS_D0Q3S7A1 0 1 0 0 0 0 . .
+
+;
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save_<a name="_axis.depends_on" >_axis.depends_on</a>
+    _item_description.description
+;            The value of <a href="#_axis.depends_on" >_axis.depends_on</a> specifies the next outermost
+              axis upon which this axis depends, unless
+              <a href="#_axis.rotation_axis" >_axis.rotation_axis</a> is specified, in which case,
+              <a href="#_axis.rotation_axis" >_axis.rotation_axis</a> is next outermost and
+              <a href="#_axis.depends_on" >_axis.depends_on</a> is second outermost.
+
+              This item is a pointer to <a href="#_axis.id">_axis.id</a> in the same category.
+;
+    _item.name                      '<a href="#_axis.depends_on">_axis.depends_on</a>'
+    _item.category_id                 axis
+    _item.mandatory_code              no
+     save_
+
+
+save_<a name="_axis.equipment" >_axis.equipment</a>
+    _item_description.description
+;            The value of  <a href="#_axis.equipment" >_axis.equipment</a> specifies the type of
+              equipment using the axis:  'goniometer', 'detector',
+             'gravity', 'source' or 'general'.
+;
+    _item.name                      '<a href="#_axis.equipment">_axis.equipment</a>'
+    _item.category_id                 axis
+    _item.mandatory_code              implicit
+    _item_type.code                   ucode
+    _item_default.value               general
+     loop_
+    _item_enumeration.value
+    _item_enumeration.detail   goniometer
+                              'equipment used to orient or position samples'
+                               detector
+                              'equipment used to detect reflections'
+                               general
+                              'equipment used for general purposes'
+                               gravity
+                              'axis specifying the downward direction'
+                               source
+                              'axis specifying the direction sample to source'
+     save_
+
+save_<a name="_axis.equipment_component" >_axis.equipment_component</a>
+    _item_description.description
+;            The value of  <a href="#_axis.equipment_component" >_axis.equipment_component</a> specifies
+              an arbitrary identifier of a component of the equipment to which
+              the axis belongs, such as 'detector_arm' or 'detector_module'.
+
+;
+    _item.name                      '<a href="#_axis.equipment_component">_axis.equipment_component</a>'
+    _item.category_id                 axis
+    _item.mandatory_code              no
+    _item_type.code                   ucode
+     save_
+
+
+save_<a name="_axis.offset[1]" >_axis.offset[1]</a>
+    _item_description.description
+;             The [1] element of the three-element vector used to specify
+               the offset to the base of a rotation or translation axis.
+
+               The vector is specified in millimetres.
+;
+    _item.name                  '<a href="#_axis.offset[1]">_axis.offset[1]</a>'
+    _item.category_id             axis
+    _item.mandatory_code          no
+    _item_default.value           0.0
+    _item_sub_category.id         vector
+    _item_type.code               float
+    _item_units.code              millimetres
+     save_
+
+
+save_<a name="_axis.offset[2]" >_axis.offset[2]</a>
+    _item_description.description
+;             The [2] element of the three-element vector used to specify
+               the offset to the base of a rotation or translation axis.
+
+               The vector is specified in millimetres.
+;
+    _item.name                  '<a href="#_axis.offset[2]">_axis.offset[2]</a>'
+    _item.category_id             axis
+    _item.mandatory_code          no
+    _item_default.value           0.0
+    _item_sub_category.id         vector
+    _item_type.code               float
+    _item_units.code              millimetres
+     save_
+
+
+save_<a name="_axis.offset[3]" >_axis.offset[3]</a>
+    _item_description.description
+;             The [3] element of the three-element vector used to specify
+               the offset to the base of a rotation or translation axis.
+
+               The vector is specified in millimetres.
+;
+    _item.name                  '<a href="#_axis.offset[3]">_axis.offset[3]</a>'
+    _item.category_id             axis
+    _item.mandatory_code          no
+    _item_default.value           0.0
+    _item_sub_category.id         vector
+    _item_type.code               float
+    _item_units.code              millimetres
+     save_
+
+
+save_<a name="_axis.id" >_axis.id</a></a>
+    _item_description.description
+;            The value of <a href="#_axis.id" >_axis.id</a> must uniquely identify
+              each axis relevant to the experiment.  Note that multiple
+              pieces of equipment may share the same axis (e.g. a twotheta
+              arm), so the category key for <a href="#AXIS">AXIS</a> also includes the
+              equipment.
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+         '<a href="#_axis.id" >_axis.id</a>'                         axis                    yes
+         '<a href="#_array_structure_list_axis.axis_id" >_array_structure_list_axis.axis_id</a>'
+                                            array_structure_list_axis
+                                                                    yes
+         '<a href="#_diffrn_detector_axis.axis_id" >_diffrn_detector_axis.axis_id</a>'    diffrn_detector_axis    yes
+         '<a href="#_diffrn_measurement_axis.axis_id" >_diffrn_measurement_axis.axis_id</a>' diffrn_measurement_axis yes
+         '<a href="#_diffrn_scan_axis.axis_id" >_diffrn_scan_axis.axis_id</a>'        diffrn_scan_axis        yes
+         '<a href="#_diffrn_scan_frame_axis.axis_id" >_diffrn_scan_frame_axis.axis_id</a>'  diffrn_scan_frame_axis  yes
+
+    _item_type.code               code
+     loop_
+    _item_linked.child_name
+    _item_linked.parent_name
+         '<a href="#_axis.depends_on" >_axis.depends_on</a>'                   '<a href="#_axis.id" >_axis.id</a>'
+         '<a href="#_array_structure_list_axis.axis_id" >_array_structure_list_axis.axis_id</a>' '<a href="#_axis.id" >_axis.id</a>'
+         '<a href="#_diffrn_detector_axis.axis_id" >_diffrn_detector_axis.axis_id</a>'      '<a href="#_axis.id" >_axis.id</a>'
+         '<a href="#_diffrn_measurement_axis.axis_id" >_diffrn_measurement_axis.axis_id</a>'   '<a href="#_axis.id" >_axis.id</a>'
+         '<a href="#_diffrn_scan_axis.axis_id" >_diffrn_scan_axis.axis_id</a>'          '<a href="#_axis.id" >_axis.id</a>'
+         '<a href="#_diffrn_scan_frame_axis.axis_id" >_diffrn_scan_frame_axis.axis_id</a>'    '<a href="#_axis.id" >_axis.id</a>'
+     save_
+
+save_<a name="_axis.rotation" >_axis.rotation</a>
+    _item_description.description
+;            The value of <a href="#_axis.rotation" >_axis.rotation</a> specifies
+              the fixed base rotation angle for <a href="#_axis.rotation_axis" >_axis.rotation_axis</a>
+              to which the value of any frame-by-frame setting, if any, should
+              be added.  Normally, only the fixed value would be given.
+;
+    _item.name                      '<a href="#_axis.rotation">_axis.rotation</a>'
+    _item.category_id                 axis
+    _item.mandatory_code              no
+    _item_default.value               0.0
+    _item_type.code                   float
+    _item_units.code                  degrees  
+     save_
+
+
+save_<a name="_axis.rotation_axis" >_axis.rotation_axis</a>
+    _item_description.description
+;            The value of <a href="#_axis.rotation_axis" >_axis.rotation_axis</a> specifies
+              an optional additional dependency for this axis to be applied
+              after applying <a href="#_axis.depends_on" >_axis.depends_on</a>.
+
+              This item is a pointer to <a href="#_axis.id">_axis.id</a> in the same category.
+;
+    _item.name                      '<a href="#_axis.rotation_axis">_axis.rotation_axis</a>'
+    _item.category_id                 axis
+    _item.mandatory_code              no
+    _item_type.code                   ucode   
+     save_
+
+
+save_<a name="_axis.system" >_axis.system</a>
+    _item_description.description
+;            The value of  <a href="#_axis.system" >_axis.system</a> specifies the coordinate
+              system used to define the axis: 'laboratory', 'McStas', 'direct', 
+             'orthogonal', 'reciprocal' or 'abstract'.
+;
+    _item.name                      '<a href="#_axis.system">_axis.system</a>'
+    _item.category_id                 axis
+    _item.mandatory_code              no
+    _item_type.code                   ucode
+    _item_default.value               laboratory
+     loop_
+    _item_enumeration.value
+    _item_enumeration.detail   
+
+laboratory
+; the axis is referenced to the imgCIF standard laboratory Cartesian
+   coordinate system
+;
+
+McStas
+; the axis is referenced to the NeXus/HDF5 McStas laboratory Cartesian
+   coordinate system
+;
+
+direct
+; the axis is referenced to the direct lattice
+;
+
+orthogonal
+; the axis is referenced to the cell Cartesian orthogonal coordinates
+;
+
+reciprocal
+; the axis is referenced to the reciprocal lattice
+;
+
+abstract
+; the axis is referenced to an abstract Cartesian coordinate system
+;
+
+     save_
+
+
+save_<a name="_axis.type" >_axis.type</a>
+    _item_description.description
+;            The value of <a href="#_axis.type" >_axis.type</a> specifies the type of
+              axis:  'rotation' or 'translation' (or 'general' when
+              the type is not relevant, as for gravity).
+;
+    _item.name                      '<a href="#_axis.type">_axis.type</a>'
+    _item.category_id                 axis
+    _item.mandatory_code              no
+    _item_type.code                   ucode
+    _item_default.value               general
+     loop_
+    _item_enumeration.value
+    _item_enumeration.detail      rotation
+                                 'right-handed axis of rotation'
+                                  translation
+                                 'translation in the direction of the axis'
+                                  general
+                                 'axis for which the type is not relevant'
+     save_
+
+
+save_<a name="_axis.vector[1]" >_axis.vector[1]</a>
+    _item_description.description
+;             The [1] element of the three-element vector used to specify
+               the direction of a rotation or translation axis.
+               The vector should be normalized to be a unit vector and
+               is dimensionless.
+;
+    _item.name                  '<a href="#_axis.vector[1]" >_axis.vector[1]</a>'
+    _item.category_id             axis
+    _item.mandatory_code          no
+    _item_default.value           0.0
+    _item_sub_category.id         vector
+    _item_type.code               float
+     save_
+
+
+save_<a name="_axis.vector[2]" >_axis.vector[2]</a>
+    _item_description.description
+;             The [2] element of the three-element vector used to specify
+               the direction of a rotation or translation axis.
+               The vector should be normalized to be a unit vector and
+               is dimensionless.
+;
+    _item.name                  '<a href="#_axis.vector[2]" >_axis.vector[2]</a>'
+    _item.category_id             axis
+    _item.mandatory_code          no
+    _item_default.value           0.0
+    _item_sub_category.id         vector
+    _item_type.code               float
+     save_
+
+
+save_<a name="_axis.vector[3]" >_axis.vector[3]</a>
+    _item_description.description
+;             The [3] element of the three-element vector used to specify
+               the direction of a rotation or translation axis.
+               The vector should be normalized to be a unit vector and
+               is dimensionless.
+;
+    _item.name                  '<a href="#_axis.vector[3]" >_axis.vector[3]</a>'
+    _item.category_id             axis
+    _item.mandatory_code          no
+    _item_default.value           0.0
+    _item_sub_category.id         vector
+    _item_type.code               float
+     save_
+
+
+save_<a name="_axis.variant" >_axis.variant</a>
+    _item_description.description
+;            The value of <a href="#_axis.variant" >_axis.variant</a> gives the variant
+              to which the given AXIS row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to <a href="#_variant.variant" >_variant.variant</a> in the
+              <a href="#variant">VARIANT</a> category.
+;
+    _item.name                  '<a href="#_axis.variant" >_axis.variant</a>'
+    _item.category_id             axis
+    _item.mandatory_code          implicit
+    _item_default.value           .
+    _item_type.code               code
+     save_
+
+
+
+#####################
+# <a name="diffrn_data_frame" >DIFFRN_DATA_FRAME</a> #
+#####################
+
+
+save_DIFFRN_DATA_FRAME
+    _category.description
+;            Data items in the <a href="#DIFFRN_DATA_FRAME">DIFFRN_DATA_FRAME</a> category record
+              the details about each frame of data.
+
+              The items in this category were previously in a
+              DIFFRN_FRAME_DATA category, which is now deprecated.
+              The items from the old category are provided
+              as aliases but should not be used for new work.
+;
+    _category.id                   diffrn_data_frame
+    _category.mandatory_code       no
+<div id="print_NX_diffrn_data_frame" style="display:block">   #_category.NX_mapping_details in online version <a href="javascript:open_close2('online_NX_diffrn_data_frame','print_NX_diffrn_data_frame');">+/-</a>
+</div><div id="online_NX_diffrn_data_frame" style="display:none">    _category.NX_mapping_details                  #<a href="javascript:open_close2('online_NX_diffrn_data_frame','print_NX_diffrn_data_frame');">+/-</a>
+;
+
+    _diffrn_data_frame.array_id ARRAYID
+    _diffrn_data_frame.array_section_id SECTIONID
+    _diffrn_data_frame.binary_id BINID
+    _diffrn_data_frame.center_fast CENF
+    _diffrn_data_frame.center_slow CENS
+    _diffrn_data_frame.center_units UNITS
+    _diffrn_data_frame.detector_element_id ELEMENTID
+    _diffrn_data_frame.id FRAMEID
+    _diffrn_data_frame.details DETAILS
+
+    -->
+
+    /entry:NXentry
+      /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+          /CBF_diffrn_data_frame__section_id=[SECTIONIDARRAY]
+          /CBF_diffrn_data_frame__binary_id=[BINARYIDARRAY]
+          /CBF_diffrn_data_frame__center_fast_slow=[CENTERARRAY]
+            @units="UNITS"
+          /CBF_diffrn_data_frame__details=["DETAILSARRAY"]
+
+    inserts either ARRAYID (if SECTIONID is not specified or SECTIONID
+    into the element of SECTIONIDARRY for this frame and for this detector
+    element (see below);
+
+    inserts BINID
+    into the element of BINARYIDARRAY for this frame and for this detector
+    element (see below);
+
+    inserts CENF
+    into the element of CENTERARRAY for this frame, for this detector element
+    and for the fast centre (see below);
+
+    inserts CENS
+    into the element of CENTERARRAY for this frame, for this detector element
+    and for the slow centre (see below);
+
+    only one CENTERARRY unit is provided.  If there is variation, the values in
+    CENTERARRAY should be rescaled to uniform units.
+
+    _diffrn_data_frame.detector_element_id ELEMENTID -->
+    ELEMENTID used to index into the arrays of this category by the ordinal of
+    the matching ELEMENTID in DIFFRN_DETECTOR_ELEMENT__id for the fast index;
+
+    FRAMEID used to index into the arrays of this category by the ordinal of
+    the matching ELEMENTID in DIFFRN_DETECTOR_ELEMENT__id for the slow index
+    by matching FRAMEID against _diffrn_scan_frame.frame_id and using
+    _diffrn_scan_frame.frame_number from the same row.
+
+    inserts DETAILS
+    into the element of DETAILSARRAY for this frame and for this detector
+    element (see below); 
+
+    The arrays created in the mapping have a slow index of the number of frames
+    and a fast index of the number of detector elements.  There is a middle
+    index for CENTERARRAY in the order fast and then slow.
+;
+</div>
+     loop_
+    _category_key.name             '<a href="#_diffrn_data_frame.id" >_diffrn_data_frame.id</a>'
+                                   '<a href="#_diffrn_data_frame.detector_element_id" >_diffrn_data_frame.detector_element_id</a>'
+                                   '<a href="#_diffrn_data_frame.variant" >_diffrn_data_frame.variant</a>'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'array_data_group'
+                                   'diffrn_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;     Example 1. a frame containing data from four frame elements.
+
+                       Each frame element has a common array configuration
+                       'array_1' described in <a href="#array_structure">ARRAY_STRUCTURE</a> and related
+                       categories.  The data for each detector element are
+                       stored in four groups of binary data in the
+                       <a href="#array_data">ARRAY_DATA</a> category, linked by the array_id and
+                       binary_id.
+;
+;
+        loop_
+        <a href="#_diffrn_data_frame.id" >_diffrn_data_frame.id</a>
+        <a href="#_diffrn_data_frame.detector_element_id" >_diffrn_data_frame.detector_element_id</a>
+        <a href="#_diffrn_data_frame.array_id" >_diffrn_data_frame.array_id</a>
+        <a href="#_diffrn_data_frame.binary_id" >_diffrn_data_frame.binary_id</a>
+        frame_1   d1_ccd_1  array_1  1
+        frame_1   d1_ccd_2  array_1  2
+        frame_1   d1_ccd_3  array_1  3
+        frame_1   d1_ccd_4  array_1  4
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save_<a name="_diffrn_data_frame.array_id" >_diffrn_data_frame.array_id</a>
+    _item_description.description
+;            This item is a pointer to <a href="#_array_structure.id" >_array_structure.id</a> in the
+              <a href="#array_structure">ARRAY_STRUCTURE</a> category.
+;
+    _item.name                  '<a href="#_diffrn_data_frame.array_id" >_diffrn_data_frame.array_id</a>'
+    _item.category_id             diffrn_data_frame
+    _item.mandatory_code          implicit
+    _item_aliases.alias_name    '_diffrn_frame_data.array_id'
+    _item_aliases.dictionary      cif_img.dic
+    _item_aliases.version         1.0
+    _item_type.code               code
+     save_
+
+
+save_<a name="_diffrn_data_frame.array_section_id" >_diffrn_data_frame.array_section_id</a>
+    _item_description.description
+;            This item is a pointer to <a href="#_array_structure_list_section.id" >_array_structure_list_section.id</a>
+              in the <a href="#array_structure_list_section">ARRAY_STRUCTURE_LIST_SECTION</a> category.
+;
+    _item.name                  '<a href="#_diffrn_data_frame.array_section_id" >_diffrn_data_frame.array_section_id</a>'
+    _item.category_id             diffrn_data_frame
+    _item.mandatory_code          implicit
+    _item_type.code               code
+     save_
+
+
+save_<a name="_diffrn_data_frame.binary_id" >_diffrn_data_frame.binary_id</a>
+    _item_description.description
+;            This item is a pointer to <a href="#_array_data.binary_id" >_array_data.binary_id</a> in the
+              <a href="#array_data">ARRAY_DATA</a> category.
+;
+    _item.name                  '<a href="#_diffrn_data_frame.binary_id" >_diffrn_data_frame.binary_id</a>'
+    _item.category_id             diffrn_data_frame
+    _item.mandatory_code          implicit
+    _item_aliases.alias_name    '_diffrn_frame_data.binary_id'
+    _item_aliases.dictionary      cif_img.dic
+    _item_aliases.version         1.0
+    _item_type.code               int
+     save_
+
+
+save_<a name="_diffrn_data_frame.center_fast">_diffrn_data_frame.center_fast</a>
+    _item_description.description
+;            The value of <a href="#_diffrn_data_frame.center_fast">_diffrn_data_frame.center_fast</a> is 
+              the fast index axis beam centre position relative to the detector
+              element face in the units specified in the data item
+              <a href="#_diffrn_data_frame.center_units">_diffrn_data_frame.center_units</a> along the fast
+              axis of the detector from the centre of the first pixel to 
+              the point at which the Z axis (which should be collinear with the
+              beam) intersects the face of the detector, if in fact it does.
+              At the time of the measurement the current settings of
+              the detector positioner for the given frame are used.
+
+              It is important to note that for measurements in mm,
+              the sense of the axis is used, rather than the sign of the 
+              pixel-to-pixel increments.
+
+;
+    _item.name '<a href="#_diffrn_data_frame.center_fast">_diffrn_data_frame.center_fast</a>'
+    _item.category_id             diffrn_data_frame
+    _item.mandatory_code          no
+    _item_type.code               float
+     save_
+
+
+save_<a name="_diffrn_data_frame.center_slow">_diffrn_data_frame.center_slow</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_data_frame.center_slow">_diffrn_data_frame.center_slow</a> is
+              the slow index axis beam centre position relative to the detector
+              element face in the units specified in the data item
+              <a href="#_diffrn_data_frame.center_units">_diffrn_data_frame.center_units</a> along the slow
+              axis of the detector from the centre of the first pixel to
+              the point at which the Z axis (which should be collinear with the
+              beam) intersects the face of the detector, if in fact it does.
+              At the time of the measurement the current settings of
+              the detector positioner for the given frame are used.
+
+              It is important to note that the sense of the axis is used,
+              rather than the sign of the pixel-to-pixel increments.
+;
+    _item.name '<a href="#_diffrn_data_frame.center_slow">_diffrn_data_frame.center_slow</a>'
+    _item.category_id             diffrn_data_frame
+    _item.mandatory_code          no
+    _item_type.code               float
+     save_
+
+
+save_<a name="_diffrn_data_frame.center_derived" >_diffrn_data_frame.center_derived</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_data_frame.center_derived" >_diffrn_data_frame.center_derived</a>
+              is assumed to be 'yes', i.e. that values of
+              <a href="#_diffrn_data_frame.center_fast">_diffrn_data_frame.center_fast</a> and
+              <a href="#_diffrn_data_frame.center_slow">_diffrn_data_frame.center_slow</a> 
+              are derived from the axis settings rather than measured.               
+;
+    _item.name                  '<a href="#_diffrn_data_frame.center_derived" >_diffrn_data_frame.center_derived</a>'
+    _item.category_id             diffrn_data_frame
+    _item.mandatory_code          no
+    _item_type.code               ucode
+    _item_default.value           'yes'
+     save_
+
+
+save_<a name="_diffrn_data_frame.center_units">_diffrn_data_frame.center_units</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_data_frame.center_units">_diffrn_data_frame.center_units</a>
+              specifies the units in which the values of 
+              <a href="#_diffrn_data_frame.center_fast">_diffrn_data_frame.center_fast</a> and
+              <a href="#_diffrn_data_frame.center_slow">_diffrn_data_frame.center_slow</a>
+              are presented.  The default is 'mm' for millimetres.  The 
+              alternatives are 'pixels' and 'bins'.  In all cases the
+              centre distances are measured from the centre of the
+              first pixel, i.e. in a 2x2 binning, the measuring origin
+              is offset from the centres of the bins by one half pixel
+              towards the first pixel.
+
+              If 'bins' is specified, the data in
+                  <a href="#_array_intensities.pixel_fast_bin_size" >_array_intensities.pixel_fast_bin_size</a>,
+                  <a href="#_array_intensities.pixel_slow_bin_size" >_array_intensities.pixel_slow_bin_size</a>, and
+                  <a href="#_array_intensities.pixel_binning_method" >_array_intensities.pixel_binning_method</a>
+              are used to define the binning scheme.
+;
+    _item.name '<a href="#_diffrn_data_frame.center_units">_diffrn_data_frame.center_units</a>'
+    _item.category_id             diffrn_data_frame
+    _item.mandatory_code          no
+    _item_type.code               code
+     loop_
+    _item_enumeration.value
+    _item_enumeration.detail
+                                   mm        'millimetres'
+                                   pixels    'detector pixels'
+                                   bins      'detector bins'
+     save_
+
+
+save_<a name="_diffrn_data_frame.detector_element_id" >_diffrn_data_frame.detector_element_id</a>
+    _item_description.description
+;             This item is a pointer to <a href="#_diffrn_detector_element.id">_diffrn_detector_element.id</a>
+              in the <a href="#diffrn_detector_element">DIFFRN_DETECTOR_ELEMENT</a> category.
+;
+    _item.name                  '<a href="#_diffrn_data_frame.detector_element_id" >_diffrn_data_frame.detector_element_id</a>'
+    _item.category_id             diffrn_data_frame
+    _item.mandatory_code          yes
+    _item_aliases.alias_name    '_diffrn_frame_data.detector_element_id'
+    _item_aliases.dictionary      cif_img.dic
+    _item_aliases.version         1.0
+    _item_type.code               code
+     save_
+
+
+save_<a name="_diffrn_data_frame.id" >_diffrn_data_frame.id</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_data_frame.id" >_diffrn_data_frame.id</a> must uniquely identify
+              each complete frame of data.
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+           '<a href="#_diffrn_data_frame.id" >_diffrn_data_frame.id</a>'        diffrn_data_frame  yes
+           '<a href="#_diffrn_refln.frame_id" >_diffrn_refln.frame_id</a>'       diffrn_refln       yes
+           '<a href="#_diffrn_scan.frame_id_start" >_diffrn_scan.frame_id_start</a>'  diffrn_scan        yes
+           '<a href="#_diffrn_scan.frame_id_end" >_diffrn_scan.frame_id_end</a>'    diffrn_scan        yes
+           '<a href="#_diffrn_scan_frame.frame_id" >_diffrn_scan_frame.frame_id</a>'  diffrn_scan_frame  yes
+           '<a href="#_diffrn_scan_frame_axis.frame_id" >_diffrn_scan_frame_axis.frame_id</a>'
+                                          diffrn_scan_frame_axis
+                                                             yes
+           '<a href="#_diffrn_scan_frame_monitor.frame_id" >_diffrn_scan_frame_monitor.frame_id</a>'
+                                          diffrn_scan_frame_monitor
+                                                             implicit
+    _item_aliases.alias_name    '_diffrn_frame_data.id'
+    _item_aliases.dictionary      cif_img.dic
+    _item_aliases.version         1.0
+    _item_type.code               code
+     loop_
+    _item_linked.child_name
+    _item_linked.parent_name
+           '<a href="#_diffrn_refln.frame_id" >_diffrn_refln.frame_id</a>'        '<a href="#_diffrn_data_frame.id" >_diffrn_data_frame.id</a>'
+           '<a href="#_diffrn_scan.frame_id_start" >_diffrn_scan.frame_id_start</a>'   '<a href="#_diffrn_data_frame.id" >_diffrn_data_frame.id</a>'
+           '<a href="#_diffrn_scan.frame_id_end" >_diffrn_scan.frame_id_end</a>'     '<a href="#_diffrn_data_frame.id" >_diffrn_data_frame.id</a>'
+           '<a href="#_diffrn_scan_frame.frame_id" >_diffrn_scan_frame.frame_id</a>'   '<a href="#_diffrn_data_frame.id" >_diffrn_data_frame.id</a>'
+           '<a href="#_diffrn_scan_frame_axis.frame_id" >_diffrn_scan_frame_axis.frame_id</a>'
+                                           '<a href="#_diffrn_data_frame.id" >_diffrn_data_frame.id</a>'
+           '<a href="#_diffrn_scan_frame_monitor.frame_id" >_diffrn_scan_frame_monitor.frame_id</a>'
+                                           '<a href="#_diffrn_data_frame.id" >_diffrn_data_frame.id</a>'
+     save_
+
+
+save_<a name="_diffrn_data_frame.details" >_diffrn_data_frame.details</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_data_frame.details" >_diffrn_data_frame.details</a> should give a
+              description of special aspects of each frame of data.
+
+              This is an appropriate location in which to record
+              information from vendor headers as presented in those
+              headers, but it should never be used as a substitute
+              for providing the fully parsed information within
+              the appropriate imgCIF/CBF categories.
+
+              Normally, when a conversion from a miniCBF has been done
+              the data from <a href="#_array_data.header_convention">_array_data.header_convention</a>
+              should be transferred to this data item and 
+              <a href="#_array_data.header_convention">_array_data.header_convention</a>
+              should be removed.
+;
+    _item.name                  '<a name="_diffrn_data_frame.details" >_diffrn_data_frame.details</a>'
+    _item.category_id             diffrn_data_frame
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_frame_data.details'
+    _item_aliases.dictionary      cif_img.dic
+    _item_aliases.version         1.4
+    _item_type.code               text
+     loop_
+    _item_examples.case
+    _item_examples.detail
+;
+HEADER_BYTES = 512;
+DIM = 2;
+BYTE_ORDER = big_endian;
+TYPE = unsigned_short;
+SIZE1 = 3072;
+SIZE2 = 3072;
+PIXEL_SIZE = 0.102588;
+BIN = 2x2;
+DETECTOR_SN = 901;
+TIME = 29.945155;
+DISTANCE = 200.000000;
+PHI = 85.000000;
+OSC_START = 85.000000;
+OSC_RANGE = 1.000000;
+WAVELENGTH = 0.979381;
+BEAM_CENTER_X = 157.500000;
+BEAM_CENTER_Y = 157.500000;
+PIXEL SIZE = 0.102588;
+OSCILLATION RANGE = 1;
+EXPOSURE TIME = 29.9452;
+TWO THETA = 0;
+BEAM CENTRE = 157.5 157.5;
+;
+;              Example of header information extracted from an ADSC Quantum
+               315 detector header by CBFlib_0.7.6.  Image provided by Chris
+               Nielsen of ADSC from a data collection at SSRL beamline 1-5.
+;
+     save_
+
+
+save_<a name="_diffrn_data_frame.variant" >_diffrn_data_frame.variant</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_data_frame.variant" >_diffrn_data_frame.variant</a> gives the variant
+              to which the given DIFFRN_DATA_FRAME row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to <a href="#_variant.variant" >_variant.variant</a> in the
+              <a href="#variant">VARIANT</a> category.
+;
+    _item.name                  '<a href="#_diffrn_data_frame.variant" >_diffrn_data_frame.variant</a>'
+    _item.category_id             diffrn_data_frame
+    _item.mandatory_code          implicit
+    _item_default.value           .
+    _item_type.code               code
+     save_
+
+
+##########################################################################
+#  The following is a restatement of the mmCIF <a href="#diffrn_detector">DIFFRN_DETECTOR</a>,          #
+#  <a href="#diffrn_measurement">DIFFRN_MEASUREMENT</a> and <a href="#diffrn_radiation">DIFFRN_RADIATION</a> categories, modified for      #
+#  the CBF/imgCIF extensions                                             #
+##########################################################################
+
+###################
+# <a name="diffrn_detector">DIFFRN_DETECTOR</a> #
+###################
+
+
+save_DIFFRN_DETECTOR
+    _category.description
+;   Data items in the <a href="#DIFFRN_DETECTOR">DIFFRN_DETECTOR</a> category describe the
+    detector used to measure the scattered radiation, including
+    any analyser and post-sample collimation.
+;
+    _category.id                  diffrn_detector
+    _category.mandatory_code      no
+<div id="print_NX_diffrn_detector" style="display:block">   #_category.NX_mapping_details in online version <a href="javascript:open_close2('online_NX_diffrn_detector','print_NX_diffrn_detector');">+/-</a>
+</div><div id="online_NX_diffrn_detector" style="display:none">    _category.NX_mapping_details                  #<a href="javascript:open_close2('online_NX_diffrn_detector','print_NX_diffrn_detector');">+/-</a>
+;
+
+    _diffrn_detector.diffrn_id DIFFRNID 
+    _diffrn_detector.id DETECTORNAME 
+    _diffrn_detector.details DETAILS
+    _diffrn_detector.detector DETECTOR
+    _diffrn_detector.dtime DTIME
+    _diffrn_detector.gain_setting GAINSETTING
+    _diffrn_detector.number_of_axes NAXES
+    _diffrn_detector.type DETTYPE
+
+    --> 
+
+      /entry:NXentry
+        /CBF_scan_id="SCANID"
+        /CBF_diffrn_id="DIFFRNID"
+          /instrument:NXinstrument
+           /DETECTORNAME:NXdetector_group
+           /DETECTORELEMENTNAME:NXdetector
+              /details="DETAILS"
+              /type="DETECTOR"
+              /deadtime=DTIME
+              /number_of_axes=NAXES
+              /description="DETTYPE"
+              /gain_setting="GAINSETTING"
+
+;
+</div>
+     loop_
+    _category_key.name          '<a href="#_diffrn_detector.diffrn_id" >_diffrn_detector.diffrn_id</a>'
+                                '<a href="#_diffrn_detector.id" >_diffrn_detector.id</a>'
+                                '<a href="#_diffrn_detector.variant" >_diffrn_detector.variant</a>'
+     loop_
+    _category_group.id           'inclusive_group'
+                                 'diffrn_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;   Example 1. based on PDB entry 5HVP and laboratory records for the
+                structure corresponding to PDB entry 5HVP.
+;
+;
+    <a href="#_diffrn_detector.diffrn_id" >_diffrn_detector.diffrn_id</a>             'd1'
+    <a href="#_diffrn_detector.detector" >_diffrn_detector.detector</a>              'multiwire'
+    <a href="#_diffrn_detector.type" >_diffrn_detector.type</a>                  'Siemens'
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save_<a name="_diffrn_detector.details" >_diffrn_detector.details</a>
+    _item_description.description
+;             A description of special aspects of the radiation detector.
+;
+    _item.name                  '<a href="#_diffrn_detector.details" >_diffrn_detector.details</a>'
+    _item.category_id             diffrn_detector
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_detector_details'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+    _item_type.code                   text
+    _item_examples.case        'slow mode'
+     save_
+
+
+save_<a name="_diffrn_detector.detector" >_diffrn_detector.detector</a>
+    _item_description.description
+;             The general class of the radiation detector.
+;
+    _item.name                  '<a href="#_diffrn_detector.detector" >_diffrn_detector.detector</a>'
+    _item.category_id             diffrn_detector
+    _item.mandatory_code          no
+     loop_
+    _item_aliases.alias_name
+    _item_aliases.dictionary
+    _item_aliases.version       '_diffrn_radiation_detector'
+                                  cifdic.c91
+                                  1.0
+                                '_diffrn_detector'
+                                  cif_core.dic
+                                  2.0
+    _item_type.code               text
+     loop_
+    _item_examples.case          'photographic film'
+                                 'scintillation counter'
+                                 'CCD plate'
+                                 'BF~3~ counter'
+     save_
+
+
+save_<a name="_diffrn_detector.diffrn_id" >_diffrn_detector.diffrn_id</a>
+    _item_description.description
+;             This data item is a pointer to <a href="#_diffrn.id">_diffrn.id</a> in the DIFFRN
+              category.
+
+              The value of <a href="#_diffrn.id">_diffrn.id</a> uniquely defines a set of
+              diffraction data.
+;
+    _item.name                  '<a href="#_diffrn_detector.diffrn_id" >_diffrn_detector.diffrn_id</a>'
+    _item.category_id             diffrn_detector
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+
+save_<a name="_diffrn_detector.dtime" >_diffrn_detector.dtime</a>
+    _item_description.description
+;             The deadtime in microseconds of the detector(s) used to
+              measure the diffraction intensities.
+;
+    _item.name                  '<a href="#_diffrn_detector.dtime" >_diffrn_detector.dtime</a>'
+    _item.category_id             diffrn_detector
+    _item.mandatory_code          no
+     loop_
+    _item_aliases.alias_name
+    _item_aliases.dictionary
+    _item_aliases.version       '_diffrn_radiation_detector_dtime'
+                                  cifdic.c91
+                                  1.0
+                                '_diffrn_detector_dtime'
+                                  cif_core.dic
+                                  2.0
+     loop_
+    _item_range.maximum
+    _item_range.minimum            .    0.0
+                                  0.0   0.0
+    _item_type.code               float
+    _item_units.code              microseconds
+     save_
+
+
+save_<a name="_diffrn_detector.id" >_diffrn_detector.id</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_detector.id" >_diffrn_detector.id</a> must uniquely identify
+              each detector used to collect each diffraction data set.
+
+              If the value of <a href="#_diffrn_detector.id" >_diffrn_detector.id</a> is not given, it is
+              implicitly equal to the value of
+              <a href="#_diffrn_detector.diffrn_id" >_diffrn_detector.diffrn_id</a>.
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+             '<a href="#_diffrn_detector.id" >_diffrn_detector.id</a>'         diffrn_detector       implicit
+             '<a href="#_diffrn_detector_axis.detector_id" >_diffrn_detector_axis.detector_id</a>'
+                                           diffrn_detector_axis       yes
+             '<a href="#_diffrn_scan_frame_monitor.detector_id" >_diffrn_scan_frame_monitor.detector_id</a>'
+                                           diffrn_scan_frame_monitor  yes
+     loop_
+    _item_linked.child_name
+    _item_linked.parent_name
+             '<a href="#_diffrn_detector_axis.detector_id" >_diffrn_detector_axis.detector_id</a>'
+                                         '_diffrn_detector.id'
+             '<a href="#_diffrn_scan_frame_monitor.detector_id" >_diffrn_scan_frame_monitor.detector_id</a>'
+                                         '_diffrn_detector.id'
+
+    _item_type.code               code
+     save_
+
+
+save_<a name="_diffrn_detector.layer_thickness" >_diffrn_detector.layer_thickness</a>
+    _item_description.description
+;             The thickness in mm of the sensing layer of the detector
+              for use in angular corrections.
+;
+    _item.name                  '<a href="#_diffrn_detector.layer_thickness" >_diffrn_detector.layer_thickness</a>'
+    _item.category_id             diffrn_detector
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum            .    0.0
+                                  0.0   0.0
+    _item_type.code               float
+    _item_units.code              millimetres
+     save_
+
+
+save_<a name="_diffrn_detector.gain_setting" >_diffrn_detector.gain_setting </a>
+    _item_description.description
+;             The gain setting for detector.   This is a text string usually
+              reflecting a detector setting that may have a simple or very
+              complex relationship with the value of
+              <a href="#_array_intensities.gain" >_array_intensities.gain</a>
+              and should not be used directly for computations without
+              further information.
+
+              This tag is provided for completeness in recording the settings
+              of an experiment using a detector with a panel-switch, jumper
+              or control command that allows a choice of gain settings.
+;
+    _item.name                  '<a href="#_diffrn_detector.gain_setting" >_diffrn_detector.gain_setting</a>'
+    _item.category_id             diffrn_detector
+    _item.mandatory_code          no
+    _item_type.code               text
+    save_
+
+
+save_<a name="_diffrn_detector.number_of_axes" >_diffrn_detector.number_of_axes</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_detector.number_of_axes" >_diffrn_detector.number_of_axes</a> gives the
+              number of axes of the positioner for the detector identified
+              by <a href="#_diffrn_detector.id" >_diffrn_detector.id</a>.
+
+              The word 'positioner' is a general term used in
+              instrumentation design for devices that are used to change
+              the positions of portions of apparatus by linear
+              translation, rotation or combinations of such motions.
+
+              Axes which are used to provide a coordinate system for the
+              face of an area detector should not be counted for this
+              data item.
+
+              The description of each axis should be provided by entries
+              in <a href="#diffrn_detector_axis">DIFFRN_DETECTOR_AXIS</a>.
+;
+    _item.name                  '<a href="#_diffrn_detector.number_of_axes" >_diffrn_detector.number_of_axes</a>'
+    _item.category_id             diffrn_detector
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .   1
+                                  1   1
+    _item_type.code               int
+     save_
+
+
+save_<a name="_diffrn_detector.type" >_diffrn_detector.type</a>
+    _item_description.description
+;             The make, model or name of the detector device used.
+;
+    _item.name                  '<a href="#_diffrn_detector.type" >_diffrn_detector.type</a>'
+    _item.category_id             diffrn_detector
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_detector_type'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+    _item_type.code               text
+     save_
+
+
+save_<a name="_diffrn_detector.variant" >_diffrn_detector.variant</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_detector.variant" >_diffrn_detector.variant</a> gives the variant
+              to which the given DIFFRN_DETECTOR row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to <a href="#_variant.variant" >_variant.variant</a> in the
+              <a href="#variant">VARIANT</a> category.
+;
+    _item.name                  '<a href="#_diffrn_detector.variant" >_diffrn_detector.variant</a>'
+    _item.category_id             diffrn_detector
+    _item.mandatory_code          implicit
+    _item_default.value           .
+    _item_type.code               code
+     save_
+
+
+########################
+# <a name="diffrn_detector_axis" >DIFFRN_DETECTOR_AXIS</a> #
+########################
+
+
+save_DIFFRN_DETECTOR_AXIS
+    _category.description
+;   Data items in the <a href="#diffrn_detector_axis">DIFFRN_DETECTOR_AXIS</a> category associate
+    axes with detectors.
+;
+    _category.id                   diffrn_detector_axis
+    _category.mandatory_code       no
+<div id="print_NX_diffrn_detector_axis" style="display:block">   #_category.NX_mapping_details in online version <a href="javascript:open_close2('online_NX_diffrn_detector_axis','print_NX_diffrn_detector_axis');">+/-</a>
+</div><div id="online_NX_diffrn_detector_axis" style="display:none">    _category.NX_mapping_details                  #<a href="javascript:open_close2('online_NX_diffrn_detector_axis','print_NX_diffrn_detector_axis');">+/-</a>
+;
+
+    _diffrn_detector_axis.axis_id AXISID --> 
+    _diffrn_detector_axis.detector_id DETECTORNAME -->
+        /instrument:NXinstrument
+         /DETECTORNAME:NXdetector_group
+         /DETECTORELEMENTNAME:NXdetector
+            /transformations:NXtransformations
+              /AXISID=[]
+
+This information normally will duplicate information obtained from 
+the ARRAY_STRUCTURE_LIST_AXIS.
+;
+</div>
+     loop_
+    _category_key.name          '<a href="#_diffrn_detector_axis.detector_id" >_diffrn_detector_axis.detector_id</a>'
+                                '<a href="#_diffrn_detector_axis.axis_id" >_diffrn_detector_axis.axis_id</a>'
+                                '<a href="#_diffrn_detector_axis.variant" >_diffrn_detector_axis.variant</a>'
+     loop_
+    _category_group.id           'inclusive_group'
+                                 'diffrn_group'
+     save_
+
+
+save_<a name="_diffrn_detector_axis.axis_id" >_diffrn_detector_axis.axis_id</a>
+    _item_description.description
+;             This data item is a pointer to <a href="#_axis.id" >_axis.id</a> in
+               the AXIS category.
+;
+    _item.name                  '<a href="#_diffrn_detector_axis.axis_id">_diffrn_detector_axis.axis_id</a>'
+    _item.category_id             diffrn_detector_axis
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+
+save_<a name="_diffrn_detector_axis.detector_id" >_diffrn_detector_axis.detector_id</a>
+    _item_description.description
+;             This data item is a pointer to <a href="#_diffrn_detector.id" >_diffrn_detector.id</a> in
+              the <a href="#DIFFRN_DETECTOR">DIFFRN_DETECTOR</a> category.
+
+              This item was previously named _diffrn_detector_axis.id
+              which is now a deprecated name.  The old name is
+              provided as an alias but should not be used for new work.
+;
+    _item.name                  '<a href="#_diffrn_detector_axis.detector_id" >_diffrn_detector_axis.detector_id</a>'
+    _item.category_id             diffrn_detector_axis
+    _item.mandatory_code          yes
+    _item_aliases.alias_name    '_diffrn_detector_axis.id'
+    _item_aliases.dictionary      cif_img.dic
+    _item_aliases.version         1.0
+    _item_type.code               code
+     save_
+
+
+save_<a name="_diffrn_detector_axis.variant" >_diffrn_detector_axis.variant</a>
+    _item_description.description
+;            The value of <a href="#_diffrn_detector_axis.variant" >_diffrn_detector_axis.variant</a> gives the variant
+             to which the given DIFFRN_DETECTOR_AXIS row is related.
+
+             If this value is not given, the variant is assumed to be
+             the default null variant.
+
+             This item is a pointer to <a href="#_variant.variant" >_variant.variant</a> in the
+             <a href="#variant">VARIANT</a> category.
+;
+    _item.name                  '<a href="#_diffrn_detector_axis.variant" >_diffrn_detector_axis.variant</a>'
+    _item.category_id             diffrn_detector_axis
+    _item.mandatory_code          implicit
+    _item_default.value           .
+    _item_type.code               code
+     save_
+
+
+###########################
+# <a name="diffrn_detector_element">DIFFRN_DETECTOR_ELEMENT</a> #
+###########################
+
+
+save_DIFFRN_DETECTOR_ELEMENT
+    _category.description
+;   Data items in the <a href="#diffrn_detector_element">DIFFRN_DETECTOR_ELEMENT</a> category record
+    the details about spatial layout and other characteristics
+    of each element of a detector which may have multiple elements.
+
+    In most cases, giving more detailed information
+    in <a href="#array_structure_list">ARRAY_STRUCTURE_LIST</a> and <a href="#array_structure_list_axis">ARRAY_STRUCTURE_LIST_AXIS</a>
+    is preferable to simply providing the centre of the
+    detector element.
+;
+    _category.id                   diffrn_detector_element
+    _category.mandatory_code       no
+<div id="print_NX_diffrn_detector_element" style="display:block">   #_category.NX_mapping_details in online version <a href="javascript:open_close2('online_NX_diffrn_detector_element','print_NX_diffrn_detector_element');">+/-</a>
+</div><div id="online_NX_diffrn_detector_element" style="display:none">    _category.NX_mapping_details                  #<a href="javascript:open_close2('online_NX_diffrn_detector_element','print_NX_diffrn_detector_element');">+/-</a>
+;
+
+    _diffrn_detector_element.id ELEMENTID
+    _diffrn_detector_element.detector_id DETECTORNAME
+    _diffrn_detector_element.reference_center_fast RCF
+    _diffrn_detector_element.reference_center_slow RCS
+    _diffrn_detector_element.reference_center_units UNITS
+
+    -->
+
+    /entry:NXentry
+      /CBF_scan_id="SCANID"
+      /CBF_diffrn_id="DIFFRNID"
+      /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+          /beam_center_x=[RCS]  (converted from UNITS as needed)
+            @units=mm
+          /beam_center_y=[RCF]  (converted from UNITS as needed)
+            @units=mm
+          /CBF_diffrn_detector_element__id="ELEMENTID1:ELEMENTID2:..."
+          /CBF_diffrn_detector_element__reference_center_fast=[RCF1,RCF2,...]
+          /CBF_diffrn_detector_element__reference_center_slow=[RCS1,RCS2,...]
+          /CBF_diffrn_detector_element__id="UNITS1:UNITS2:..."
+     inserts ELEMENTID into the colon-separated list of element IDs
+     inserts RCF into the array of reference centres
+     inserts RCS into the array of reference centres
+     inserts ELEMENTID into the colon-separated list of units
+
+;
+</div>
+     loop_
+    _category_key.name             '<a href="#_diffrn_detector_element.id" >_diffrn_detector_element.id</a>'
+                                   '<a href="#_diffrn_detector_element.detector_id" >_diffrn_detector_element.detector_id</a>'
+                                   '<a href="#_diffrn_detector_element.variant" >_diffrn_detector_element.variant</a>'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'array_data_group'
+                                   'diffrn_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;      Example 1. Detector d1 is composed of four CCD detector elements,
+        each 200 mm by 200 mm, arranged in a square, in the pattern
+
+                   1     2
+                      *
+                   3     4
+
+        Note that the beam centre is slightly displaced from each of the
+        detector elements, just beyond the lower right corner of 1,
+        the lower left corner of 2, the upper right corner of 3 and
+        the upper left corner of 4.  For each element, the detector
+        face coordinate system is assumed to have the fast axis
+        running from left to right and the slow axis running from
+        top to bottom with the origin at the top left corner.
+;
+;
+        loop_
+        <a href="#_diffrn_detector_element.detector_id" >_diffrn_detector_element.detector_id</a>
+        <a href="#_diffrn_detector_element.id" >_diffrn_detector_element.id</a>
+        <a href="#_diffrn_detector_elelemt.reference_center_fast" >_diffrn_detector_element.reference_center_fast</a>
+        <a href="#_diffrn_detector_element.reference_center_slow" >_diffrn_detector_element.reference_center_slow</a>
+        <a href="#_diffrn_detector_element.reference_center_units" >_diffrn_detector_element.reference_center_units</a>
+        d1     d1_ccd_1  201.5 201.5  mm
+        d1     d1_ccd_2  -1.8  201.5  mm
+        d1     d1_ccd_3  201.6  -1.4  mm
+        d1     d1_ccd_4  -1.7   -1.5  mm
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save_<a name="_diffrn_detector_element.id" >_diffrn_detector_element.id</a>
+    _item_description.description
+;            The value of <a href="#_diffrn_detector_element.id" >_diffrn_detector_element.id</a> must uniquely
+             identify each element of a detector.
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+           '<a href="#_diffrn_detector_element.id" >_diffrn_detector_element.id</a>'
+           diffrn_detector_element
+           yes
+    _item_type.code               code
+     loop_
+    _item_linked.child_name
+    _item_linked.parent_name
+           '<a href="#_diffrn_data_frame.detector_element_id" >_diffrn_data_frame.detector_element_id</a>'
+           '<a href="#_diffrn_detector_element.id" >_diffrn_detector_element.id</a>'
+
+     save_
+
+
+save_<a name="_diffrn_detector_element.detector_id" >_diffrn_detector_element.detector_id</a>
+    _item_description.description
+;             This item is a pointer to <a href="#_diffrn_detector.id" >_diffrn_detector.id</a>
+              in the <a href="#DIFFRN_DETECTOR">DIFFRN_DETECTOR</a> category.
+;
+    _item.name                  '<a href="#_diffrn_detector_element.detector_id" >_diffrn_detector_element.detector_id</a>'
+    _item.category_id             diffrn_detector_element
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+
+save_<a name="_diffrn_detector_element.reference_center_fast">_diffrn_detector_element.reference_center_fast</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_detector_element.reference_center_fast">_diffrn_detector_element.reference_center_fast</a> is 
+              the fast index axis beam centre position relative to the detector
+              element face in the units specified in the data item
+              <a href="#_diffrn_detector_element.reference_center_units">_diffrn_detector_element.reference_center_units</a> along the fast
+              axis of the detector from the centre of the first pixel to 
+              the point at which the Z-axis (which should be collinear with the 
+              beam) intersects the face of the detector, if in fact it does.   
+              At the time of the measurement all settings of the detector
+              positioner should be at their reference settings.  If more than 
+              one reference setting has been used the value given should be 
+              representative of the beam centre as determined from the ensemble 
+              of settings.
+
+              It is important to note that for measurements in mm,
+              the sense of the axis is used, rather than the sign of the 
+              pixel-to-pixel increments.
+
+;
+    _item.name '<a href="#_diffrn_detector_element.reference_center_fast">_diffrn_detector_element.reference_center_fast</a>'
+    _item.category_id             diffrn_detector_element
+    _item.mandatory_code          no
+    _item_type.code               float
+
+     save_
+
+
+save_<a name="_diffrn_detector_element.reference_center_slow">_diffrn_detector_element.reference_center_slow</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_detector_element.reference_center_slow">_diffrn_detector_element.reference_center_slow</a> is
+              the slow index axis beam centre position relative to the detector
+              element face in the units specified in the data item
+              <a href="#_diffrn_detector_element.reference_center_units">_diffrn_detector_element.reference_center_units</a> along the slow
+              axis of the detector from the centre of the first pixel to 
+              the point at which the Z-axis (which should be collinear with the
+              beam) intersects the face of the detector, if in fact it does.
+              At the time of the measurement all settings of the detector
+              positioner should be at their reference settings.  If more than
+              one reference setting has been used the value given should be 
+              representative of the beam centre as determined from the ensemble
+              of settings.
+
+              It is important to note that the sense of the axis is used,
+              rather than the sign of the pixel-to-pixel increments.
+;
+    _item.name '<a href="#_diffrn_detector_element.reference_center_slow">_diffrn_detector_element.reference_center_slow</a>'
+    _item.category_id             diffrn_detector_element
+    _item.mandatory_code          no
+    _item_type.code               float
+     save_
+
+
+save_<a name="_diffrn_detector_element.reference_center_units">_diffrn_detector_element.reference_center_units</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_detector_element.reference_center_units">_diffrn_detector_element.reference_center_units</a>
+              specifies the units in which the values of 
+              <a href="#_diffrn_detector_element.reference_center_fast">_diffrn_detector_element.reference_center_fast</a> and
+              <a href="#_diffrn_detector_element.reference_center_slow">_diffrn_detector_element.reference_center_slow</a>
+              are presented.  The default is 'mm' for millimetres.  The 
+              alternatives are 'pixels' and 'bins'.  In all cases the
+              centre distances are measured from the centre of the
+              first pixel, i.e. in a 2x2 binning, the measuring origin
+              is offset from the centres of the bins by one half pixel
+              towards the first pixel.
+
+              If 'bins' is specified, the data in
+                  <a href="#_array_intensities.pixel_fast_bin_size" >_array_intensities.pixel_fast_bin_size</a>,
+                  <a href="#_array_intensities.pixel_slow_bin_size" >_array_intensities.pixel_slow_bin_size</a>, and
+                  <a href="#_array_intensities.pixel_binning_method" >_array_intensities.pixel_binning_method</a>
+              are used to define the binning scheme.
+;
+    _item.name '<a href="#_diffrn_detector_element.reference_center_units">_diffrn_detector_element.reference_center_units</a>'
+    _item.category_id             diffrn_detector_element
+    _item.mandatory_code          no
+    _item_type.code               code
+     loop_
+    _item_enumeration.value
+    _item_enumeration.detail
+                                   mm        'millimetres'
+                                   pixels    'detector pixels'
+                                   bins      'detector bins'
+     save_
+
+
+save_<a name="_diffrn_detector_element.variant" >_diffrn_detector_element.variant</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_detector_element.variant" >_diffrn_detector_element.variant</a> gives the variant
+              to which the given DIFFRN_DETECTOR_ELEMENT row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to <a href="#_variant.variant" >_variant.variant</a> in the
+               <a href="#variant">VARIANT</a> category.
+;
+    _item.name                  '<a href="#_diffrn_detector_element.variant" >_diffrn_detector_element.variant</a>'
+    _item.category_id             diffrn_detector_element
+    _item.mandatory_code          implicit
+    _item_default.value           .
+    _item_type.code               code
+     save_
+
+
+########################
+## <a name="diffrn_measurement" >DIFFRN_MEASUREMENT</a> ##
+########################
+
+
+save_DIFFRN_MEASUREMENT
+    _category.description
+;   Data items in the <a href="#diffrn_measurement">DIFFRN_MEASUREMENT</a> category record details
+    about the device used to orient and/or position the crystal
+    during data measurement and the manner in which the
+    diffraction data were measured.
+;
+    _category.id                  diffrn_measurement
+    _category.mandatory_code      no
+<div id="print_NX_diffrn_measurement" style="display:block">   #_category.NX_mapping_details in online version <a href="javascript:open_close2('online_NX_diffrn_measurement','print_NX_diffrn_measurement');">+/-</a>
+</div><div id="online_NX_diffrn_measurement" style="display:none">    _category.NX_mapping_details                  #<a href="javascript:open_close2('online_NX_diffrn_measurement','print_NX_diffrn_measurement');">+/-</a>
+;
+
+    _diffrn_measurement.diffrn_id DIFFRNID
+    _diffrn_measurement.details DETAILS
+    _diffrn_measurement.device DEVICE
+    _diffrn_measurement.device_details DEVDETAILS
+    _diffrn_measurement.device_type DEVTYPE
+    _diffrn_measurement.id GONIOMETER
+    _diffrn_measurement.method METHOD
+    _diffrn_measurement.number_of_axes NUMBER
+    _diffrn_measurement.sample_detector_distance DIST
+    _diffrn_measurement.sample_detector_distance_derived DISTDERIVED
+    _diffrn_measurement.sample_detector_voffset VOFST
+    _diffrn_measurement.specimen_support SPECSPRT
+
+    -->
+
+    /entry:NXentry
+      /CBF_scan_id="SCANID
+      /CBF_diffrn_id="DIFFRNID"
+      /instrument:NXinstrument
+      /CBF_diffrn_measurement__GONIOMETER:NXgoniometer
+        /details="DETAILS"
+        /local_name="DEVICE"
+        /description="DEVDETAILS"
+        /type="DEVTYPE"
+        /CBF_diffrn_measurement__method="METHOD"
+          /number_of_axes=NUMBER
+        /CBF_diffrn_measurement__specimen_support="SPECSPRT"
+      /CBF_diffrn_detector__DETECTORNAME:NXdetector
+        /distance=DIST
+          @units="mm"
+        /distance_derived=DISTDERIVED
+        /CBF_diffrn_measurement__sample_detector_voffset=VOFST
+          @units="mm"    
+;
+</div>     loop_
+    _category_key.name          '<a href="#_diffrn_measurement.device" >_diffrn_measurement.device</a>'
+                                '<a href="#_diffrn_measurement.diffrn_id" >_diffrn_measurement.diffrn_id</a>'
+                                '<a href="#_diffrn_measurement.id" >_diffrn_measurement.id</a>'
+                                '<a href="#_diffrn_measurement.variant" >_diffrn_measurement.variant</a>'
+     loop_
+    _category_group.id           'inclusive_group'
+                                 'diffrn_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;    Example 1. based on PDB entry 5HVP and laboratory records for the
+                 structure corresponding to PDB entry 5HVP
+;
+;
+    <a href="#_diffrn_measurement.diffrn_id" >_diffrn_measurement.diffrn_id</a>          'd1'
+    <a href="#_diffrn_measurement.device" >_diffrn_measurement.device</a>             '3-circle camera'
+    <a href="#_diffrn_measurement.device_type" >_diffrn_measurement.device_type</a>        'Supper model <b>X</b>'
+    <a href="#_diffrn_measurement.device_details" >_diffrn_measurement.device_details</a>     'none'
+    <a href="#_diffrn_measurement.method" >_diffrn_measurement.method</a>             'omega scan'
+    <a href="#_diffrn_measurement.details" >_diffrn_measurement.details</a>
+    ; 440 frames, 0.20 degrees, 150 sec, detector distance 12 cm, 
+      detector angle 22.5 degrees
+    ;
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;     Example 2. based on data set TOZ of Willis, Beckwith &amp; Tozer
+                  [Acta Cryst. (1991), C47, 2276-2277].
+;
+;
+    <a href="#_diffrn_measurement.diffrn_id" >_diffrn_measurement.diffrn_id</a>       's1'
+    <a href="#_diffrn_measurement.device_type" >_diffrn_measurement.device_type</a>     'Philips PW1100/20 diffractometer'
+    <a href="#_diffrn_measurement.method" >_diffrn_measurement.method</a>          'theta/2theta (\q/2\q)'
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save_<a name="_diffrn_measurement.device" >_diffrn_measurement.device</a>
+    _item_description.description
+;             The general class of goniometer or device used to support
+              and orient the specimen.
+
+              If the value of <a href="#_diffrn_measurement.device">_diffrn_measurement.device</a> is not given,
+              it is implicitly equal to the value of
+              <a href="#_diffrn_measurement.diffrn_id">_diffrn_measurement.diffrn_id</a>.
+
+              Either <a href="#_diffrn_measurement.device">_diffrn_measurement.device</a> or
+              <a href="#_diffrn_measurement.id">_diffrn_measurement.id</a> may be used to link to other
+              categories.  If the experimental setup admits multiple
+              devices, then <a href="#_diffrn_measurement.id">_diffrn_measurement.id</a> is used to provide
+              a unique link.
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+             '<a href="#_diffrn_measurement.device">_diffrn_measurement.device</a>'  diffrn_measurement      implicit
+             '<a href="#_diffrn_measurement_axis.measurement_device">_diffrn_measurement_axis.measurement_device</a>'
+                                           diffrn_measurement_axis implicit
+     loop_
+    _item_linked.child_name
+    _item_linked.parent_name
+             '<a href="#_diffrn_measurement_axis.measurement_device">_diffrn_measurement_axis.measurement_device</a>'
+                                         '_diffrn_measurement.device'
+    _item_aliases.alias_name    '_diffrn_measurement_device'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+    _item_type.code               text
+     loop_
+    _item_examples.case          '3-circle camera'
+                                 '4-circle camera'
+                                 'kappa-geometry camera'
+                                 'oscillation camera'
+                                 'precession camera'
+     save_
+
+
+save_<a name="_diffrn_measurement.device_details" >_diffrn_measurement.device_details</a>
+    _item_description.description
+;             A description of special aspects of the device used to
+              measure the diffraction intensities.
+;
+    _item.name                  '<a href="#_diffrn_measurement.device_details" >_diffrn_measurement.device_details</a>'
+    _item.category_id             diffrn_measurement
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_measurement_device_details'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+    _item_type.code               text
+    _item_examples.case
+;                                 commercial goniometer modified locally to
+                                  allow for 90\% \t arc
+;
+     save_
+
+
+save_<a name="_diffrn_measurement.device_type" >_diffrn_measurement.device_type</a>
+    _item_description.description
+;             The make, model or name of the measurement device
+              (goniometer) used.
+;
+    _item.name                  '<a href="#_diffrn_measurement.device_type" >_diffrn_measurement.device_type</a>'
+    _item.category_id             diffrn_measurement
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_measurement_device_type'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+    _item_type.code               text
+     loop_
+    _item_examples.case          'Supper model q'
+                                 'Huber model r'
+                                 'Enraf-Nonius model s'
+                                 'home-made'
+     save_
+
+
+save_<a name="_diffrn_measurement.diffrn_id" >_diffrn_measurement.diffrn_id</a>
+    _item_description.description
+;             This data item is a pointer to <a href="#_diffrn.id">_diffrn.id</a> in the DIFFRN
+              category.
+;
+    _item.name                  '<a href="#_diffrn_measurement.diffrn_id" >_diffrn_measurement.diffrn_id</a>'
+    _item.category_id             diffrn_measurement
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+
+save_<a name="_diffrn_measurement.details" >_diffrn_measurement.details</a>
+    _item_description.description
+;             A description of special aspects of the intensity
+              measurement.
+;
+    _item.name                  '<a href="#_diffrn_measurement.details" >_diffrn_measurement.details</a>'
+    _item.category_id             diffrn_measurement
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_measurement_details'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+    _item_type.code               text
+    _item_examples.case
+;                                 440 frames, 0.20 degrees, 150 sec, detector
+                                  distance 12 cm, detector angle 22.5 degrees
+;
+     save_
+
+
+save_<a name="_diffrn_measurement.id" >_diffrn_measurement.id</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_measurement.id" >_diffrn_measurement.id</a> must uniquely identify
+              the set of mechanical characteristics of the device used to
+              orient and/or position the sample used during the collection
+              of each diffraction data set.
+
+              If the value of <a href="#_diffrn_measurement.id" >_diffrn_measurement.id</a> is not given, it is
+              implicitly equal to the value of
+              <a href="#_diffrn_measurement.diffrn_id" >_diffrn_measurement.diffrn_id</a>.
+
+              Either <a href="#_diffrn_measurement.device">_diffrn_measurement.device</a> or
+              <a href="#_diffrn_measurement.id">_diffrn_measurement.id</a> may be used to link to other
+              categories.  If the experimental setup admits multiple
+              devices, then <a href="#_diffrn_measurement.id">_diffrn_measurement.id</a> is used to provide
+              a unique link.
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+             '<a href="#_diffrn_measurement.id" >_diffrn_measurement.id</a>'      diffrn_measurement      implicit
+             '<a href="#_diffrn_measurement_axis.measurement_id" >_diffrn_measurement_axis.measurement_id</a>'
+                                           diffrn_measurement_axis implicit
+     loop_
+    _item_linked.child_name
+    _item_linked.parent_name
+             '<a href="#_diffrn_measurement_axis.measurement_id" >_diffrn_measurement_axis.measurement_id</a>'
+                                         '<a href="#_diffrn_measurement.id" >_diffrn_measurement.id</a>'
+
+    _item_type.code               code
+     save_
+
+
+save_<a name="_diffrn_measurement.method" >_diffrn_measurement.method</a>
+    _item_description.description
+;             Method used to measure intensities.
+;
+    _item.name                  '<a href="#_diffrn_measurement.method" >_diffrn_measurement.method</a>'
+    _item.category_id             diffrn_measurement
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_measurement_method'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+    _item_type.code               text
+    _item_examples.case
+      'profile data from theta/2theta (\q/2\q) scans'
+     save_
+
+
+save_<a name="_diffrn_measurement.number_of_axes" >_diffrn_measurement.number_of_axes</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_measurement.number_of_axes" >_diffrn_measurement.number_of_axes</a> gives the
+              number of axes of the positioner for the goniometer or
+              other sample orientation or positioning device identified
+              by <a href="#_diffrn_measurement.id" >_diffrn_measurement.id</a>.
+
+              The description of the axes should be provided by entries in
+              <a href="#diffrn_measurement_axis">DIFFRN_MEASUREMENT_AXIS</a>.
+;
+    _item.name                  '<a href="#_diffrn_measurement.number_of_axes" >_diffrn_measurement.number_of_axes</a>'
+    _item.category_id             diffrn_measurement
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .   1
+                                  1   1
+    _item_type.code               int
+     save_
+
+
+save_<a name="_diffrn_measurement.sample_detector_distance" >_diffrn_measurement.sample_detector_distance</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_measurement.sample_detector_distance" >_diffrn_measurement.sample_detector_distance</a> gives
+              the unsigned distance in millimetres from the sample to the 
+              detector along the beam.  Normally this distance is derived
+              from the axis settings.
+;
+    _item.name                  '<a href="#_diffrn_measurement.sample_detector_distance" >_diffrn_measurement.sample_detector_distance</a>'
+    _item.category_id             diffrn_measurement
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .   0.0
+    _item_type.code               float
+    _item_units.code              'millimetres'
+     save_
+
+save_<a name="_diffrn_measurement.sample_detector_distance_derived" >_diffrn_measurement.sample_detector_distance_derived</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_measurement.sample_detector_distance_derived" >_diffrn_measurement.sample_detector_distance_derived</a>
+              is assumed to be 'yes', i.e. that value of 
+              <a href="#_diffrn_measurement.sample_detector_distance">_diffrn_measurement.sample_detector_distance<a>
+              is derived from the axis settings rather than measured.               
+;
+    _item.name                  '<a href="#_diffrn_measurement.sample_detector_distance_derived" >_diffrn_measurement.sample_detector_distance_derived</a>'
+    _item.category_id             diffrn_measurement
+    _item.mandatory_code          no
+    _item_type.code               ucode
+    _item_default.value           'yes'
+     save_
+
+
+save_<a name="_diffrn_measurement.sample_detector_voffset" >_diffrn_measurement.sample_detector_voffset</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_measurement.sample_detector_voffset" >_diffrn_measurement.sample_detector_voffset</a> gives
+              the signed distance in millimetres in the vertical
+              direction (positive for up) from the centre of
+              the beam to the centre of the detector. 
+;
+    _item.name                  '<a href="#_diffrn_measurement.sample_detector_voffset" >_diffrn_measurement.sample_detector_voffset</a>'
+    _item.category_id             diffrn_measurement
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .   .
+                                  .   .
+    _item_type.code               float
+    _item_units.code              'millimetres'
+     save_
+
+
+save_<a name="_diffrn_measurement.specimen_support" >_diffrn_measurement.specimen_support</a>
+    _item_description.description
+;             The physical device used to support the crystal during data
+              collection.
+;
+    _item.name                  '<a href="#_diffrn_measurement.specimen_support" >_diffrn_measurement.specimen_support</a>'
+    _item.category_id             diffrn_measurement
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_measurement_specimen_support'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+    _item_type.code               text
+     loop_
+    _item_examples.case          'glass capillary'
+                                 'quartz capillary'
+                                 'fiber'
+                                 'metal loop'
+     save_
+
+
+save_<a name="_diffrn_measurement.variant" >_diffrn_measurement.variant</a>
+    _item_description.description
+;            The value of <a href="#_diffrn_measurement.variant" >_diffrn_measurement.variant</a> gives the variant
+             to which the given DIFFRN_MEASUREMENT row is related.
+
+             If this value is not given, the variant is assumed to be
+             the default null variant.
+
+             This item is a pointer to <a href="#_variant.variant" >_variant.variant</a> in the
+             <a href="#variant">VARIANT</a> category.
+;
+    _item.name                  '<a href="#_diffrn_measurement.variant" >_diffrn_measurement.variant</a>'
+    _item.category_id             diffrn_measurement
+    _item.mandatory_code          implicit
+    _item_default.value           .
+    _item_type.code               code
+     save_
+
+
+###########################
+# <a name="diffrn_measurement_axis">DIFFRN_MEASUREMENT_AXIS</a> #
+###########################
+
+
+save_DIFFRN_MEASUREMENT_AXIS
+    _category.description
+;   Data items in the <a href="#diffrn_measurement_axis">DIFFRN_MEASUREMENT_AXIS</a> category associate
+    axes with goniometers.
+;
+    _category.id                   diffrn_measurement_axis
+    _category.mandatory_code       no
+<div id="print_NX_diffrn_measurement_axis" style="display:block">   #_category.NX_mapping_details in online version <a href="javascript:open_close2('online_NX_diffrn_measurement_axis','print_NX_diffrn_measurement_axis');">+/-</a>
+</div><div id="online_NX_diffrn_measurement_axis" style="display:none">    _category.NX_mapping_details                  #<a href="javascript:open_close2('online_NX_diffrn_measurement_axis','print_NX_diffrn_measurement_axis');">+/-</a>
+;
+
+    _diffrn_measurement_axis.axis_id AXISID
+    _diffrn_measurement_axis.measurement_device DEVICE
+    _diffrn_measurement_axis.measurement_id GONIOMETER
+
+    -->
+
+    /entry:NXentry
+      /CBF_scan_id="SCANID
+      /CBF_diffrn_id="DIFFRNID"
+      /sample:NXsample
+        /transformations:NXtransformations      
+          /AXISID=[]      
+      /instrument:NXinstrument
+        /CBF_diffrn_measurement__GONIOMETER:NXgoniometer
+          /CBF_diffrn_measurement__device="DEVICE"
+
+
+;
+</div>     loop_
+    _category_key.name
+                              '<a href="#_diffrn_measurement_axis.measurement_device" >_diffrn_measurement_axis.measurement_device</a>'
+                              '<a href="#_diffrn_measurement_axis.measurement_id" >_diffrn_measurement_axis.measurement_id</a>'
+                              '<a href="#_diffrn_measurement_axis.axis_id" >_diffrn_measurement_axis.axis_id</a>'
+                              '<a href="#_diffrn_measurement_axis.variant" >_diffrn_measurement_axis.variant</a>'
+     loop_
+    _category_group.id        'inclusive_group'
+                              'diffrn_group'
+     save_
+
+
+save_<a name="_diffrn_measurement_axis.axis_id" >_diffrn_measurement_axis.axis_id</a>
+    _item_description.description
+;             This data item is a pointer to <a href="#_axis.id" >_axis.id</a> in
+              the <a href="#AXIS">AXIS</a> category.
+;
+    _item.name                  '<a href="#_diffrn_measurement_axis.axis_id" >_diffrn_measurement_axis.axis_id</a>'
+    _item.category_id             diffrn_measurement_axis
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+
+save_<A name="_diffrn_measurement_axis.measurement_device">_diffrn_measurement_axis.measurement_device</a>
+    _item_description.description
+;             This data item is a pointer to <a href="#_diffrn_measurement.device">_diffrn_measurement.device</a>
+              in the <a href="#diffrn_measurement">DIFFRN_MEASUREMENT</a> category.
+;
+    _item.name
+      '<a href="#_diffrn_measurement_axis.measurement_device">_diffrn_measurement_axis.measurement_device</a>'
+    _item.category_id             diffrn_measurement_axis
+    _item.mandatory_code          implicit
+    _item_type.code               text
+     save_
+
+
+save_<a name="_diffrn_measurement_axis.measurement_id">_diffrn_measurement_axis.measurement_id</a>
+    _item_description.description
+;             This data item is a pointer to <a href="#_diffrn_measurement.id">_diffrn_measurement.id</a> in
+              the <a href="#diffrn_measurement">DIFFRN_MEASUREMENT</a> category.
+
+              This item was previously named _diffrn_measurement_axis.id,
+              which is now a deprecated name.  The old name is
+              provided as an alias but should not be used for new work.
+;
+    _item.name                  '<a href="#_diffrn_measurement_axis.measurement_id">_diffrn_measurement_axis.measurement_id</a>'
+    _item.category_id             diffrn_measurement_axis
+    _item.mandatory_code          implicit
+    _item_aliases.alias_name    '_diffrn_measurement_axis.id'
+    _item_aliases.dictionary      cif_img.dic
+    _item_aliases.version         1.0
+    _item_type.code               code
+     save_
+
+
+save_<a name="_diffrn_measurement_axis.variant" >_diffrn_measurement_axis.variant</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_measurement_axis.variant" >_diffrn_measurement_axis.variant</a> gives the variant
+              to which the given DIFFRN_MEASUREMENT_AXIS row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to <a href="#_variant.variant" >_variant.variant</a> in the
+              <a href="#variant">VARIANT</a> category.
+;
+    _item.name                  '<a href="#_diffrn_measurement_axis.variant" >_diffrn_measurement_axis.variant</a>'
+    _item.category_id             diffrn_measurement_axis
+    _item.mandatory_code          implicit
+    _item_default.value           .
+    _item_type.code               code
+     save_
+
+
+####################
+# <a name="diffrn_radiation">DIFFRN_RADIATION</a> #
+####################
+
+
+save_DIFFRN_RADIATION
+    _category.description
+;             Data items in the <a href="#diffrn_radiation">DIFFRN_RADIATION</a> category describe
+              the radiation used for measuring diffraction intensities,
+              its collimation and monochromatization before the sample.
+
+              Post-sample treatment of the beam is described by data
+              items in the <a href="#DIFFRN_DETECTOR">DIFFRN_DETECTOR</a> category.
+;
+    _category.id                  diffrn_radiation
+    _category.mandatory_code      no
+<div id="print_NX_diffrn_radiation" style="display:block">   #_category.NX_mapping_details in online version <a href="javascript:open_close2('online_NX_diffrn_radiation','print_NX_diffrn_radiation');">+/-</a>
+</div><div id="online_NX_diffrn_radiation" style="display:none">    _category.NX_mapping_details                  #<a href="javascript:open_close2('online_NX_diffrn_radiation','print_NX_diffrn_radiation');">+/-</a>
+;
+
+    _diffrn_radiation.collimation    COLLIMATION
+    _diffrn_radiation.diffrn_id      DIFFRNID
+    _diffrn_radiation.div_x_source   DIVX
+    _diffrn_radiation.div_y_source   DIVY
+    _diffrn_radiation.div_x_y_source DIVXY
+    _diffrn_radiation.filter_edge'   ABSEDGE
+    _diffrn_radiation.inhomogeneity  HWIDTH
+    _diffrn_radiation.monochromator  MONOCHROMATOR
+    _diffrn_radiation.polarisn_norm  POLNANG
+    _diffrn_radiation.polarisn_ratio POLRAT
+    _diffrn_radiation.polarizn_source_norm   POLSNANG
+    _diffrn_radiation.polarizn_source_ratio  POLSRAT
+    _diffrn_radiation.polarizn_Stokes_I  SVECI
+    _diffrn_radiation.polarizn_Stokes_Q  SVECQ
+    _diffrn_radiation.polarizn_Stokes_U  SVECU
+    _diffrn_radiation.polarizn_Stokes_V  SVECV
+    _diffrn_radiation.polarisn_norm_esd  POLNANGESD
+    _diffrn_radiation.polarisn_ratio_esd POLRATESD
+    _diffrn_radiation.polarizn_source_norm_esd   POLSNANGESD
+    _diffrn_radiation.polarizn_source_ratio_esd  POLSRATESD
+    _diffrn_radiation.polarizn_Stokes_I_esd  SVECIESD
+    _diffrn_radiation.polarizn_Stokes_Q_esd  SVECQESD
+    _diffrn_radiation.polarizn_Stokes_U_esd  SVECUESD
+    _diffrn_radiation.polarizn_Stokes_V_esd  SVECVESD
+    _diffrn_radiation.probe          RADIATION
+    _diffrn_radiation.type           SIEGBAHNTYPE
+    _diffrn_radiation.xray_symbol    IUPACXRAYSYMB
+    _diffrn_radiation.wavelength_id  ID
+    _diffrn_radiation_wavelength.id  ID
+    _diffrn_radiation_wavelength.wavelength    WAVELENGTH
+    _diffrn_radiation_wavelength.wt            WEIGHT
+    _diffrn_scan_frame.polarizn_Stokes_I STOKESI
+    _diffrn_scan_frame.polarizn_Stokes_Q STOKESQ
+    _diffrn_scan_frame.polarizn_Stokes_U STOKESU
+    _diffrn_scan_frame.polarizn_Stokes_V STOKESV
+    _diffrn_scan_frame.polarizn_Stokes_I_esd STOKESIESD
+    _diffrn_scan_frame.polarizn_Stokes_Q_esd STOKESQESD
+    _diffrn_scan_frame.polarizn_Stokes_U_esd STOKESUESD
+    _diffrn_scan_frame.polarizn_Stokes_V_esd STOKESVESD
+    _diffrn_scan_frame.frame_number FRAMENO
+
+    -->
+
+       /entry:NXentry
+         /CBF_scan_id="SCANID"
+         /sample:NXsample
+           /beam:NXbeam
+             /incident_divergence_x=DIVX
+               @units="degrees"
+             /incident_divergence_y=DIVY
+               @units="degrees"
+             /incident_divergence_xy=DIXXY
+               @units="degrees^2"
+             /CBF_diffrn_radiation_wavelength__wavelength_id=[WAVELENGTH_ID]
+             /incident_wavelength=[WAVELENGTH]
+               @units="A"
+             /weight=[WEIGHT]
+             /incident_polarisation_stokes_average=[SVECI,SVECQ,SVECU,SVECV]
+             /incident_polarisation_stokes_average_uncertainty=[SVECIESD,SVECQESD,SVECUESD,SVECVESD]
+             /incident_polarisation_stokes=[STOKESI,STOKESQ,STOKESU,STOKESV]
+             /incident_polarisation_stokes_uncertainty=[STOKESIESD,STOKESQESD,STOKESUESD,STOKESVESD]
+               @units="Watts/meter^2"
+             /CBF_diffrn_radiation__polarisn_norm=POLNANG
+               @units="deg"
+             /CBF_diffrn_radiation__polarisn_ratio=POLRAT
+             /CBF_diffrn_radiation__polarisn_norm_uncertainty=POLNANGESD
+               @units="deg"
+             /CBF_diffrn_radiation__polarisn_ratio_uncertainty=POLRATESD
+             /CBF_diffrn_radiation__polarisn_source_norm=POLSNANG
+               @units="deg"
+             /CBF_diffrn_radiation__polarizn_source_ratio=POLSRAT
+             /CBF_diffrn_radiation__polarisn_source_norm_uncertainty=POLSNANGESD
+               @units="deg"
+             /CBF_diffrn_radiation__polarizn_source_ratio_uncertainty=POLSRATESD
+             /CBF_diffrn_radiation__filter_edge=ABSEDGE
+                @units="angstroms"
+             /CBF_diffrn_radiation__inhomogeneity=HWIDTH
+                @units="mm"
+         /instrument:NXinstrument
+           /monochromator:NXmonochromator
+             /description="MONOCHROMATOR"
+           /source:NXsource
+             /probe="RADIATION"
+             /CBF_diffrn_radiation__type="SIEGBAHNTYPE"
+             /CBF_diffrn_radiation__xray_symbol="IUPACXRAYSYMB"
+
+         With the incident_polarisation_stokes array indexed by FRAMENO
+
+;
+
+</div>     loop_
+    _category_key.name          '<a href="#_diffrn_radiation.diffrn_id">_diffrn_radiation.diffrn_id</a>'
+                                '<a href="#_diffrn_radiation.variant">_diffrn_radiation.variant</a>'
+     loop_
+    _category_group.id           'inclusive_group'
+                                 'diffrn_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;   Example 1. based on PDB entry 5HVP and laboratory records for the
+                structure corresponding to PDB entry 5HVP
+;
+;
+    <a href="#_diffrn_radiation.diffrn_id">_diffrn_radiation.diffrn_id</a>            'set1'
+
+    <a href="#_diffrn_radiation.collimation">_diffrn_radiation.collimation</a>          '0.3 mm double pinhole'
+    <a href="#_diffrn_radiation.monochromator">_diffrn_radiation.monochromator</a>        'graphite'
+    <a href="#_diffrn_radiation.type">_diffrn_radiation.type</a>                 'Cu K\a'
+    <a href="#_diffrn_radiation.wavelength_id">_diffrn_radiation.wavelength_id</a>         1
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;    Example 2. based on data set TOZ of Willis, Beckwith &amp; Tozer
+                [Acta Cryst. (1991), C47, 2276-2277].
+;
+;
+    <a href="#_diffrn_radiation.wavelength_id">_diffrn_radiation.wavelength_id</a>    1
+    <a href="#_diffrn_radiation.type">_diffrn_radiation.type</a>             'Cu K\a'
+    <a href="#_diffrn_radiation.monochromator">_diffrn_radiation.monochromator</a>    'graphite'
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save_<a name="_diffrn_radiation.beam_width">_diffrn_radiation.beam_width</a>
+    _item_description.description
+;             Full width at half maximum of the beam incident on the sample
+              in the plane of polarization (or horizontally if unpolarized).
+;
+    _item.name                  '<a href="#_diffrn_radiation.beam_width">_diffrn_radiation.beam_width</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_type.code               float
+    _item_units.code              micrometres
+     save_
+
+
+save_<a name="_diffrn_radiation.beam_height">_diffrn_radiation.beam_height</a>
+    _item_description.description
+;             Full width at half maximum of the beam incident on the sample
+              orthogonal to the plane of polarization (or vertically
+              if unpolarized).
+;
+    _item.name                  '<a href="#_diffrn_radiation.beam_width">_diffrn_radiation.beam_width</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_type.code               float
+    _item_units.code              micrometres
+     save_
+
+
+save_<a name="_diffrn_radiation.flux">_diffrn_radiation.beam_flux</a>
+    _item_description.description
+;             The average flux integrated over the beam incident on the sample.
+;
+    _item.name                  '<a href="#_diffrn_radiation.beam_flux">_diffrn_radiation.beam_flux</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_type.code               float
+    _item_units.code              'photons per second'
+     save_
+
+
+save_<A name="_diffrn_radiation.collimation">_diffrn_radiation.collimation</a>
+    _item_description.description
+;             The collimation or focusing applied to the radiation.
+;
+    _item.name                  '<a href="#_diffrn_radiation.collimation">_diffrn_radiation.collimation</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_radiation_collimation'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+    _item_type.code               text
+     loop_
+    _item_examples.case          '0.3 mm double-pinhole'
+                                 '0.5 mm'
+                                 'focusing mirrors'
+     save_
+
+
+save_<A name="_diffrn_radiation.diffrn_id">_diffrn_radiation.diffrn_id</a>
+    _item_description.description
+;             This data item is a pointer to <a href="#_diffrn.id">_diffrn.id</a> in the DIFFRN
+              category.
+;
+    _item.name                  '<a href="#_diffrn_radiation.diffrn_id">_diffrn_radiation.diffrn_id</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+
+save_<a name="_diffrn_radiation.div_x_source">_diffrn_radiation.div_x_source</a>
+    _item_description.description
+;             Beam crossfire in degrees parallel to the laboratory <b>X</b> axis
+              (see <a href="#AXIS">AXIS</a> category).
+
+              This is a characteristic of the X-ray beam as it illuminates
+              the sample (or specimen) after all monochromation and
+              collimation.
+
+              This is the standard uncertainty (estimated standard
+              deviation, e.s.d.)  of the directions of photons in 
+              the XZ plane around the mean source beam direction.
+
+              Note that for some synchrotrons this value is specified
+              in milliradians, in which case a conversion is needed.
+              To convert a value in milliradians to a value in degrees,
+              multiply by 0.180 and divide by \p.
+;
+    _item.name                  '<a href="#_diffrn_radiation.div_x_source">_diffrn_radiation.div_x_source</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_type.code               float
+    _item_units.code              degrees
+     save_
+
+
+save_<A name="_diffrn_radiation.div_y_source">_diffrn_radiation.div_y_source</a>
+    _item_description.description
+;             Beam crossfire in degrees parallel to the laboratory <b>Y</b> axis
+              (see <a href="#AXIS">AXIS</a> category).
+
+              This is a characteristic of the X-ray beam as it illuminates
+              the sample (or specimen) after all monochromation and
+              collimation.
+
+              This is the standard uncertainty (estimated standard deviation,
+              e.s.d.) of the directions of photons in the YZ plane around 
+              the mean source beam direction.
+
+              Note that for some synchrotrons this value is specified
+              in milliradians, in which case a conversion is needed.
+              To convert a value in milliradians to a value in degrees,
+              multiply by 0.180 and divide by \p.
+;
+    _item.name                  '<a href="#_diffrn_radiation.div_y_source">_diffrn_radiation.div_y_source</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_type.code               float
+    _item_units.code              degrees
+    _item_default.value           0.0
+     save_
+
+
+save_<A name="_diffrn_radiation.div_x_y_source">_diffrn_radiation.div_x_y_source</a>
+    _item_description.description
+;             Beam crossfire correlation in degrees squared between the
+              crossfire laboratory <b>X</b>-axis component and the crossfire
+              laboratory <b>Y</b>-axis component (see <a href="#AXIS">AXIS</a> category).
+
+              This is a characteristic of the X-ray beam as it illuminates
+              the sample (or specimen) after all monochromation and
+              collimation.
+
+              This is the mean of the products of the deviations of the
+              direction of each photon in XZ plane times the deviations
+              of the direction of the same photon in the YZ plane
+              around the mean source beam direction.  This will be zero
+              for uncorrelated crossfire.
+
+              Note that for some synchrotrons, this value is specified in
+              milliradians squared, in which case a conversion is
+              needed. To convert a value in milliradians squared to a value
+              in degrees squared, multiply by 0.180^2^ and divide by \p^2^.
+;
+    _item.name                  '<a href="#_diffrn_radiation.div_x_y_source">_diffrn_radiation.div_x_y_source</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_type.code               float
+    _item_units.code              degrees_squared
+    _item_default.value           0.0
+     save_
+
+
+save_<A name="_diffrn_radiation.filter_edge">_diffrn_radiation.filter_edge</a>
+    _item_description.description
+;              Absorption edge in \%angstr\"oms of the radiation filter used.
+;
+    _item.name                  '<a href="#_diffrn_radiation.filter_edge">_diffrn_radiation.filter_edge</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_radiation_filter_edge'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+     loop_
+    _item_range.maximum
+    _item_range.minimum            .    0.0
+                                  0.0   0.0
+    _item_type.code               float
+    _item_units.code              angstroms
+     save_
+
+
+save_<A name="_diffrn_radiation.inhomogeneity">_diffrn_radiation.inhomogeneity</a>
+    _item_description.description
+;             Half-width in millimetres of the incident beam in the
+              direction perpendicular to the diffraction plane.
+;
+    _item.name                  '<a href="#_diffrn_radiation.inhomogeneity">_diffrn_radiation.inhomogeneity</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_radiation_inhomogeneity'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+     loop_
+    _item_range.maximum
+    _item_range.minimum            .    0.0
+                                  0.0   0.0
+    _item_type.code               float
+    _item_units.code              millimetres
+     save_
+
+
+save_<A name="_diffrn_radiation.monochromator">_diffrn_radiation.monochromator</a>
+    _item_description.description
+;             The method used to obtain monochromatic radiation. If a
+              monochromator crystal is used, the material and the
+              indices of the Bragg reflection are specified.
+;
+    _item.name                  '<a href="#_diffrn_radiation.monochromator">_diffrn_radiation.monochromator</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_radiation_monochromator'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+    _item_type.code               text
+     loop_
+    _item_examples.case          'Zr filter'
+                                 'Ge 220'
+                                 'none'
+                                 'equatorial mounted graphite'
+     save_
+
+
+save_<A name="_diffrn_radiation.polarisn_norm">_diffrn_radiation.polarisn_norm</a>
+    _item_description.description
+;             The angle in degrees, as viewed from the specimen, between the
+              perpendicular component of the polarization and the diffraction
+              plane. See _diffrn_radiation_polarisn_ratio.
+;
+    _item.name                  '<a href="#_diffrn_radiation.polarisn_norm">_diffrn_radiation.polarisn_norm</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_radiation_polarisn_norm'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+     loop_
+    _item_range.maximum
+    _item_range.minimum           90.0  90.0
+                                  90.0 -90.0
+                                 -90.0 -90.0
+    _item_type.code               float
+    _item_units.code              degrees
+     save_
+
+
+save_<A name="_diffrn_radiation.polarisn_norm_esd">_diffrn_radiation.polarisn_norm_esd</a>
+    _item_description.description
+;             The standard uncertainty (estimated standard deviation, e.s.d.) of
+              <A href="#_diffrn_radiation.polarisn_norm">_diffrn_radiation.polarisn_norm</a>,
+              the angle in degrees, as viewed from the specimen, between the
+              perpendicular component of the polarization and the diffraction
+              plane. See _diffrn_radiation_polarisn_ratio.
+;
+    _item.name                  '<a href="#_diffrn_radiation.polarisn_norm_esd">_diffrn_radiation.polarisn_norm_esd</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .     0.0
+                                  0.0   0.0
+    _item_type.code               float
+    _item_units.code              degrees
+     loop_
+    _item_related.related_name
+    _item_related.function_code  '<a href="#_diffrn_radiation.polarisn_norm">_diffrn_radiation.polarisn_norm</a>'
+                                 'associated_value'
+     save_
+
+
+save_<A name="_diffrn_radiation.polarisn_ratio">_diffrn_radiation.polarisn_ratio</a>
+    _item_description.description
+;             Polarization ratio of the diffraction beam incident on the
+              crystal. This is the ratio of the perpendicularly polarized to
+              the parallel polarized component of the radiation. The
+              perpendicular component forms an angle of
+              <a href="#_diffrn_radiation.polarisn_norm">_diffrn_radiation.polarisn_norm</a> to the normal to the
+              diffraction plane of the sample (i.e. the plane containing
+              the incident and reflected beams).
+;
+    _item.name                  '<a href="#_diffrn_radiation.polarisn_ratio">_diffrn_radiation.polarisn_ratio</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_radiation_polarisn_ratio'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+     loop_
+    _item_range.maximum
+    _item_range.minimum            .    0.0
+                                  0.0   0.0
+    _item_type.code               float
+     save_
+
+
+save_<A name="_diffrn_radiation.polarisn_ratio_esd">_diffrn_radiation.polarisn_ratio_esd</a>
+    _item_description.description
+;             The standard uncertainty (estimated standard deviation, e.s.d.) of
+              <A href="#_diffrn_radiation.polarisn_ratio">_diffrn_radiation.polarisn_ratio</a>,
+              the polarization ratio of the diffraction beam incident on the
+              crystal. 
+;
+    _item.name                  '<a href="#_diffrn_radiation.polarisn_ratio_esd">_diffrn_radiation.polarisn_ratio_esd</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum            .    0.0
+                                  0.0   0.0
+    _item_type.code               float
+     loop_
+    _item_related.related_name
+    _item_related.function_code  '<a href="#_diffrn_radiation.polarisn_ratio">_diffrn_radiation.polarisn_ratio</a>'
+                                 'associated_value'
+     save_
+
+
+save_<a name="_diffrn_radiation.polarizn_source_norm">_diffrn_radiation.polarizn_source_norm</a>
+    _item_description.description
+;             The angle in degrees, as viewed from the specimen, between
+              the normal to the polarization plane and the laboratory
+              <b>Y</b>-axis as defined in the <a href="#AXIS">AXIS</a> category.
+
+              Note that this is the angle of polarization of the source
+              photons, either directly from a synchrotron beamline or
+              from a monochromator.
+
+              This differs from the value of
+              <a href="#_diffrn_radiation.polarisn_norm">_diffrn_radiation.polarisn_norm</a>
+              in that <a href="#_diffrn_radiation.polarisn_norm">_diffrn_radiation.polarisn_norm</a> refers to
+              polarization relative to the diffraction plane rather than
+              to the laboratory axis system.
+
+              In the case of an unpolarized beam, or a beam with true
+              circular polarization, in which no single plane of
+              polarization can be determined, the plane should be taken
+              as the XZ plane and the angle as 0.
+
+              See <a href="#_diffrn_radiation.polarizn_source_ratio">_diffrn_radiation.polarizn_source_ratio</a>.
+;
+    _item.name                  '<a href="#_diffrn_radiation.polarizn_source_norm">_diffrn_radiation.polarizn_source_norm</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           90.0   90.0
+                                  90.0  -90.0
+                                 -90.0  -90.0
+    _item_type.code               float
+    _item_units.code              degrees
+    _item_default.value           0.0
+     save_
+
+
+save_<a name="_diffrn_radiation.polarizn_source_norm_esd">_diffrn_radiation.polarizn_source_norm_esd</a>
+    _item_description.description
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of <A href="#_diffrn_radiation.polarizn_source_norm">_diffrn_radiation.polarizn_source_norm</a>,
+              the angle in degrees, as viewed from the specimen, between
+              the normal to the polarization plane and the laboratory
+              <b>Y</b>-axis as defined in the <a href="#AXIS">AXIS</a> category.
+;
+    _item.name
+        '<a href="#_diffrn_radiation.polarizn_source_norm_esd">_diffrn_radiation.polarizn_source_norm_esd</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .      0.0
+                                  0.0    0.0
+    _item_type.code               float
+    _item_units.code              degrees
+     loop_
+    _item_related.related_name
+    _item_related.function_code  '<a href="#_diffrn_radiation.polarizn_source_norm">_diffrn_radiation.polarizn_source_norm</a>'
+                                 'associated_value'
+     save_
+
+
+save_<a name="_diffrn_radiation.polarizn_source_ratio">_diffrn_radiation.polarizn_source_ratio</a>
+    _item_description.description
+;             The quantity (Ip-In)/(Ip+In), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization and In is the intensity (amplitude squared)
+              of the electric vector in the plane of the normal to the
+              plane of polarization.
+
+              In the case of an unpolarized beam, or a beam with true
+              circular polarization, in which no single plane of
+              polarization can be determined, the plane is to be taken
+              as the XZ plane and the normal is parallel to the <b>Y</b> axis.
+
+              Thus, if there was complete polarization in the plane of
+              polarization, the value of
+              <a href="#_diffrn_radiation.polarizn_source_ratio">_diffrn_radiation.polarizn_source_ratio</a> would be 1, and
+              for an unpolarized beam
+              <a href="#_diffrn_radiation.polarizn_source_ratio">_diffrn_radiation.polarizn_source_ratio</a> would have a
+              value of 0.
+
+              If the <b>X</b> axis has been chosen to lie in the plane of
+              polarization, this definition will agree with the definition
+              of 'MONOCHROMATOR' in the Denzo glossary, and values of near
+              1 should be expected for a bending-magnet source.  However,
+              if the <b>X</b>-axis were perpendicular to the polarization plane
+              (not a common choice), then the Denzo value would be the
+              negative of <a href="#_diffrn_radiation.polarizn_source_ratio">_diffrn_radiation.polarizn_source_ratio</a>.
+
+              See <a href="http://www.hkl-xray.com">http://www.hkl-xray.com</a> for information on Denzo and
+              Otwinowski &amp; Minor (1997).
+
+              This differs both in the choice of ratio and choice of
+              orientation from <a href="#_diffrn_radiation.polarisn_ratio">_diffrn_radiation.polarisn_ratio</a>, which,
+              unlike <a href="#_diffrn_radiation.polarizn_source_ratio">_diffrn_radiation.polarizn_source_ratio</a>, is
+              unbounded.
+
+              Reference: Otwinowski, Z. &amp; Minor, W. (1997). 'Processing of
+              X-ray diffraction data collected in oscillation mode.' Methods
+              Enzymol. 276, 307-326.
+;
+    _item.name                  '<a href="#_diffrn_radiation.polarizn_source_ratio">_diffrn_radiation.polarizn_source_ratio</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           1.0    1.0
+                                  1.0   -1.0
+                                 -1.0   -1.0
+    _item_type.code               float
+     save_
+
+
+save_<a name="_diffrn_radiation.polarizn_source_ratio_esd">_diffrn_radiation.polarizn_source_ratio_esd</a>
+    _item_description.description
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of <A href="#_diffrn_radiation.polarizn_source_ratio">_diffrn_radiation.polarizn_source_ratio</a>,
+              (Ip-In)/(Ip+In), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization and In is the intensity (amplitude squared)
+              of the electric vector in the plane of the normal to the
+              plane of polarization.
+;
+    _item.name                  '<a href="#_diffrn_radiation.polarizn_source_ratio_esd">_diffrn_radiation.polarizn_source_ratio_esd</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .      0.0
+                                  0.0    0.0
+    _item_type.code               float
+     loop_
+    _item_related.related_name
+    _item_related.function_code  '<a href="#_diffrn_radiation.polarizn_source_ratio">_diffrn_radiation.polarizn_source_ratio</a>'
+                                 'associated_value'
+     save_
+
+
+save_<a name="_diffrn_radiation.polarizn_Stokes_I">_diffrn_radiation.polarizn_Stokes_I</a>
+    _item_description.description
+;             The quantity Ip+In+Inp, where Ip is the intensity (amplitude
+              squared) of the electric vector in the plane of polarization,
+              In is the intensity (amplitude squared) of the electric vector
+              in the plane of the normal to the plane of polarization,
+              and Inp is the intensity (amplitude squared) of the
+              non-polarized (incoherent) electric vector.
+
+              This is an average or other representative sample of the
+              scan.
+
+              This is the first of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
+
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
+
+              Note that, if the polarized intensity Ip+In is required,
+              (Ip+In)^2^ is the sum of Q^2^+U^2^+V^2^.
+
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200 -- 3205.
+;
+    _item.name                  '<a href="#_diffrn_radiation.polarizn_Stokes_I">_diffrn_radiation.polarizn_Stokes_I</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          implicit
+    _item_default.value           1.0
+     loop_
+    _item_range.maximum
+    _item_range.minimum           
+                                   .    0.0
+                                  0.0   0.0
+    _item_type.code               float
+     save_
+
+
+save_<a name="_diffrn_radiation.polarizn_Stokes_I_esd">_diffrn_radiation.polarizn_Stokes_I_esd</a>
+    _item_description.description
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of <A href="#_diffrn_radiation.polarizn_Stokes_I">_diffrn_radiation.polarizn_Stokes_I</a>,
+              Ip+In+Inp, where Ip is the intensity (amplitude squared)
+              of the electric vector in the plane of polarization,
+              In is the intensity (amplitude squared) of the electric vector
+              in the plane of the normal to the plane of polarization,
+              and Inp is the intensity (amplitude squared) of the
+              non-polarized (incoherent) electric vector.
+;
+    _item.name                  '<a href="#_diffrn_radiation.polarizn_Stokes_I_esd">_diffrn_radiation.polarizn_Stokes_I_esd</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .      0.0
+                                  0.0    0.0
+    _item_type.code               float
+     loop_
+    _item_related.related_name
+    _item_related.function_code  '<a href="#_diffrn_radiation.polarizn_Stokes_I">_diffrn_radiation.polarizn_Stokes_I</a>'
+                                 'associated_value'
+     save_
+
+
+save_<a name="_diffrn_radiation.polarizn_Stokes_Q">_diffrn_radiation.polarizn_Stokes_Q</a>
+    _item_description.description
+;             The quantity (Ip-In)*cos(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory <b>Y</b> axis as defined in the
+              <a href="#AXIS">AXIS</a> category.
+
+              This is an average or other representative sample of the
+              scan.
+
+              This is the second of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
+
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
+
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200 -- 3205.
+;
+    _item.name                  '<a href="#_diffrn_radiation.polarizn_Stokes_Q">_diffrn_radiation.polarizn_Stokes_Q</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_type.code               float
+     save_
+
+
+save_<a name="_diffrn_radiation.polarizn_Stokes_Q_esd">_diffrn_radiation.polarizn_Stokes_Q_esd</a>
+    _item_description.description
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of <A href="#_diffrn_radiation.polarizn_Stokes_Q">_diffrn_radiation.polarizn_Stokes_Q</a>,
+              (Ip-In)*cos(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory <b>Y</b>-axis as defined in the
+              <a href="#AXIS">AXIS</a> category.
+;
+    _item.name                  '<a href="#_diffrn_radiation.polarizn_Stokes_Q_esd">_diffrn_radiation.polarizn_Stokes_Q_esd</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .      0.0
+                                  0.0    0.0
+    _item_type.code               float
+     loop_
+    _item_related.related_name
+    _item_related.function_code  '<a href="#_diffrn_radiation.polarizn_Stokes_Q">_diffrn_radiation.polarizn_Stokes_Q</a>'
+                                 'associated_value'
+     save_
+
+
+save_<a name="_diffrn_radiation.polarizn_Stokes_U">_diffrn_radiation.polarizn_Stokes_U</a>
+    _item_description.description
+;             The quantity (Ip-In)*sin(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory <b>Y</b> axis as defined in the
+              <a href="#AXIS">AXIS</a> category.
+
+              This is an average or other representative sample of the
+              scan.
+
+              This is the third of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry at al. (1977)].
+
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
+
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200 -- 3205.
+;
+    _item.name                  '<a href="#_diffrn_radiation.polarizn_Stokes_U">_diffrn_radiation.polarizn_Stokes_U</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_type.code               float
+     save_
+
+
+save_<a name="_diffrn_radiation.polarizn_Stokes_U_esd">_diffrn_radiation.polarizn_Stokes_U_esd</a>
+    _item_description.description
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of <A href="#_diffrn_radiation.polarizn_Stokes_U">_diffrn_radiation.polarizn_Stokes_U</a>,
+              (Ip-In)*sin(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory <b>Y</b>-axis as defined in the
+              <a href="#AXIS">AXIS</a> category.
+;
+    _item.name                  '<a href="#_diffrn_radiation.polarizn_Stokes_U_esd">_diffrn_radiation.polarizn_Stokes_U_esd</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .      0.0
+                                  0.0    0.0
+    _item_type.code               float
+     loop_
+    _item_related.related_name
+    _item_related.function_code  '<a href="#_diffrn_radiation.polarizn_Stokes_U">_diffrn_radiation.polarizn_Stokes_U</a>'
+                                 'associated_value'
+     save_
+
+
+save_<a name="_diffrn_radiation.polarizn_Stokes_V">_diffrn_radiation.polarizn_Stokes_V</a>
+    _item_description.description
+;             The quantity +/-2*sqrt(IpIn), with a + sign for right-handed
+              circular polarization, where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization and In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory <b>Y</b> axis as defined in the
+              <a href="#AXIS">AXIS</a> category.
+
+              This is an average or other representative sample of the
+              scan.
+
+              This is the fourth of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
+
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
+
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200 -- 3205.
+;
+    _item.name                  '<a href="#_diffrn_radiation.polarizn_Stokes_V">_diffrn_radiation.polarizn_Stokes_V</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_type.code               float
+     save_
+
+
+save_<a name="_diffrn_radiation.polarizn_Stokes_V_esd">_diffrn_radiation.polarizn_Stokes_V_esd</a>
+    _item_description.description
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of <A href="#_diffrn_radiation.polarizn_Stokes_V">_diffrn_radiation.polarizn_Stokes_V</a>,
+              +/-2*sqrt(IpIn), with a + sign for right-handed circular
+              polarization, where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization and In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory <b>Y</b> axis as defined in the
+              <a href="#AXIS">AXIS</a> category.
+;
+    _item.name                  '<a href="#_diffrn_radiation.polarizn_Stokes_V_esd">_diffrn_radiation.polarizn_Stokes_V_esd</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .      0.0
+                                  0.0    0.0
+    _item_type.code               float
+     loop_
+    _item_related.related_name
+    _item_related.function_code  '<a href="#_diffrn_radiation.polarizn_Stokes_V">_diffrn_radiation.polarizn_Stokes_V</a>'
+                                 'associated_value'
+     save_
+
+
+save_<A name="_diffrn_radiation.probe">_diffrn_radiation.probe</a>
+    _item_description.description
+;             Name of the type of radiation used. It is strongly
+              recommended that this be given so that the
+              probe radiation is clearly specified.
+;
+    _item.name                  '<a href="#_diffrn_radiation.probe">_diffrn_radiation.probe</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_radiation_probe'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+    _item_type.code               line
+     loop_
+    _item_enumeration.value      'x-ray'
+                                 'neutron'
+                                 'electron'
+                                 'gamma'
+     save_
+
+
+save_<A name="_diffrn_radiation.type">_diffrn_radiation.type</a>
+    _item_description.description
+;             The nature of the radiation. This is typically a description
+              of the X-ray wavelength in Siegbahn notation.
+;
+    _item.name                  '<a href="#_diffrn_radiation.type">_diffrn_radiation.type</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_radiation_type'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+    _item_type.code               line
+     loop_
+    _item_examples.case          'CuK\a'
+                                 'Cu K\a~1~'
+                                 'Cu K-L~2,3~'
+                                 'white-beam'
+     save_
+
+
+save_<A name="_diffrn_radiation.xray_symbol">_diffrn_radiation.xray_symbol</a>
+    _item_description.description
+;             The IUPAC symbol for the X-ray wavelength for the probe
+              radiation.
+;
+    _item.name                  '<a href="#_diffrn_radiation.xray_symbol">_diffrn_radiation.xray_symbol</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+    _item_aliases.alias_name    '_diffrn_radiation_xray_symbol'
+    _item_aliases.dictionary      cif_core.dic
+    _item_aliases.version         2.0.1
+    _item_type.code               line
+     loop_
+    _item_enumeration.value
+    _item_enumeration.detail     'K-L~3~'
+                                 'K\a~1~ in older Siegbahn notation'
+                                 'K-L~2~'
+                                 'K\a~2~ in older Siegbahn notation'
+                                 'K-M~3~'
+                                 'K\b~1~ in older Siegbahn notation'
+                                 'K-L~2,3~'
+                                 'use where K-L~3~ and K-L~2~ are not resolved'
+     save_
+
+
+save_<A name="_diffrn_radiation.wavelength_id">_diffrn_radiation.wavelength_id</a>
+    _item_description.description
+;             This data item is a pointer to
+              <a href="#_diffrn_radiation_wavelength.id">_diffrn_radiation_wavelength.id</a> in the
+              DIFFRN_RADIATION_WAVELENGTH category.
+;
+    _item.name                  '<a href="#_diffrn_radiation.wavelength_id">_diffrn_radiation.wavelength_id</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+
+save_<a name="_diffrn_radiation.variant" >_diffrn_radiation.variant</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_radiation.variant" >_diffrn_radiation.variant</a> gives the variant
+              to which the given DIFFRN_RADIATION row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to <a href="#_variant.variant" >_variant.variant</a> in the
+              <a href="#variant">VARIANT</a> category.
+;
+    _item.name                  '<a href="#_diffrn_radiation.variant" >_diffrn_radiation.variant</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          implicit
+    _item_default.value           .
+    _item_type.code               code
+     save_
+
+
+################
+# <a name="diffrn_refln">DIFFRN_REFLN</a> #
+################
+
+
+save_DIFFRN_REFLN
+    _category.description
+;   This category redefinition has been added to extend the key of
+    the standard <a href="#diffrn_refln">DIFFRN_REFLN</a> category.
+
+    Data items in the DIFFRN_REFLN category record details about
+    the intensities in the diffraction data set
+    identified by _diffrn_refln.diffrn_id.
+
+    The DIFFRN_REFLN data items refer to individual intensity
+    measurements and must be included in looped lists.
+
+    The DIFFRN_REFLNS data items specify the parameters that apply
+    to all intensity  measurements in the particular diffraction
+    data set identified by _diffrn_reflns.diffrn_id and
+    _diffrn_refln.frame_id
+;
+    _category.id                   diffrn_refln
+    _category.mandatory_code       no
+<div id="print_NX_diffrn_refln" style="display:block">   #_category.NX_mapping_details in online version <a href="javascript:open_close2('online_NX_diffrn_refln','print_NX_diffrn_refln');">+/-</a>
+</div><div id="online_NX_diffrn_refln" style="display:none">    _category.NX_mapping_details                  #<a href="javascript:open_close2('online_NX_diffrn_refln','print_NX_diffrn_refln');">+/-</a>
+;
+    This category will be addressed at a future date.
+;
+</div>     loop_
+    _category_key.name             '_diffrn_refln.diffrn_id'
+                                   '_diffrn_refln.id' 
+                                   '<a href="#_diffrn_refln.frame_id" >_diffrn_refln.frame_id</a>'
+                                   '<a href="#_diffrn_refln.variant" >_diffrn_refln.variant</a>'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'diffrn_group'
+     save_
+
+
+save_<a name="_diffrn_refln.frame_id" >_diffrn_refln.frame_id</a>
+    _item_description.description
+;             This item is a pointer to <a href="#_diffrn_data_frame.id" >_diffrn_data_frame.id</a>
+              in the <a href="#DIFFRN_DATA_FRAME">DIFFRN_DATA_FRAME</a> category.
+;
+    _item.name                  '<a href="#_diffrn_refln.frame_id" >_diffrn_refln.frame_id</a>'
+    _item.category_id             diffrn_refln
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+save_<a name="_diffrn_refln.variant" >_diffrn_refln.variant</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_refln.variant" >_diffrn_refln.variant</a> gives the variant
+              to which the given DIFFRN_REFLN row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to <a href="#_variant.variant" >_variant.variant</a> in the
+              <a href="#variant">VARIANT</a> category.
+;
+    _item.name                  '<a href="#_diffrn_refln.variant" >_diffrn_refln.variant</a>'
+    _item.category_id             diffrn_refln
+    _item.mandatory_code          implicit
+    _item_default.value           .
+    _item_type.code               code
+     save_
+
+
+save_<a name="_diffrn_refln.id" >_diffrn_refln.id</a>
+    _item_description.description
+;             This item is a placeholder for the definition in the
+              PDBx/mmCIF dictionary.
+;
+    _item.name                  '<a href="#_diffrn_refln.id" >_diffrn_refln.id</a>'
+    _item.category_id             diffrn_refln
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+
+save_<a name="_diffrn_refln.diffrn_id" >_diffrn_refln.diffrn_id</a>
+    _item_description.description
+;             This item is a placeholder for the definition in the
+              PDBx/mmCIF dictionary
+;
+    _item.name                  '<a href="#_diffrn_refln.diffrn_id" >_diffrn_refln.diffrn_id</a>'
+    _item.category_id             diffrn_refln
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+
+###############
+# <a name="diffrn_scan">DIFFRN_SCAN</a> #
+###############
+
+save_DIFFRN_SCAN
+    _category.description
+;   Data items in the <a href="#diffrn_scan">DIFFRN_SCAN</a> category describe the parameters of one
+    or more scans, relating axis positions to frames.
+;
+    _category.id                   diffrn_scan
+    _category.mandatory_code       no
+<div id="print_NX_diffrn_scan" style="display:block">   #_category.NX_mapping_details in online version <a href="javascript:open_close2('online_NX_diffrn_scan','print_NX_diffrn_scan');">+/-</a>
+</div><div id="online_NX_diffrn_scan" style="display:none">    _category.NX_mapping_details                  #<a href="javascript:open_close2('online_NX_diffrn_scan','print_NX_diffrn_scan');">+/-</a>
+;
+    _diffrn_scan.id SCANID
+    _diffrn_scan.date_end ENDDATETIME
+    _diffrn_scan.date_end_estimated ENDDATETIMEEST
+    _diffrn_scan.date_start STARTDATETIME
+    _diffrn_scan.integration_time AVGCOUNTTIME
+    _diffrn_scan.frame_id_start FRAMESTARTID
+    _diffrn_scan.frame_id_end FRAMEENDID
+    _diffrn_scan.frames FRAMES
+    _diffrn_scan.time_period TIMEPER
+    _diffrn_scan.time_rstrt_incr RSTRTTIME
+
+    -->
+
+        /entry:NXentry
+          /CBF_scan_id="SCANID"
+          /end_time=ENDDATETIME
+          /end_time_estimated=ENDDATETIMEEST
+          /start_time=STARTDATETIME
+          /average_count_time=AVGCOUNTTIME
+            @units="sec"
+          /average_frame_time=TIMEPER
+            @units="sec"
+          /average_frame_restart_time=RSTRTTIME
+            @units="sec"
+          /instrument:NXinstrument
+           /DETECTORNAME:NXdetector_group
+           /DETECTORELEMENTNAME:NXdetector
+              /frame_start_number=FRAMESTARTNO
+              /frame_end_number=FRAMEENDNO
+
+    FRAMESTARTNO is the value of _diffrn_scan_frame.frame_number
+    for which the value of _diffrn_scan_frame.frame_id equals FRAMESTARTID
+    FRAMEENDNO is the value of _diffrn_scan_frame.frame_number
+    for which the value of _diffrn_scan_frame.frame_id equals FRAMEENDID   
+;
+</div>     loop_
+    _category_key.name            '<a href="#_diffrn_scan.id" >_diffrn_scan.id</a>'
+                                  '<a href="#_diffrn_scan.variant" >_diffrn_scan.variant</a>'
+     loop_
+    _category_group.id            'inclusive_group'
+                                  'diffrn_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;   Example 1. derived from a suggestion by R. M. Sweet.
+
+   The vector of each axis is not given here, because it is provided in
+   the <a href="#AXIS">AXIS</a> category.  By making <a href="#_diffrn_scan_axis.scan_id" >_diffrn_scan_axis.scan_id</a> and
+   <a href="#_diffrn_scan_axis.axis_id" >_diffrn_scan_axis.axis_id</a> keys of the <a href="#diffrn_scan_axis">DIFFRN_SCAN_AXIS</a> category,
+   an arbitrary number of scanning and fixed axes can be specified for a
+   scan.  In this example, three rotation axes and one translation axis
+   at nonzero values are specified, with one axis stepping.  There is no
+   reason why more axes could not have been specified to step. Range
+   information has been specified, but note that it can be calculated from
+   the  number of frames and the increment, so the data item
+   <a href="#_diffrn_scan_axis.angle_range">_diffrn_scan_axis.angle_range</a> could be dropped.
+
+   Both the sweep data and the data for a single frame are specified.
+
+   Note that the information on how the axes are stepped is given twice,
+   once in terms of the overall averages in the value of
+   <a href="#_diffrn_scan.integration_time" >_diffrn_scan.integration_time</a> and the values for <a href="#diffrn_scan_axis">DIFFRN_SCAN_AXIS</a>,
+   and precisely for the given frame in the value for
+   <a href="#_diffrn_scan_frame.integration_time" >_diffrn_scan_frame.integration_time</a> and the values for
+   <a href="#diffrn_scan_frame_axis">DIFFRN_SCAN_FRAME_AXIS</a>.  If dose-related adjustments are made to
+   scan times and nonlinear stepping is done, these values may differ.
+   Therefore, in interpreting the data for a particular frame it is
+   important to use the frame-specific data.
+
+   There are three date/times in this set: *.date_start and
+   *. date_end_estimated, both of which are mandatory, because the former
+   is data which can be logged at the start of collection and the latter
+   is data that can be estimated at the same time, and *.date_end which
+   can only be logged exactly if the data collection completes normally.
+;
+;
+      <a href="#_diffrn_scan.id">_diffrn_scan.id</a>                   1
+      <a href="#_diffrn_scan.date_start" >_diffrn_scan.date_start</a>         '2001-11-18T03:26:42'
+      <a href="#_diffrn_scan.date_end_estimated" >_diffrn_scan.date_end_estimated</a> '2001-11-18T03:36:45'
+      <a href="#_diffrn_scan.date_end" >_diffrn_scan.date_end</a>           '2001-11-18T03:36:45'
+      <a href="#_diffrn_scan.integration_time" >_diffrn_scan.integration_time</a>    3.0
+      <a href="#_diffrn_scan.frame_id_start" >_diffrn_scan.frame_id_start</a>      mad_L2_000
+      <a href="#_diffrn_scan.frame_id_end" >_diffrn_scan.frame_id_end</a>        mad_L2_200
+      <a href="#_diffrn_scan.frames" >_diffrn_scan.frames</a>              201
+
+     loop_
+      <a href="#_diffrn_scan_axis.scan_id" >_diffrn_scan_axis.scan_id</a>
+      <a href="#_diffrn_scan_axis.axis_id" >_diffrn_scan_axis.axis_id</a>
+      <a href="#_diffrn_scan_axis.angle_start" >_diffrn_scan_axis.angle_start</a>
+      <a href="#_diffrn_scan_axis.angle_range" >_diffrn_scan_axis.angle_range</a>
+      <a href="#_diffrn_scan_axis.angle_increment" >_diffrn_scan_axis.angle_increment</a>
+      <a href="#_diffrn_scan_axis.displacement_start" >_diffrn_scan_axis.displacement_start</a>
+      <a href="#_diffrn_scan_axis.displacement_range" >_diffrn_scan_axis.displacement_range</a>
+      <a href="#_diffrn_scan_axis.displacement_increment" >_diffrn_scan_axis.displacement_increment</a>
+
+       1 omega 200.0 20.0 0.1 . . .
+       1 kappa -40.0  0.0 0.0 . . .
+       1 phi   127.5  0.0 0.0 . . .
+       1 tranz  . . .   2.3 0.0 0.0
+
+      <a href="#_diffrn_scan_frame.scan_id" >_diffrn_scan_frame.scan_id</a>                   1
+      <a href="#_diffrn_scan_frame.date" >_diffrn_scan_frame.date</a>               '2001-11-18T03:27:33'
+      <a href="#_diffrn_scan_frame.integration_time" >_diffrn_scan_frame.integration_time</a>    3.0
+      <a href="#_diffrn_scan_frame.frame_id" >_diffrn_scan_frame.frame_id</a>            mad_L2_018
+      <a href="#_diffrn_scan_frame.frame_number" >_diffrn_scan_frame.frame_number</a>        18
+
+     loop_
+      <a href="#_diffrn_scan_frame_axis.frame_id" >_diffrn_scan_frame_axis.frame_id</a>
+      <a href="#_diffrn_scan_frame_axis.axis_id" >_diffrn_scan_frame_axis.axis_id</a>
+      <a href="#_diffrn_scan_frame_axis.angle">_diffrn_scan_frame_axis.angle</a>
+      <a href="#_diffrn_scan_frame_axis.angle_increment" >_diffrn_scan_frame_axis.angle_increment</a>
+      <a href="#_diffrn_scan_frame_axis.displacement" >_diffrn_scan_frame_axis.displacement</a>
+      <a href="#_diffrn_scan_frame_axis.displacement_increment" >_diffrn_scan_frame_axis.displacement_increment</a>
+
+       mad_L2_018 omega 201.8  0.1 . .
+       mad_L2_018 kappa -40.0  0.0 . .
+       mad_L2_018 phi   127.5  0.0 . .
+       mad_L2_018 tranz  .     .  2.3 0.0
+;
+
+;  Example 2. a more extensive example (R. M. Sweet, P. J. Ellis &amp;
+   H. J. Bernstein).
+
+   A detector is placed 240 mm along the <b>Z</b> axis from the goniometer.
+   This leads to a choice:  either the axes of
+   the detector are defined at the origin, and then a Z setting of -240
+   is entered, or the axes are defined with the necessary Z offset.
+   In this case, the setting is used and the offset is left as zero.
+   This axis is called DETECTOR_Z.
+
+   The axis for positioning the detector in the <b>Y</b> direction depends
+   on the detector <b>Z</b> axis.  This axis is called DETECTOR_Y.
+
+   The axis for positioning the detector in the <b>X</b> direction depends
+   on the detector <b>Y</b> axis (and therefore on the detector <b>Z</b> axis).
+   This axis is called DETECTOR_X.
+
+   This detector may be rotated around the <b>Y</b> axis.  This rotation axis
+   depends on the three translation axes.  It is called DETECTOR_PITCH.
+
+   A coordinate system is defined on the face of the detector in terms of
+   2300 0.150 mm pixels in each direction.  The ELEMENT_X axis is used to
+   index the first array index of the data array and the ELEMENT_Y
+   axis is used to index the second array index.  Because the pixels
+   are 0.150mm <b>x</b> 0.150mm, the centre of the first pixel is at (0.075,
+   0.075) in this coordinate system.
+;
+
+;    ###CBF: VERSION 1.1
+
+     data_image_1
+
+     # category DIFFRN
+    _diffrn.id P6MB
+    _diffrn.crystal_id P6MB_CRYSTAL7
+
+     # category DIFFRN_SOURCE
+     loop_
+    _diffrn_source.diffrn_id
+    _diffrn_source.source
+    _diffrn_source.type
+      P6MB synchrotron 'SSRL beamline 9-1'
+
+     # category <a href="#diffrn_radiation">DIFFRN_RADIATION</a>
+     loop_
+     <a href="#_diffrn_radiation.diffrn_id">_diffrn_radiation.diffrn_id</a>
+     <a href="#_diffrn_radiation.wavelength_id">_diffrn_radiation.wavelength_id</a>
+     <a href="#_diffrn_radiation.monochromator">_diffrn_radiation.monochromator</a>
+     <a href="#_diffrn_radiation.polarizn_source_ratio">_diffrn_radiation.polarizn_source_ratio</a>
+     <a href="#_diffrn_radiation.polarizn_source_norm">_diffrn_radiation.polarizn_source_norm</a>
+     <a href="#_diffrn_radiation.div_x_source">_diffrn_radiation.div_x_source</a>
+     <a href="#_diffrn_radiation.div_y_source">_diffrn_radiation.div_y_source</a>
+     <a href="#_diffrn_radiation.div_x_y_source">_diffrn_radiation.div_x_y_source</a>
+      P6MB WAVELENGTH1 'Si 111' 0.8 0.0 0.08 0.01 0.00
+
+     # category DIFFRN_RADIATION_WAVELENGTH
+     loop_
+    _diffrn_radiation_wavelength.id
+    _diffrn_radiation_wavelength.wavelength
+    _diffrn_radiation_wavelength.wt
+      WAVELENGTH1 0.98 1.0
+
+     # category <a href="#DIFFRN_DETECTOR">DIFFRN_DETECTOR</a>
+     loop_
+     <a href="#_diffrn_detector.diffrn_id">_diffrn_detector.diffrn_id</a>
+     <a href="#_diffrn_detector.id">_diffrn_detector.id</a>
+     <a href="#_diffrn_detector.type">_diffrn_detector.type</a>
+     <a href="#_diffrn_detector.number_of_axes">_diffrn_detector.number_of_axes</a>
+      P6MB MAR345-SN26 'MAR 345' 4
+
+     # category <a href="#diffrn_detector_axis">DIFFRN_DETECTOR_AXIS</a>
+     loop_
+     <a href="#_diffrn_detector_axis.detector_id">_diffrn_detector_axis.detector_id</a>
+     <a href="#_diffrn_detector_axis.axis_id">_diffrn_detector_axis.axis_id</a>
+      MAR345-SN26 DETECTOR_X
+      MAR345-SN26 DETECTOR_Y
+      MAR345-SN26 DETECTOR_Z
+      MAR345-SN26 DETECTOR_PITCH
+
+     # category <a href="#diffrn_detector_element">DIFFRN_DETECTOR_ELEMENT</a>
+     loop_
+     <a href="#_diffrn_detector_element.id">_diffrn_detector_element.id</a>
+     <a href="#_diffrn_detector_element.detector_id#">_diffrn_detector_element.detector_id</a>
+      ELEMENT1 MAR345-SN26
+
+     # category <a href="#DIFFRN_DATA_FRAME">DIFFRN_DATA_FRAME</a>
+     loop_
+     <a href="#_diffrn_data_frame.id">_diffrn_data_frame.id</a>
+     <a href="#_diffrn_data_frame.detector_element_id">_diffrn_data_frame.detector_element_id</a>
+     <a href="#_diffrn_data_frame.array_id">_diffrn_data_frame.array_id</a>
+     <a href="#_diffrn_data_frame.binary_id">_diffrn_data_frame.binary_id</a>
+      FRAME1 ELEMENT1 ARRAY1 1
+
+     # category <a href="#diffrn_measurement">DIFFRN_MEASUREMENT</a>
+     loop_
+     <a href="#_diffrn_measurement.diffrn_id">_diffrn_measurement.diffrn_id</a>
+     <a href="#_diffrn_measurement.id">_diffrn_measurement.id</a>
+     <a href="#_diffrn_measurement.number_of_axes">_diffrn_measurement.number_of_axes</a>
+     <a href="#_diffrn_measurement.method">_diffrn_measurement.method</a>
+      P6MB GONIOMETER 3 rotation
+
+     # category <a href="#diffrn_measurement_axis">DIFFRN_MEASUREMENT_AXIS</a>
+     loop_
+     <a href="#_diffrn_measurement_axis.measurement_id">_diffrn_measurement_axis.measurement_id</a>
+     <a href="#_diffrn_measurement_axis.axis_id">_diffrn_measurement_axis.axis_id</a>
+      GONIOMETER GONIOMETER_PHI
+      GONIOMETER GONIOMETER_KAPPA
+      GONIOMETER GONIOMETER_OMEGA
+
+     # category <a href="#diffrn_scan">DIFFRN_SCAN</a>
+     loop_
+     <a href="#_diffrn_scan.id" >_diffrn_scan.id</a>
+     <a href="#_diffrn_scan.frame_id_start" >_diffrn_scan.frame_id_start</a>
+     <a href="#_diffrn_scan.frame_id_end" >_diffrn_scan.frame_id_end</a>
+     <a href="#_diffrn_scan.frames" >_diffrn_scan.frames</a>
+      SCAN1 FRAME1 FRAME1 1
+
+     # category <a href="#diffrn_scan_axis">DIFFRN_SCAN_AXIS</a>
+     loop_
+     <a href="#_diffrn_scan_axis.scan_id" >_diffrn_scan_axis.scan_id</a>
+     <a href="#_diffrn_scan_axis.axis_id" >_diffrn_scan_axis.axis_id</a>
+     <a href="#_diffrn_scan_axis.angle_start" >_diffrn_scan_axis.angle_start</a>
+     <a href="#_diffrn_scan_axis.angle_range" >_diffrn_scan_axis.angle_range</a>
+     <a href="#_diffrn_scan_axis.angle_increment" >_diffrn_scan_axis.angle_increment</a>
+     <a href="#_diffrn_scan_axis.displacement_start" >_diffrn_scan_axis.displacement_start</a>
+     <a href="#_diffrn_scan_axis.displacement_range" >_diffrn_scan_axis.displacement_range</a>
+     <a href="#_diffrn_scan_axis.displacement_increment" >_diffrn_scan_axis.displacement_increment</a>
+      SCAN1 GONIOMETER_OMEGA 12.0 1.0 1.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_KAPPA 23.3 0.0 0.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_PHI -165.8 0.0 0.0 0.0 0.0 0.0
+      SCAN1 DETECTOR_Z 0.0 0.0 0.0 -240.0 0.0 0.0
+      SCAN1 DETECTOR_Y 0.0 0.0 0.0 0.6 0.0 0.0
+      SCAN1 DETECTOR_X 0.0 0.0 0.0 -0.5 0.0 0.0
+      SCAN1 DETECTOR_PITCH 0.0 0.0 0.0 0.0 0.0 0.0
+
+     # category <a href="#diffrn_scan_frame">DIFFRN_SCAN_FRAME</a>
+     loop_
+     <a href="#_diffrn_scan_frame.frame_id" >_diffrn_scan_frame.frame_id</a>
+     <a href="#_diffrn_scan_frame.frame_number" >_diffrn_scan_frame.frame_number</a>
+     <a href="#_diffrn_scan_frame.integration_time" >_diffrn_scan_frame.integration_time</a>
+     <a href="#_diffrn_scan_frame.scan_id" >_diffrn_scan_frame.scan_id</a>
+     <a href="#_diffrn_scan_frame.date" >_diffrn_scan_frame.date</a>
+      FRAME1 1 20.0 SCAN1 1997-12-04T10:23:48
+
+     # category <a href="#diffrn_scan_frame_axis">DIFFRN_SCAN_FRAME_AXIS</a>
+     loop_
+     <a href="#_diffrn_scan_frame_axis.frame_id" >_diffrn_scan_frame_axis.frame_id</a>
+     <a href="#_diffrn_scan_frame_axis.axis_id" >_diffrn_scan_frame_axis.axis_id</a>
+     <a href="#_diffrn_scan_frame_axis.angle" >_diffrn_scan_frame_axis.angle</a>
+     <a href="#_diffrn_scan_frame_axis.displacement" >_diffrn_scan_frame_axis.displacement</a>
+      FRAME1 GONIOMETER_OMEGA 12.0 0.0
+      FRAME1 GONIOMETER_KAPPA 23.3 0.0
+      FRAME1 GONIOMETER_PHI -165.8 0.0
+      FRAME1 DETECTOR_Z 0.0 -240.0
+      FRAME1 DETECTOR_Y 0.0 0.6
+      FRAME1 DETECTOR_X 0.0 -0.5
+      FRAME1 DETECTOR_PITCH 0.0 0.0
+
+     # category <a href="#AXIS">AXIS</a>
+     loop_
+     <a href="#_axis.id">_axis.id</a>
+     <a href="#_axis.type">_axis.type</a>
+     <a href="#_axis.equipment">_axis.equipment</a>
+     <a href="#_axis.depends_on">_axis.depends_on</a>
+     <a href="#_axis.vector[1]">_axis.vector[1]</a> <a href="#_axis.vector[2]">_axis.vector[2]</a> <a href="#_axis.vector[3]">_axis.vector[3]</a>
+     <a href="#_axis.offset[1]">_axis.offset[1]</a> <a href="#_axis.offset[2]">_axis.offset[2]</a> <a href="#_axis.offset[3]">_axis.offset[3]</a>
+      GONIOMETER_OMEGA rotation goniometer . 1 0 0 . . .
+      GONIOMETER_KAPPA rotation goniometer GONIOMETER_OMEGA 0.64279
+      0 0.76604 . . .
+      GONIOMETER_PHI   rotation goniometer GONIOMETER_KAPPA 1 0 0
+     . . .
+      SOURCE           general source . 0 0 1 . . .
+      GRAVITY          general gravity . 0 -1 0 . . .
+      DETECTOR_Z       translation detector . 0 0 1 0 0 0
+      DETECTOR_Y       translation detector DETECTOR_Z 0 1 0 0 0 0
+      DETECTOR_X       translation detector DETECTOR_Y 1 0 0 0 0 0
+      DETECTOR_PITCH   rotation    detector DETECTOR_X 0 1 0 0 0 0
+      ELEMENT_X        translation detector DETECTOR_PITCH
+     1 0 0 172.43 -172.43 0
+      ELEMENT_Y        translation detector ELEMENT_X
+     0 1 0 0 0 0
+
+     # category <a href="#array_structure_list">ARRAY_STRUCTURE_LIST</a>
+     loop_
+     <a href="#_array_structure_list.array_id">_array_structure_list.array_id</a>
+     <a href="#_array_structure_list.index">_array_structure_list.index</a>
+     <a href="#_array_structure_list.dimension">_array_structure_list.dimension</a>
+     <a href="#_array_structure_list.precedence">_array_structure_list.precedence</a>
+     <a href="#_array_structure_list.direction">_array_structure_list.direction</a>
+     <a href="#_array_structure_list.axis_set_id">_array_structure_list.axis_set_id</a>
+      ARRAY1 1 2300 1 increasing ELEMENT_X
+      ARRAY1 2 2300 2 increasing ELEMENT_Y
+
+     # category <a href="#array_structure_list_axis">ARRAY_STRUCTURE_LIST_AXIS</a>
+     loop_
+     <a href="#_array_structure_list_axis.axis_set_id">_array_structure_list_axis.axis_set_id</a>
+     <a href="#_array_structure_list_axis.axis_id">_array_structure_list_axis.axis_id</a>
+     <a href="#_array_structure_list_axis.displacement">_array_structure_list_axis.displacement</a>
+     <a href="#_array_structure_list_axis.displacement_increment">_array_structure_list_axis.displacement_increment</a>
+      ELEMENT_X ELEMENT_X 0.075 0.150
+      ELEMENT_Y ELEMENT_Y 0.075 0.150
+
+     # category <a href="#array_element_size">ARRAY_ELEMENT_SIZE</a>
+     loop_
+     <a href="#_array_element_size.array_id">_array_element_size.array_id</a>
+     <a href="#_array_element_size.index">_array_element_size.index</a>
+     <a href="#_array_element_size.index">_array_element_size.size</a>
+      ARRAY1 1 150e-6
+      ARRAY1 2 150e-6
+
+     # category <a href="#array_intensities">ARRAY_INTENSITIES</a>
+     loop_
+     <a href="#_array_intensities.array_id">_array_intensities.array_id</a>
+     <a href="#_array_intensities.binary_id">_array_intensities.binary_id</a>
+     <a href="#_array_intensities.linearity">_array_intensities.linearity</a>
+     <a href="#_array_intensities.gain">_array_intensities.gain</a>
+     <a href="#_array_intensities.gain_esd">_array_intensities.gain_esd</a>
+     <a href="#_array_intensities.overload">_array_intensities.overload</a>
+     <a href="#_array_intensities.undefined_value">_array_intensities.undefined_value</a>
+      ARRAY1 1 linear 1.15 0.2 240000 0
+
+      # category <a href="#array_structure">ARRAY_STRUCTURE</a>
+     loop_
+      <a href="#_array_structure.id">_array_structure.id</a>
+      <a href="#_array_structure.encoding_type">_array_structure.encoding_type</a>
+      <a href="#_array_structure.compression_type">_array_structure.compression_type</a>
+      <a href="#_array_structure.byte_order">_array_structure.byte_order</a>
+      ARRAY1 "signed 32-bit integer" packed little_endian
+
+     # category <a href="#array_data">ARRAY_DATA</a>
+     loop_
+     <a href="#_array_data.array_id">_array_data.array_id</a>
+     <a href="#_array_data.binary_id">_array_data.binary_id</a>
+     <a href="#_array_data.data">_array_data.data</a>
+      ARRAY1 1
+     ;
+     --CIF-BINARY-FORMAT-SECTION--
+     Content-Type: application/octet-stream;
+         conversions="<b>X</b>-CBF_PACKED"
+     Content-Transfer-Encoding: BASE64
+     <b>X</b>-Binary-Size: 3801324
+     <b>X</b>-Binary-ID: 1
+     <b>X</b>-Binary-Element-Type: "signed 32-bit integer"
+     Content-MD5: 07lZFvF+aOcW85IN7usl8A==
+
+     AABRAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZBQSr1sKNBOeOe9HITdMdDUnbq7bg
+     ...
+     8REo6TtBrxJ1vKqAvx9YDMD6J18Qg83OMr/tgssjMIJMXATDsZobL90AEXc4KigE
+
+     --CIF-BINARY-FORMAT-SECTION----
+     ;
+;
+
+;   Example 3. Example 2 revised for a spiral scan (R. M. Sweet,
+    P. J. Ellis &amp; H. J. Bernstein).
+
+   A detector is placed 240 mm along the <b>Z</b> axis from the
+   goniometer, as in Example 2 above, but in this example the
+   image plate is scanned in a spiral pattern from the outside edge in.
+
+   The axis for positioning the detector in the <b>Y</b> direction depends
+   on the detector <b>Z</b> axis.  This axis is called DETECTOR_Y.
+
+   The axis for positioning the detector in the <b>X</b> direction depends
+   on the detector <b>Y</b> axis (and therefore on the detector <b>Z</b> axis).
+   This axis is called DETECTOR_X.
+
+   This detector may be rotated around the <b>Y</b> axis.  This rotation axis
+   depends on the three translation axes.  It is called DETECTOR_PITCH.
+
+   A coordinate system is defined on the face of the detector in
+   terms of a coupled rotation axis and radial scan axis to form
+   a spiral scan.  The rotation axis is called  ELEMENT_ROT  and the
+   radial axis is called ELEMENT_RAD.  A 150 micrometre radial pitch
+   and a 75 micrometre 'constant velocity' angular pitch are assumed.
+
+   Indexing is carried out first on the rotation axis and the radial axis
+   is made to be dependent on it.
+
+   The two axes are coupled to form an axis set ELEMENT_SPIRAL.
+;
+;    ###CBF: VERSION 1.1
+
+     data_image_1
+
+     # category DIFFRN
+    _diffrn.id P6MB
+    _diffrn.crystal_id P6MB_CRYSTAL7
+
+     # category DIFFRN_SOURCE
+     loop_
+    _diffrn_source.diffrn_id
+    _diffrn_source.source
+    _diffrn_source.type
+      P6MB synchrotron 'SSRL beamline 9-1'
+
+     # category <a href="#diffrn_radiation">DIFFRN_RADIATION</a>
+          loop_
+     <a href="#_diffrn_radiation.diffrn_id">_diffrn_radiation.diffrn_id</a>
+     <a href="#_diffrn_radiation.wavelength_id">_diffrn_radiation.wavelength_id</a>
+     <a href="#_diffrn_radiation.monochromator">_diffrn_radiation.monochromator</a>
+     <a href="#_diffrn_radiation.polarizn_source_ratio">_diffrn_radiation.polarizn_source_ratio</a>
+     <a href="#_diffrn_radiation.polarizn_source_norm">_diffrn_radiation.polarizn_source_norm</a>
+     <a href="#_diffrn_radiation.div_x_source">_diffrn_radiation.div_x_source</a>
+     <a href="#_diffrn_radiation.div_y_source">_diffrn_radiation.div_y_source</a>
+     <a href="#_diffrn_radiation.div_x_y_source">_diffrn_radiation.div_x_y_source</a>
+      P6MB WAVELENGTH1 'Si 111' 0.8 0.0 0.08 0.01 0.00
+
+     # category DIFFRN_RADIATION_WAVELENGTH
+     loop_
+    _diffrn_radiation_wavelength.id
+    _diffrn_radiation_wavelength.wavelength
+    _diffrn_radiation_wavelength.wt
+      WAVELENGTH1 0.98 1.0
+
+     # category <a href="#DIFFRN_DETECTOR">DIFFRN_DETECTOR</a>
+     loop_
+     <a href="#_diffrn_detector.diffrn_id">_diffrn_detector.diffrn_id</a>
+     <a href="#_diffrn_detector.id">_diffrn_detector.id</a>
+     <a href="#_diffrn_detector.type">_diffrn_detector.type</a>
+     <a href="#_diffrn_detector.number_of_axes">_diffrn_detector.number_of_axes</a>
+      P6MB MAR345-SN26 'MAR 345' 4
+
+     # category <a href="#diffrn_detector_axis">DIFFRN_DETECTOR_AXIS</a>
+     loop_
+     <a href="#_diffrn_detector_axis.detector_id">_diffrn_detector_axis.detector_id</a>
+     <a href="#_diffrn_detector_axis.axis_id">_diffrn_detector_axis.axis_id</a>
+      MAR345-SN26 DETECTOR_X
+      MAR345-SN26 DETECTOR_Y
+      MAR345-SN26 DETECTOR_Z
+      MAR345-SN26 DETECTOR_PITCH
+
+     # category <a href="#diffrn_detector_element">DIFFRN_DETECTOR_ELEMENT</a>
+     loop_
+     <a href="#_diffrn_detector_element.id">_diffrn_detector_element.id</a>
+     <a href="#_diffrn_detector_element.detector_id#">_diffrn_detector_element.detector_id</a>
+      ELEMENT1 MAR345-SN26
+
+     # category <a href="#DIFFRN_DATA_FRAME">DIFFRN_DATA_FRAME</a>
+     loop_
+     <a href="#_diffrn_data_frame.id">_diffrn_data_frame.id</a>
+     <a href="#_diffrn_data_frame.detector_element_id">_diffrn_data_frame.detector_element_id</a>
+     <a href="#_diffrn_data_frame.array_id">_diffrn_data_frame.array_id</a>
+     <a href="#_diffrn_data_frame.binary_id">_diffrn_data_frame.binary_id</a>
+      FRAME1 ELEMENT1 ARRAY1 1
+
+     # category <a href="#diffrn_measurement">DIFFRN_MEASUREMENT</a>
+     loop_
+     <a href="#_diffrn_measurement.diffrn_id">_diffrn_measurement.diffrn_id</a>
+     <a href="#_diffrn_measurement.id">_diffrn_measurement.id</a>
+     <a href="#_diffrn_measurement.number_of_axes">_diffrn_measurement.number_of_axes</a>
+     <a href="#_diffrn_measurement.method">_diffrn_measurement.method</a>
+      P6MB GONIOMETER 3 rotation
+
+     # category <a href="#diffrn_measurement_axis">DIFFRN_MEASUREMENT_AXIS</a>
+     loop_
+     <a href="#_diffrn_measurement_axis.measurement_id">_diffrn_measurement_axis.measurement_id</a>
+     <a href="#_diffrn_measurement_axis.axis_id">_diffrn_measurement_axis.axis_id</a>
+      GONIOMETER GONIOMETER_PHI
+      GONIOMETER GONIOMETER_KAPPA
+      GONIOMETER GONIOMETER_OMEGA
+
+     # category <a href="#diffrn_scan">DIFFRN_SCAN</a>
+     loop_
+     <a href="#_diffrn_scan.id" >_diffrn_scan.id</a>
+     <a href="#_diffrn_scan.frame_id_start" >_diffrn_scan.frame_id_start</a>
+     <a href="#_diffrn_scan.frame_id_end" >_diffrn_scan.frame_id_end</a>
+     <a href="#_diffrn_scan.frames" >_diffrn_scan.frames</a>
+      SCAN1 FRAME1 FRAME1 1
+
+     # category <a href="#diffrn_scan_axis">DIFFRN_SCAN_AXIS</a>
+     loop_
+     <a href="#_diffrn_scan_axis.scan_id" >_diffrn_scan_axis.scan_id</a>
+     <a href="#_diffrn_scan_axis.axis_id" >_diffrn_scan_axis.axis_id</a>
+     <a href="#_diffrn_scan_axis.angle_start" >_diffrn_scan_axis.angle_start</a>
+     <a href="#_diffrn_scan_axis.angle_range" >_diffrn_scan_axis.angle_range</a>
+     <a href="#_diffrn_scan_axis.angle_increment" >_diffrn_scan_axis.angle_increment</a>
+     <a href="#_diffrn_scan_axis.displacement_start" >_diffrn_scan_axis.displacement_start</a>
+     <a href="#_diffrn_scan_axis.displacement_range" >_diffrn_scan_axis.displacement_range</a>
+     <a href="#_diffrn_scan_axis.displacement_increment" >_diffrn_scan_axis.displacement_increment</a>
+      SCAN1 GONIOMETER_OMEGA 12.0 1.0 1.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_KAPPA 23.3 0.0 0.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_PHI -165.8 0.0 0.0 0.0 0.0 0.0
+      SCAN1 DETECTOR_Z 0.0 0.0 0.0 -240.0 0.0 0.0
+      SCAN1 DETECTOR_Y 0.0 0.0 0.0 0.6 0.0 0.0
+      SCAN1 DETECTOR_X 0.0 0.0 0.0 -0.5 0.0 0.0
+      SCAN1 DETECTOR_PITCH 0.0 0.0 0.0 0.0 0.0 0.0
+
+     # category <a href="#diffrn_scan_frame">DIFFRN_SCAN_FRAME</a>
+     loop_
+     <a href="#_diffrn_scan_frame.frame_id" >_diffrn_scan_frame.frame_id</a>
+     <a href="#_diffrn_scan_frame.frame_number" >_diffrn_scan_frame.frame_number</a>
+     <a href="#_diffrn_scan_frame.integration_time" >_diffrn_scan_frame.integration_time</a>
+     <a href="#_diffrn_scan_frame.scan_id" >_diffrn_scan_frame.scan_id</a>
+     <a href="#_diffrn_scan_frame.date" >_diffrn_scan_frame.date</a>
+      FRAME1 1 20.0 SCAN1 1997-12-04T10:23:48
+
+     # category <a href="#diffrn_scan_frame_axis">DIFFRN_SCAN_FRAME_AXIS</a>
+     loop_
+     <a href="#_diffrn_scan_frame_axis.frame_id" >_diffrn_scan_frame_axis.frame_id</a>
+     <a href="#_diffrn_scan_frame_axis.axis_id" >_diffrn_scan_frame_axis.axis_id</a>
+     <a href="#_diffrn_scan_frame_axis.angle" >_diffrn_scan_frame_axis.angle</a>
+     <a href="#_diffrn_scan_frame_axis.displacement" >_diffrn_scan_frame_axis.displacement</a>
+      FRAME1 GONIOMETER_OMEGA 12.0 0.0
+      FRAME1 GONIOMETER_KAPPA 23.3 0.0
+      FRAME1 GONIOMETER_PHI -165.8 0.0
+      FRAME1 DETECTOR_Z 0.0 -240.0
+      FRAME1 DETECTOR_Y 0.0 0.6
+      FRAME1 DETECTOR_X 0.0 -0.5
+      FRAME1 DETECTOR_PITCH 0.0 0.0
+
+     # category <a href="#AXIS">AXIS</a>
+     loop_
+     <a href="#_axis.id">_axis.id</a>
+     <a href="#_axis.type">_axis.type</a>
+     <a href="#_axis.equipment">_axis.equipment</a>
+     <a href="#_axis.depends_on">_axis.depends_on</a>
+     <a href="#_axis.vector[1]">_axis.vector[1]</a> <a href="#_axis.vector[2]">_axis.vector[2]</a> <a href="#_axis.vector[3]">_axis.vector[3]</a>
+     <a href="#_axis.offset[1]">_axis.offset[1]</a> <a href="#_axis.offset[2]">_axis.offset[2]</a> <a href="#_axis.offset[3]">_axis.offset[3]</a>
+      GONIOMETER_OMEGA rotation goniometer . 1 0 0 . . .
+      GONIOMETER_KAPPA rotation goniometer GONIOMETER_OMEGA 0.64279
+      0 0.76604 . . .
+      GONIOMETER_PHI   rotation goniometer GONIOMETER_KAPPA 1 0 0
+     . . .
+      SOURCE           general source . 0 0 1 . . .
+      GRAVITY          general gravity . 0 -1 0 . . .
+      DETECTOR_Z       translation detector . 0 0 1 0 0 0
+      DETECTOR_Y       translation detector DETECTOR_Z 0 1 0 0 0 0
+      DETECTOR_X       translation detector DETECTOR_Y 1 0 0 0 0 0
+      DETECTOR_PITCH   rotation    detector DETECTOR_X 0 1 0 0 0 0
+      ELEMENT_ROT      translation detector DETECTOR_PITCH 0 0 1 0 0 0
+      ELEMENT_RAD      translation detector ELEMENT_ROT 0 1 0 0 0 0
+
+     # category <a href="#array_structure_list">ARRAY_STRUCTURE_LIST</a>
+     loop_
+     <a href="#_array_structure_list.array_id">_array_structure_list.array_id</a>
+     <a href="#_array_structure_list.index">_array_structure_list.index</a>
+     <a href="#_array_structure_list.dimension">_array_structure_list.dimension</a>
+     <a href="#_array_structure_list.precedence">_array_structure_list.precedence</a>
+     <a href="#_array_structure_list.direction">_array_structure_list.direction</a>
+     <a href="#_array_structure_list.axis_set_id">_array_structure_list.axis_set_id</a>
+      ARRAY1 1 8309900 1 increasing ELEMENT_SPIRAL
+
+     # category <a href="#array_structure_list_axis">ARRAY_STRUCTURE_LIST_AXIS</a>
+     loop_
+     <a href="#_array_structure_list_axis.axis_set_id">_array_structure_list_axis.axis_set_id</a>
+     <a href="#_array_structure_list_axis.axis_id">_array_structure_list_axis.axis_id</a>
+     <a href="#_array_structure_list_axis.angle">_array_structure_list_axis.angle</a>
+     <a href="#_array_structure_list_axis.displacement">_array_structure_list_axis.displacement</a>
+     <a href="#_array_structure_list_axis.angular_pitch">_array_structure_list_axis.angular_pitch</a>
+     <a href="#_array_structure_list_axis.radial_pitch">_array_structure_list_axis.radial_pitch</a>
+      ELEMENT_SPIRAL ELEMENT_ROT 0    .  0.075   .
+      ELEMENT_SPIRAL ELEMENT_RAD . 172.5  .    -0.150
+
+     # category <a href="#array_element_size">ARRAY_ELEMENT_SIZE</a>
+     # the actual pixels are 0.075 by 0.150 mm
+     # We give the coarser dimension here.
+     loop_
+     <a href="#_array_element_size.array_id">_array_element_size.array_id</a>
+     <a href="#_array_element_size.index">_array_element_size.index</a>
+     <a href="#_array_element_size.index">_array_element_size.size</a>
+      ARRAY1 1 150e-6
+
+     # category <a href="#array_intensities">ARRAY_INTENSITIES</a>
+     loop_
+     <a href="#_array_intensities.array_id">_array_intensities.array_id</a>
+     <a href="#_array_intensities.binary_id">_array_intensities.binary_id</a>
+     <a href="#_array_intensities.linearity">_array_intensities.linearity</a>
+     <a href="#_array_intensities.gain">_array_intensities.gain</a>
+     <a href="#_array_intensities.gain_esd">_array_intensities.gain_esd</a>
+     <a href="#_array_intensities.overload">_array_intensities.overload</a>
+     <a href="#_array_intensities.undefined_value">_array_intensities.undefined_value</a>
+      ARRAY1 1 linear 1.15 0.2 240000 0
+
+      # category <a href="#array_structure">ARRAY_STRUCTURE</a>
+     loop_
+      <a href="#_array_structure.id">_array_structure.id</a>
+      <a href="#_array_structure.encoding_type">_array_structure.encoding_type</a>
+      <a href="#_array_structure.compression_type">_array_structure.compression_type</a>
+      <a href="#_array_structure.byte_order">_array_structure.byte_order</a>
+      ARRAY1 "signed 32-bit integer" packed little_endian
+
+     # category <a href="#array_data">ARRAY_DATA</a>
+     loop_
+     <a href="#_array_data.array_id">_array_data.array_id</a>
+     <a href="#_array_data.binary_id">_array_data.binary_id</a>
+     <a href="#_array_data.data">_array_data.data</a>
+      ARRAY1 1
+     ;
+     --CIF-BINARY-FORMAT-SECTION--
+     Content-Type: application/octet-stream;
+         conversions="<b>X</b>-CBF_PACKED"
+     Content-Transfer-Encoding: BASE64
+     <b>X</b>-Binary-Size: 3801324
+     <b>X</b>-Binary-ID: 1
+     <b>X</b>-Binary-Element-Type: "signed 32-bit integer"
+     Content-MD5: 07lZFvF+aOcW85IN7usl8A==
+
+     AABRAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZBQSr1sKNBOeOe9HITdMdDUnbq7bg
+     ...
+     8REo6TtBrxJ1vKqAvx9YDMD6J18Qg83OMr/tgssjMIJMXATDsZobL90AEXc4KigE
+
+     --CIF-BINARY-FORMAT-SECTION----
+     ;
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+       save_
+
+
+save_<a name="_diffrn_scan.id" >_diffrn_scan.id</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_scan.id" >_diffrn_scan.id</a> uniquely identifies each
+              scan.  The identifier is used to tie together all the
+              information about the scan.
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+       '<a href="#_diffrn_scan.id" >_diffrn_scan.id</a>'                 diffrn_scan             yes
+       '<a href="#_diffrn_scan_axis.scan_id" >_diffrn_scan_axis.scan_id</a>'       diffrn_scan_axis        yes
+       '<a href="#_diffrn_scan_collection.scan_id" >_diffrn_scan_collection.scan_id</a>'
+                                           diffrn_scan_collection  implicit
+       '<a href="#_diffrn_scan_frame.scan_id" >_diffrn_scan_frame.scan_id</a>'      diffrn_scan_frame       yes
+    _item_type.code               code
+     loop_
+    _item_linked.child_name
+    _item_linked.parent_name
+       '<a href="#_diffrn_scan_axis.scan_id" >_diffrn_scan_axis.scan_id</a>'          '<a href="#_diffrn_scan.id" >_diffrn_scan.id</a>'
+       '<a href="#_diffrn_scan_collection.scan_id" >_diffrn_scan_axis.scan_id</a>'          '<a href="#_diffrn_scan.id" >_diffrn_scan.id</a>'
+       '<a href="#_diffrn_scan_frame.scan_id" >_diffrn_scan_frame.scan_id</a>'         '<a href="#_diffrn_scan.id" >_diffrn_scan.id</a>'
+     save_
+
+
+save_<a name="_diffrn_scan.date_end">_diffrn_scan.date_end</a>
+    _item_description.description
+;             The date and time of the end of the scan.  Note that this
+              may be an estimate generated during the scan, before the
+              precise time of the end of the scan is known, in which
+              case <a href="#_diffrn_scan.date_end_estimated">_diffrn_scan.date_end_estimated</a> should be used instead.
+;
+    _item.name                 '<a href="#_diffrn_scan.date_end">_diffrn_scan.date_end</a>'
+    _item.category_id          diffrn_scan
+    _item.mandatory_code       no
+    _item_type.code            yyyy-mm-dd
+     save_
+
+
+save_<a name="_diffrn_scan.date_end_estimated">_diffrn_scan.date_end_estimated</a>
+    _item_description.description
+;             The estimated date and time of the end of the scan.  Note 
+              that this may be generated at the start or during the scan,
+              before the precise time of the end of the scan is known.
+;
+    _item.name                 '<a href="#_diffrn_scan.date_end_estimated">_diffrn_scan.date_end_estimated</a>'
+    _item.category_id          diffrn_scan
+    _item.mandatory_code       yes
+    _item_type.code            yyyy-mm-dd
+     save_
+
+
+save_<a name="_diffrn_scan.date_start">_diffrn_scan.date_start</a>
+    _item_description.description
+;             The date and time of the start of the scan.
+;
+    _item.name                 '<a href="#_diffrn_scan.date_start">_diffrn_scan.date_start</a>'
+    _item.category_id          diffrn_scan
+    _item.mandatory_code       yes
+    _item_type.code            yyyy-mm-dd
+     save_
+
+
+save_<a name="_diffrn_scan.integration_time" >_diffrn_scan.integration_time</a>
+    _item_description.description
+;             Approximate average time in seconds to integrate each
+              step of the scan.  The precise time for integration
+              of each particular step must be provided in
+              <a href="#_diffrn_scan_frame.integration_time" >_diffrn_scan_frame.integration_time</a>, even
+              if all steps have the same integration time.
+;
+    _item.name                 '<a href="#_diffrn_scan.integration_time" >_diffrn_scan.integration_time</a>'
+    _item.category_id          diffrn_scan
+    _item.mandatory_code       no
+    _item_type.code            float
+    _item_units.code           'seconds'
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0.0
+     save_
+
+
+save_<a name="_diffrn_scan.frame_id_start" >_diffrn_scan.frame_id_start</a>
+    _item_description.description
+;             The value of this data item is the identifier of the
+              first frame in the scan.
+
+              This item is a pointer to <a href="#_diffrn_data_frame.id" >_diffrn_data_frame.id</a> in the
+              <a href="#DIFFRN_DATA_FRAME">DIFFRN_DATA_FRAME</a> category.
+;
+    _item.name                 '<a href="#_diffrn_scan.frame_id_start" >_diffrn_scan.frame_id_start</a>'
+    _item.category_id          diffrn_scan
+    _item.mandatory_code       yes
+    _item_type.code            code
+     save_
+
+
+save_<a name="_diffrn_scan.frame_id_end" >_diffrn_scan.frame_id_end</a>
+    _item_description.description
+;             The value of this data item is the identifier of the
+              last frame in the scan.
+
+              This item is a pointer to <a href="#_diffrn_data_frame.id" >_diffrn_data_frame.id</a> in the
+              <a href="#DIFFRN_DATA_FRAME">DIFFRN_DATA_FRAME</a> category.
+;
+    _item.name                 '<a href="#_diffrn_scan.frame_id_end" >_diffrn_scan.frame_id_end</a>'
+    _item.category_id          diffrn_scan
+    _item.mandatory_code       yes
+    _item_type.code            code
+     save_
+
+
+save_<a name="_diffrn_scan.frames" >_diffrn_scan.frames</a>
+    _item_description.description
+;             The value of this data item is the number of frames in
+              the scan.
+;
+    _item.name                 '<a href="#_diffrn_scan.frames" >_diffrn_scan.frames</a>'
+    _item.category_id          diffrn_scan
+    _item.mandatory_code       no
+    _item_type.code            int
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   1
+                            1   1
+     save_
+
+save_<a name="_diffrn_scan.time_period" >_diffrn_scan.time_period</a>
+    _item_description.description
+;             Approximate average time in seconds between the start
+              of each step of the scan.  The precise start-to-start
+              time increment of each particular step may be provided in
+              <a href="#_diffrn_scan_frame.time_period" >_diffrn_scan_frame.time_period</a>.
+;
+    _item.name                 '<a href="#_diffrn_scan.time_period" >_diffrn_scan.time_period</a>'
+    _item.category_id          diffrn_scan
+    _item.mandatory_code       no
+    _item_type.code            float
+    _item_units.code           'seconds'
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0.0
+     save_
+
+
+save_<a name="_diffrn_scan.time_rstrt_incr" >_diffrn_scan.time_rstrt_incr</a>
+    _item_description.description
+;             Approximate average time in seconds between the end
+              of integration of each step of the scan and the start
+              of integration of the next step.
+
+              In general, this will agree with
+              <a href="#_diffrn_scan_frame.time_rstrt_incr" >_diffrn_scan_frame.time_rstrt_incr</a>.  The
+              sum of the values of <a href="#_diffrn_scan_frame.integration_time" >_diffrn_scan_frame.integration_time</a>
+              and  <a href="#_diffrn_scan_frame.time_rstrt_incr" >_diffrn_scan_frame.time_rstrt_incr</a> is the
+              time from the start of integration of one frame and the start of
+              integration for the next frame and should equal the value of
+              <a href="#_diffrn_scan_frame.time_period" >_diffrn_scan_frame.time_period</a> for this
+              frame.   If the individual frame values vary, then the value of
+              <a href="#_diffrn_scan.time_rstrt_incr" >_diffrn_scan.time_rstrt_incr</a> will be
+              representative of the ensemble of values of
+              <a href="#_diffrn_scan_frame.time_rstrt_incr" >_diffrn_scan_frame.time_rstrt_incr</a> (e.g.
+              the mean).
+;
+    _item.name                 '<a href="#_diffrn_scan.time_rstrt_incr" >_diffrn_scan.time_rstrt_incr</a>'
+    _item.category_id          diffrn_scan
+    _item.mandatory_code       no
+    _item_type.code            float
+    _item_units.code           'seconds'
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0.0
+     save_
+
+
+save_<a name="_diffrn_scan.variant" >_diffrn_scan.variant</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_scan.variant" >_diffrn_scan.variant</a> gives the variant
+              to which the given DIFFRN_SCAN row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to <a href="#_variant.variant" >_variant.variant</a> in the
+              <a href="#variant">VARIANT</a> category.
+;
+    _item.name                  '<a href="#_diffrn_scan.variant" >_diffrn_scan.variant</a>'
+    _item.category_id             diffrn_scan
+    _item.mandatory_code          implicit
+    _item_default.value           .
+    _item_type.code               code
+     save_
+
+
+####################
+# <a name="diffrn_scan_axis">DIFFRN_SCAN_AXIS</a> #
+####################
+
+save_DIFFRN_SCAN_AXIS
+    _category.description
+;   Data items in the <a href="#diffrn_scan_axis">DIFFRN_SCAN_AXIS</a> category describe the settings of
+    axes for particular scans.  Unspecified axes are assumed to be at
+    their zero points.
+;
+    _category.id                   diffrn_scan_axis
+    _category.mandatory_code       no
+<div id="print_NX_diffrn_scan_axis" style="display:block">   #_category.NX_mapping_details in online version <a href="javascript:open_close2('online_NX_diffrn_scan_axis','print_NX_diffrn_scan_axis');">+/-</a>
+</div><div id="online_NX_diffrn_scan_axis" style="display:none">    _category.NX_mapping_details                  #<a href="javascript:open_close2('online_NX_diffrn_scan_axis','print_NX_diffrn_scan_axis');">+/-</a>
+;
+
+    _diffrn_scan_axis.axis_id AXISID-->
+    _diffrn_scan_axis.angle_start ANGSTART
+    _diffrn_scan_axis.angle_range ANGRANGE 
+    _diffrn_scan_axis.angle_increment ANGINC 
+    _diffrn_scan_axis.angle_rstrt_incr ANGRSTRT 
+    _diffrn_scan_axis.displacement_start DISPSTART 
+    _diffrn_scan_axis.displacement_range DISPRANGE 
+    _diffrn_scan_axis.displacement_increment DISPINC 
+    _diffrn_scan_axis.displacement_increment DISPINC 
+    _diffrn_scan_axis.displacement_rstrt_incr DISPRSTRT 
+    _diffrn_scan_axis.reference_angle ANG 
+    _diffrn_scan_axis.reference_displacement DISP 
+    _diffrn_scan_axis.scan_id SCANID
+
+    -->
+
+    { /entry:NXentry
+      /CBF_scan_id="SCANID"
+      /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+    for AXISEQUIPMENT=="detector"}
+    {  /CBF_diffrn_scan__SCANID:NXentry
+         /sample:NXsample
+    for AXISEQUIPMENT=="goniometer"}
+    {  /CBF_diffrn_scan__SCANID:NXentry
+    for AXISEQUIPMENT=="general"}
+         /transformations:NXtransformations
+           /AXISID=[]
+             @diffrn_scan_axis__angle_start=ANGSTART
+             @diffrn_scan_axis__angle_range=ANGRANGE
+             @diffrn_scan_axis__angle_increment=ANGINC
+             @diffrn_scan_axis__angle_rstrt_incr=ANGRSTRT
+             @diffrn_scan_axis__displacement_start=DISPSTART
+             @diffrn_scan_axis__displacement_range=DISPRANGE
+             @diffrn_scan_axis__displacement_increment=DISPINC
+             @diffrn_scan_axis__displacement_rstrt_incr=DISPRSTRT
+             @diffrn_scan_axis__reference_angle=ANG
+             @diffrn_scan_axis__reference_displacement=DISP
+
+
+;
+</div>     loop_
+    _category_key.name
+                                  '<a href="#_diffrn_scan_axis.scan_id" >_diffrn_scan_axis.scan_id</a>'
+                                  '<a href="#_diffrn_scan_axis.axis_id" >_diffrn_scan_axis.axis_id</a>'
+                                  '<a href="#_diffrn_scan_axis.variant" >_diffrn_scan_axis.variant</a>'
+     loop_
+    _category_group.id           'inclusive_group'
+                                 'diffrn_group'
+     save_
+
+
+save_<a name="_diffrn_scan_axis.scan_id" >_diffrn_scan_axis.scan_id</a>
+    _item_description.description
+;             The value of this data item is the identifier of the
+              scan for which axis settings are being specified.
+
+              Multiple axes may be specified for the same value of
+              <a href="#_diffrn_scan.id" >_diffrn_scan.id</a>.
+
+              This item is a pointer to <a href="#_diffrn_scan.id" >_diffrn_scan.id</a> in the
+              <a href="#diffrn_scan">DIFFRN_SCAN</a> category.
+;
+    _item.name                 '<a href="#_diffrn_scan_axis.scan_id" >_diffrn_scan_axis.scan_id</a>'
+    _item.category_id          diffrn_scan_axis
+    _item.mandatory_code       yes
+    _item_type.code            code
+     save_
+
+
+save_<a name="_diffrn_scan_axis.axis_id" >_diffrn_scan_axis.axis_id</a>
+    _item_description.description
+;             The value of this data item is the identifier of one of
+              the axes for the scan for which settings are being specified.
+
+              Multiple axes may be specified for the same value of
+              <a href="#_diffrn_scan.id" >_diffrn_scan.id</a>.
+
+              This item is a pointer to <a href="#_axis.id" >_axis.id</a> in the
+              AXIS category.
+;
+    _item.name                 '<a href="#_diffrn_scan_axis.axis_id" >_diffrn_scan_axis.axis_id</a>'
+    _item.category_id          diffrn_scan_axis
+    _item.mandatory_code       yes
+    _item_type.code            code
+     save_
+
+
+save_<a name="_diffrn_scan_axis.angle_start" >_diffrn_scan_axis.angle_start</a>
+    _item_description.description
+;             The starting position for the specified axis in degrees.
+;
+    _item.name                 '<a href="#_diffrn_scan_axis.angle_start" >_diffrn_scan_axis.angle_start</a>'
+    _item.category_id          diffrn_scan_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'degrees'
+     save_
+
+
+save_<a name="_diffrn_scan_axis.angle_range" >_diffrn_scan_axis.angle_range</a>
+    _item_description.description
+;             The range from the starting position for the specified axis
+              in degrees.
+;
+    _item.name                 '<a href="#_diffrn_scan_axis.angle_range" >_diffrn_scan_axis.angle_range</a>'
+    _item.category_id          diffrn_scan_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'degrees'
+     save_
+
+
+save_<a name="_diffrn_scan_axis.angle_increment" >_diffrn_scan_axis.angle_increment</a>
+    _item_description.description
+;             The increment for each step for the specified axis
+              in degrees.  In general, this will agree with
+              <a href="#_diffrn_scan_frame_axis.angle_increment" >_diffrn_scan_frame_axis.angle_increment</a>. The
+              sum of the values of <a href="#_diffrn_scan_frame_axis.angle">_diffrn_scan_frame_axis.angle</a> and
+              <a href="#_diffrn_scan_frame_axis.angle_increment">_diffrn_scan_frame_axis.angle_increment</a> is the
+              angular setting of the axis at the end of the integration
+              time for a given frame.  If the individual frame values
+              vary, then the value of
+              <a href="#_diffrn_scan_axis.angle_increment">_diffrn_scan_axis.angle_increment</a> will be
+              representative
+              of the ensemble of values of
+              <a href="#_diffrn_scan_frame_axis.angle_increment">_diffrn_scan_frame_axis.angle_increment</a> (e.g.
+              the mean).
+;
+    _item.name                 '<a href="#_diffrn_scan_axis.angle_increment" >_diffrn_scan_axis.angle_increment</a>'
+    _item.category_id          diffrn_scan_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'degrees'
+     save_
+
+
+save_<a name="_diffrn_scan_axis.angle_rstrt_incr">_diffrn_scan_axis.angle_rstrt_incr</a>
+    _item_description.description
+;             The increment after each step for the specified axis
+              in degrees.  In general, this will agree with
+              <a href="#_diffrn_scan_frame_axis.angle_rstrt_incr" >_diffrn_scan_frame_axis.angle_rstrt_incr</a>.  The
+              sum of the values of <a href="#_diffrn_scan_frame_axis.angle" >_diffrn_scan_frame_axis.angle</a>,
+              <a href="#_diffrn_scan_frame_axis.angle_increment" >_diffrn_scan_frame_axis.angle_increment</a>
+              and  <a href="#_diffrn_scan_frame_axis.angle_rstrt_incr" >_diffrn_scan_frame_axis.angle_rstrt_incr</a> is the
+              angular setting of the axis at the start of the integration
+              time for the next frame relative to a given frame and
+              should equal <a href="#_diffrn_scan_frame_axis.angle" >_diffrn_scan_frame_axis.angle</a> for this
+              next frame.   If the individual frame values
+              vary, then the value of
+              <a href="#_diffrn_scan_axis.angle_rstrt_incr" >_diffrn_scan_axis.angle_rstrt_incr</a> will be
+              representative
+              of the ensemble of values of
+              <a href="#_diffrn_scan_frame_axis.angle_rstrt_incr" >_diffrn_scan_frame_axis.angle_rstrt_incr</a> (e.g.
+              the mean).
+;
+    _item.name                 '<a href="#_diffrn_scan_axis.angle_rstrt_incr">_diffrn_scan_axis.angle_rstrt_incr</a>'
+    _item.category_id          diffrn_scan_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'degrees'
+     save_
+
+
+save_<a name="_diffrn_scan_axis.displacement_start" >_diffrn_scan_axis.displacement_start</a>
+    _item_description.description
+;             The starting position for the specified axis in millimetres.
+;
+    _item.name                 '<a href="#_diffrn_scan_axis.displacement_start" >_diffrn_scan_axis.displacement_start</a>'
+    _item.category_id          diffrn_scan_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save_<a name="_diffrn_scan_axis.displacement_range" >_diffrn_scan_axis.displacement_range</a>
+    _item_description.description
+;             The range from the starting position for the specified axis
+              in millimetres.
+;
+    _item.name                 '<a href="#_diffrn_scan_axis.displacement_range" >_diffrn_scan_axis.displacement_range</a>'
+    _item.category_id          diffrn_scan_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save_<a name="_diffrn_scan_axis.displacement_increment" >_diffrn_scan_axis.displacement_increment</a>
+    _item_description.description
+;             The increment for each step for the specified axis
+              in millimetres.  In general, this will agree with
+              <a href="#_diffrn_scan_frame_axis.displacement_increment">_diffrn_scan_frame_axis.displacement_increment</a>.
+              The sum of the values of
+              <a href="#_diffrn_scan_frame_axis.displacement" >_diffrn_scan_frame_axis.displacement</a> and
+              <a href="#_diffrn_scan_frame_axis.displacement_increment" >_diffrn_scan_frame_axis.displacement_increment</a> is the
+              angular setting of the axis at the end of the integration
+              time for a given frame.  If the individual frame values
+              vary, then the value of
+               <a href="#_diffrn_scan_axis.displacement_increment" >_diffrn_scan_axis.displacement_increment</a> will be
+              representative of the ensemble of values of
+               <a href="#_diffrn_scan_frame_axis.displacement_increment" >_diffrn_scan_frame_axis.displacement_increment</a> (e.g.
+               the mean).
+;
+    _item.name                 '<a href="#_diffrn_scan_axis.displacement_increment" >_diffrn_scan_axis.displacement_increment</a>'
+    _item.category_id          diffrn_scan_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save_<a name="_diffrn_scan_axis.displacement_rstrt_incr">_diffrn_scan_axis.displacement_rstrt_incr</a>
+    _item_description.description
+;             The increment for each step for the specified axis
+              in millimetres.  In general, this will agree with
+              <a href="#_diffrn_scan_frame_axis.displacement_rstrt_incr">_diffrn_scan_frame_axis.displacement_rstrt_incr</a>.
+              The sum of the values of
+              <a href="#_diffrn_scan_frame_axis.displacement" >_diffrn_scan_frame_axis.displacement</a>,
+              <a href="#_diffrn_scan_frame_axis.displacement_increment" >_diffrn_scan_frame_axis.displacement_increment</a> and
+              <a href="#_diffrn_scan_frame_axis.displacement_rstrt_incr" >_diffrn_scan_frame_axis.displacement_rstrt_incr</a> is the
+              angular setting of the axis at the start of the integration
+              time for the next frame relative to a given frame and
+              should equal <a href="#_diffrn_scan_frame_axis.displacement" >_diffrn_scan_frame_axis.displacement</a>
+              for this next frame.  If the individual frame values
+              vary, then the value of
+              <a href="#_diffrn_scan_axis.displacement_rstrt_incr" >_diffrn_scan_axis.displacement_rstrt_incr</a> will be
+              representative of the ensemble of values of
+               <a href="#_diffrn_scan_frame_axis.displacement_rstrt_incr" >_diffrn_scan_frame_axis.displacement_rstrt_incr</a> (e.g.
+               the mean).
+;
+    _item.name                 '<a href="#_diffrn_scan_axis.displacement_rstrt_incr">_diffrn_scan_axis.displacement_rstrt_incr</a>'
+    _item.category_id          diffrn_scan_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save_<a name="_diffrn_scan_axis.reference_angle">_diffrn_scan_axis.reference_angle</a>
+    _item_description.description
+;             The setting of the specified axis in degrees
+              against which measurements of the reference beam centre
+              and reference detector distance should be made.
+
+              In general, this will agree with
+              <a href="#_diffrn_scan_frame_axis.reference_angle">_diffrn_scan_frame_axis.reference_angle</a>.
+
+              If the individual frame values vary, then the value of
+              <a href="#_diffrn_scan_axis.reference_angle">_diffrn_scan_axis.reference_angle</a> will be
+              representative of the ensemble of values of
+              <a href="#_diffrn_scan_frame_axis.reference_angle">_diffrn_scan_frame_axis.reference_angle</a> (e.g.
+              the mean).
+
+              If not specified, the value defaults to zero.
+;
+    _item.name                 '<a href="#_diffrn_scan_axis.reference_angle">_diffrn_scan_axis.reference_angle</a>'
+    _item.category_id          diffrn_scan_axis
+    _item.mandatory_code       implicit
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'degrees'
+     save_
+
+
+save_<a name="_diffrn_scan_axis.reference_displacement">_diffrn_scan_axis.reference_displacement</a>
+    _item_description.description
+;             The setting of the specified axis in millimetres
+              against which measurements of the reference beam centre
+              and reference detector distance should be made.
+
+              In general, this will agree with
+              <a href="#_diffrn_scan_frame_axis.reference_displacement">_diffrn_scan_frame_axis.reference_displacement</a>.
+
+              If the individual frame values vary, then the value of
+              <a href="#_diffrn_scan_axis.reference_displacement">_diffrn_scan_axis.reference_displacement</a> will be
+              representative of the ensemble of values of
+              <a href="#_diffrn_scan_frame_axis.reference_displacement">_diffrn_scan_frame_axis.reference_displacement</a> (e.g.
+              the mean).
+
+;
+    _item.name                 '<a href="#_diffrn_scan_axis.reference_displacement">_diffrn_scan_axis.reference_displacement</a>'
+    _item.category_id          diffrn_scan_axis
+    _item.mandatory_code       implicit
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save_<a name="_diffrn_scan_axis.variant" >_diffrn_scan_axis.variant</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_scan_axis.variant" >_diffrn_scan_axis.variant</a> gives the variant
+              to which the given DIFFRN_SCAN_AXIS row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to <a href="#_variant.variant" >_variant.variant</a> in the
+              <a href="#variant">VARIANT</a> category.
+;
+    _item.name                  '<a href="#_diffrn_scan_axis.variant" >_diffrn_scan_axis.variant</a>'
+    _item.category_id             diffrn_scan_axis
+    _item.mandatory_code          implicit
+    _item_default.value           .
+    _item_type.code               code
+     save_
+
+
+##########################
+# <a name="diffrn_scan_collection">DIFFRN_SCAN_COLLECTION</a> #
+##########################
+
+save_DIFFRN_SCAN_COLLECTION
+    _category.description
+;   Data items in the <a href="#diffrn_scan_collection">DIFFRN_SCAN_COLLECTION</a> category describe
+    the collection strategy for each scan.
+
+    This category is a preliminary version being developed as
+    synchrotron and XFEL collection strategies evolve. 
+;
+    _category.id                   diffrn_scan_collection
+    _category.mandatory_code       no
+<div id="print_NX_diffrn_scan_collection" style="display:block">   #_category.NX_mapping_details in online version <a href="javascript:open_close2('online_NX_diffrn_scan_collection','print_NX_diffrn_scan_collection');">+/-</a>
+</div><div id="online_NX_diffrn_scan_collection" style="display:none">    _category.NX_mapping_details                  #<a href="javascript:open_close2('online_NX_diffrn_scan_collection','print_NX_diffrn_scan_collection');">+/-</a>
+;
+
+    _diffrn_scan_collection.type  COLLECTIONTYPE
+    _diffrn_scan_collection.translation_width TRANSLATION_WIDTH
+
+    --> 
+
+    /entry:NXentry
+      /CBF_cbf:NXpdb
+        /image1:NXpdb
+          @NXpdb="CBF_cbfdb"
+          /diffrn_scan_collection:NXpdb
+            @NXpdb="CBF_cbfcat"
+              /type=["COLLECTIONTYP"]
+              /translation_width=["TRANSLATION_WIDTH"]
+;
+</div>     loop_
+    _category_key.name
+                                  '<a href="#_diffrn_scan_collection.scan_id" >_diffrn_scan_collection.scan_id</a>'
+                                  '<a href="#_diffrn_scan_collection.variant" >_diffrn_scan_collection.variant</a>'
+     loop_
+    _category_group.id            'inclusive_group'
+                                  'diffrn_group'
+     loop_
+    _category_examples.case
+    _category_examples.detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;   Example 1 - Describing a multi-wedge raster scan.
+;
+;
+        loop_
+        _diffrn_scan_collection.scan_id
+        _diffrn_scan_collection.details
+       
+        multi_wedge
+    ;   scan 20 micrometre beam in 100 micrometre steps on 31
+        by 46 alternating raster of 20 degree wedges 
+    ;
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save_<a name="_diffrn_scan_collection.details" >_diffrn_scan_collection.details</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_scan_collection.details" >_diffrn_scan_collection.details</a> should give a
+              description of special aspects of each collection strategy.
+;
+    _item.name                  '<a name="_diffrn_scan_collection.details" >_diffrn_scan_collection.details</a>'
+    _item.category_id             diffrn_scan_collection
+    _item.mandatory_code          no
+    _item_type.code               text
+     save_
+
+
+save_<a name="_diffrn_scan_collection.scan_id" >_diffrn_scan_collection.scan_id</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_scan_collection.scan_id" >_diffrn_scan_collection.scan_id</a> identifies the scan
+              containing this frame.
+
+              This item is a pointer to <a href="#_diffrn_scan.id" >_diffrn_scan.id</a> in the
+              <a href="#diffrn_scan">DIFFRN_SCAN</a> category.
+
+              In the case of a single-scan dataset, the value is implicit.
+;
+    _item.name             '<a href="#_diffrn_scan_collection.scan_id">_diffrn_scan_collection.scan_id</a>'
+    _item.category_id        diffrn_scan_collection
+    _item.mandatory_code     implicit
+    _item_type.code          code
+     save_
+
+
+save_<a name="_diffrn_scan_collection.type" >_diffrn_scan_collection.type</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_scan_collection.type" >_diffrn_scan_collection.type</a> identifies
+              the strategy used in this scan, e.g. `rotation', 'raster',
+              'vector', 'still', etc.
+
+              The default is 'rotation'. 
+;
+    _item.name                  '<a href="#_diffrn_scan_collection.type">_diffrn_scan_collection.type</a>'
+    _item.category_id             diffrn_scan_collection
+    _item.mandatory_code          implicit
+    _item_default.value           'rotation'
+    _item_type.code               text
+     save_
+
+
+save_<a name="_diffrn_scan_collection.translation_width" >_diffrn_scan_collection.translation_width</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_scan_collection.translation_width" >_diffrn_scan_collection.translation_width</a>
+              gives the average single step translation in micrometres
+              in collection strategies for which this information is
+               appropriate, e.g. 'vector'.
+;
+    _item.name                  '<a href="#_diffrn_scan_collection.translation_width">_diffrn_scan_collection.translation_width</a>'
+    _item.category_id             diffrn_scan_collection
+    _item.mandatory_code          no
+    _item_default.value           0.0
+    _item_type.code               float
+    _item_units.code              micrometres
+
+     save_
+
+
+save_<a name="_diffrn_scan_collection.variant" >_diffrn_scan_collection.variant</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_scan_collection.variant" >_diffrn_scan_collection.variant</a> gives the variant
+              to which the given DIFFRN_SCAN_COLLECTION row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to <a href="#_variant.variant" >_variant.variant</a> in the
+              <a href="#variant">VARIANT</a> category.
+;
+    _item.name                  '<a href="#_diffrn_scan_collection.variant" >_diffrn_scan_collection.variant</a>'
+    _item.category_id             diffrn_scan_collection
+    _item.mandatory_code          implicit
+    _item_default.value           .
+    _item_type.code               code
+     save_
+
+
+#####################
+# <a name="diffrn_scan_frame">DIFFRN_SCAN_FRAME</a> #
+#####################
+
+save_DIFFRN_SCAN_FRAME
+    _category.description
+;   Data items in the <a href="#diffrn_scan_frame">DIFFRN_SCAN_FRAME</a> category describe
+    the relationships of particular frames to scans.
+;
+    _category.id                   diffrn_scan_frame
+    _category.mandatory_code       no
+<div id="print_NX_diffrn_scan_frame" style="display:block">   #_category.NX_mapping_details in online version <a href="javascript:open_close2('online_NX_diffrn_scan_frame','print_NX_diffrn_scan_frame');">+/-</a>
+</div><div id="online_NX_diffrn_scan_frame" style="display:none">    _category.NX_mapping_details                  #<a href="javascript:open_close2('online_NX_diffrn_scan_frame','print_NX_diffrn_scan_frame');">+/-</a>
+;
+    _diffrn_scan_frame.date  DATETIME
+    _diffrn_scan_frame.frame_id ID
+    _diffrn_scan_frame.frame_number FRAMENUMBER
+    _diffrn_scan_frame.integration_time COUNTTIME
+    _diffrn_scan_frame.polarizn_Stokes_I STOKESI
+    _diffrn_scan_frame.polarizn_Stokes_Q STOKESQ
+    _diffrn_scan_frame.polarizn_Stokes_U STOKESU
+    _diffrn_scan_frame.polarizn_Stokes_V STOKESV
+    _diffrn_scan_frame.scan_id SCANID
+    _diffrn_scan_frame.time_period FRAMETIME
+    _diffrn_scan_frame.time_rstrt_incr RSTRTTIME
+
+    --> 
+
+    /entry:NXentry
+      /CBF_scan_id="SCANID"
+      /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+          /CBF_diffrn_scan_frame__date=["DATETIME"]
+          /CBF_diffrn_scan_frame__frame_id=["ID"]
+          /count_time=[COUNTIME]
+          /frame_time=[FRAMETIME]
+          /frame_restart_time=[RSTRTTIME]
+      /sample:NXsample
+        /beam:NXbeam
+          /incident_polarisation_stokes=[STOKESI,STOKESQ,STOKESU,STOKESV]
+             @units="Watts/meter^2"
+     where each array element is inserted at index FRAMENUMBER          
+;
+</div>     loop_
+    _category_key.name
+                                  '<a href="#_diffrn_scan_frame.scan_id" >_diffrn_scan_frame.scan_id</a>'
+                                  '<a href="#_diffrn_scan_frame.frame_id" >_diffrn_scan_frame.frame_id</a>'
+                                  '<a href="#_diffrn_scan_frame.variant" >_diffrn_scan_frame.variant</a>'
+     loop_
+    _category_group.id            'inclusive_group'
+                                  'diffrn_group'
+     save_
+
+
+save_<a name="_diffrn_scan_frame.date">_diffrn_scan_frame.date</a>
+    _item_description.description
+;             The date and time of the start of the frame being scanned.
+;
+    _item.name                 '<a href="#_diffrn_scan_frame.date">_diffrn_scan_frame.date</a>'
+    _item.category_id          diffrn_scan_frame
+    _item.mandatory_code       no
+    _item_type.code            yyyy-mm-dd
+     save_
+
+
+save_<a name="_diffrn_scan_frame.frame_id" >_diffrn_scan_frame.frame_id</a>
+    _item_description.description
+;             The value of this data item is the identifier of the
+              frame being examined.
+
+              This item is a pointer to <a href="#_diffrn_data_frame.id" >_diffrn_data_frame.id</a> in the
+              <a href="#DIFFRN_DATA_FRAME">DIFFRN_DATA_FRAME</a> category.
+;
+    _item.name                 '<a href="#_diffrn_scan_frame.frame_id" >_diffrn_scan_frame.frame_id</a>'
+    _item.category_id          diffrn_scan_frame
+    _item.mandatory_code       yes
+    _item_type.code            code
+     save_
+
+
+save_<a name="_diffrn_scan_frame.frame_number" >_diffrn_scan_frame.frame_number</a>
+    _item_description.description
+;             The value of this data item is the number of the frame
+              within the scan, starting with 1.  It is not necessarily
+              the same as the value of <a href="#_diffrn_scan_frame.frame_id">_diffrn_scan_frame.frame_id</a>,
+              but it may be.
+
+;
+    _item.name                 '<a href="#_diffrn_scan_frame.frame_number" >_diffrn_scan_frame.frame_number</a>'
+    _item.category_id          diffrn_scan_frame
+    _item.mandatory_code       no
+    _item_type.code            int
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0
+                            0   0
+     save_
+
+
+save_<a name="_diffrn_scan_frame.integration_time">_diffrn_scan_frame.integration_time</a>
+    _item_description.description
+;             The time in seconds to integrate this step of the scan.
+              This should be the precise time of integration of each
+              particular frame.  The value of this data item should
+              be given explicitly for each frame and not inferred
+              from the value of <a href="#_diffrn_scan.integration_time" >_diffrn_scan.integration_time</a>.
+;
+    _item.name                 '<a href="#_diffrn_scan_frame.integration_time" >_diffrn_scan_frame.integration_time</a>'
+    _item.category_id          diffrn_scan_frame
+    _item.mandatory_code       yes
+    _item_type.code            float
+    _item_units.code           'seconds'
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0.0
+     save_
+
+
+save_<a name="_diffrn_scan_frame.polarizn_Stokes_I">_diffrn_scan_frame.polarizn_Stokes_I</a>
+    _item_description.description
+;             The quantity Ip+In+Inp, where Ip is the intensity (amplitude
+              squared) of the electric vector in the plane of polarization,
+              In is the intensity (amplitude squared) of the electric vector
+              in the plane of the normal to the plane of polarization,
+              and Inp is the intensity (amplitude squared) of the
+              non-polarized (incoherent) electric vector.
+
+              This is an average or other representative sample of the
+              frame.
+
+              This is the first of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
+
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
+
+              Note that, if the polarized intensity Ip+In is required,
+              (Ip+In)^2^ is the sum of Q^2^+U^2^+V^2^.
+
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200--3205.
+;
+    _item.name                  '<a href="#_diffrn_scan_frame.polarizn_Stokes_I">_diffrn_scan_frame.polarizn_Stokes_I</a>'
+    _item.category_id             diffrn_scan_frame
+    _item.mandatory_code          implicit
+    _item_default.value           1.0
+     loop_
+    _item_range.maximum
+    _item_range.minimum           
+                                   .    0.0
+                                  0.0   0.0
+    _item_type.code               float
+     save_
+
+save_<a name="_diffrn_scan_frame.polarizn_Stokes_I_esd">_diffrn_scan_frame.polarizn_Stokes_I_esd</a>
+    _item_description.description
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of <A href="#_diffrn_scan_frame.polarizn_Stokes_I">_diffrn_scan_frame.polarizn_Stokes_I</a>,
+              Ip+In+Inp, where Ip is the intensity (amplitude squared)
+              of the electric vector in the plane of polarization,
+              In is the intensity (amplitude squared) of the electric vector
+              in the plane of the normal to the plane of polarization,
+              and Inp is the intensity (amplitude squared) of the
+              non-polarized (incoherent) electric vector.
+;
+    _item.name                  '<a href="#_diffrn_scan_frame.polarizn_Stokes_I_esd">_diffrn_scan_frame.polarizn_Stokes_I_esd</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .      0.0
+                                  0.0    0.0
+    _item_type.code               float
+     loop_
+    _item_related.related_name
+    _item_related.function_code  '<a href="#_diffrn_scan_frame.polarizn_Stokes_I">_diffrn_scan_frame.polarizn_Stokes_I</a>'
+                                 'associated_value'
+     save_
+
+
+save_<a name="_diffrn_scan_frame.polarizn_Stokes_Q">_diffrn_scan_frame.polarizn_Stokes_Q</a>
+    _item_description.description
+;             The quantity (Ip-In)*cos(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory <b>Y</b> axis as defined in the
+              <a href="#AXIS">AXIS</a> category.
+
+              This is an average or other representative sample of the
+              frame.
+
+              This is the second of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
+
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
+
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200--3205.
+;
+    _item.name                  '<a href="#_diffrn_scan_frame.polarizn_Stokes_Q">_diffrn_scan_frame.polarizn_Stokes_Q</a>'
+    _item.category_id             diffrn_scan_frame
+    _item.mandatory_code          no
+     loop_
+    _item_type.code               float
+     save_
+
+
+save_<a name="_diffrn_scan_frame.polarizn_Stokes_Q_esd">_diffrn_scan_frame.polarizn_Stokes_Q_esd</a>
+    _item_description.description
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of <A href="#_diffrn_scan_frame.polarizn_Stokes_Q">_diffrn_scan_frame.polarizn_Stokes_Q</a>,
+              (Ip-In)*cos(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory <b>Y</b>-axis as defined in the
+              <a href="#AXIS">AXIS</a> category.
+;
+    _item.name                  '<a href="#_diffrn_scan_frame.polarizn_Stokes_Q_esd">_diffrn_scan_frame.polarizn_Stokes_Q_esd</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .      0.0
+                                  0.0    0.0
+    _item_type.code               float
+     loop_
+    _item_related.related_name
+    _item_related.function_code  '<a href="#_diffrn_scan_frame.polarizn_Stokes_Q">_diffrn_scan_frame.polarizn_Stokes_Q</a>'
+                                 'associated_value'
+     save_
+
+
+save_<a name="_diffrn_scan_frame.polarizn_Stokes_U">_diffrn_scan_frame.polarizn_Stokes_U</a>
+    _item_description.description
+;             The quantity (Ip-In)*sin(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory <b>Y</b> axis as defined in the
+              <a href="#AXIS">AXIS</a> category.
+
+              This is an average or other representative sample of the
+              frame.
+
+              This is the third of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)]
+
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
+
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200--3205.
+;
+    _item.name                  '<a href="#_diffrn_scan_frame.polarizn_Stokes_U">_diffrn_scan_frame.polarizn_Stokes_U</a>'
+    _item.category_id             diffrn_scan_frame
+    _item.mandatory_code          no
+     loop_
+    _item_type.code               float
+     save_
+
+save_<a name="_diffrn_scan_frame.polarizn_Stokes_U_esd">_diffrn_scan_frame.polarizn_Stokes_U_esd</a>
+    _item_description.description
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of <A href="#_diffrn_scan_frame.polarizn_Stokes_U">_diffrn_scan_frame.polarizn_Stokes_U</a>,
+              (Ip-In)*sin(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory <b>Y</b>-axis as defined in the
+              <a href="#AXIS">AXIS</a> category.
+;
+    _item.name                  '<a href="#_diffrn_scan_frame.polarizn_Stokes_U_esd">_diffrn_scan_frame.polarizn_Stokes_U_esd</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .      0.0
+                                  0.0    0.0
+    _item_type.code               float
+     loop_
+    _item_related.related_name
+    _item_related.function_code  '<a href="#_diffrn_scan_frame.polarizn_Stokes_U">_diffrn_scan_frame.polarizn_Stokes_U</a>'
+                                 'associated_value'
+     save_
+
+
+save_<a name="_diffrn_scan_frame.polarizn_Stokes_V">_diffrn_scan_frame.polarizn_Stokes_V</a>
+    _item_description.description
+;             The quantity +/-2*sqrt(IpIn), with a + sign for right-handed
+              circular polarization, where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization and In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory <b>Y</b> axis as defined in the
+              <a href="#AXIS">AXIS</a> category.
+
+              This is an average or other representative sample of the
+              frame.
+
+              This is the fourth of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
+
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
+
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200--3205.
+;
+    _item.name                  '<a href="#_diffrn_scan_frame.polarizn_Stokes_V">_diffrn_scan_frame.polarizn_Stokes_V</a>'
+    _item.category_id             diffrn_scan_frame
+    _item.mandatory_code          no
+     loop_
+    _item_type.code               float
+     save_
+
+
+save_<a name="_diffrn_scan_frame.polarizn_Stokes_V_esd">_diffrn_scan_frame.polarizn_Stokes_V_esd</a>
+    _item_description.description
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of <A href="#_diffrn_scan_frame.polarizn_Stokes_V">_diffrn_scan_frame.polarizn_Stokes_V</a>,
+              +/-2*sqrt(IpIn), with a + sign for right-handed circular
+              polarization, where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization and In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory <b>Y</b>-axis as defined in the
+              <a href="#AXIS">AXIS</a> category.
+;
+    _item.name                  '<a href="#_diffrn_scan_frame.polarizn_Stokes_V_esd">_diffrn_scan_frame.polarizn_Stokes_V_esd</a>'
+    _item.category_id             diffrn_radiation
+    _item.mandatory_code          no
+     loop_
+    _item_range.maximum
+    _item_range.minimum           .      0.0
+                                  0.0    0.0
+    _item_type.code               float
+     loop_
+    _item_related.related_name
+    _item_related.function_code  '<a href="#_diffrn_scan_frame.polarizn_Stokes_V">_diffrn_scan_frame.polarizn_Stokes_V</a>'
+                                 'associated_value'
+     save_
+
+
+save_<a name="_diffrn_scan_frame.scan_id" >_diffrn_scan_frame.scan_id</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_scan_frame.scan_id" >_diffrn_scan_frame.scan_id</a> identifies the scan
+              containing this frame.
+
+              This item is a pointer to <a href="#_diffrn_scan.id" >_diffrn_scan.id</a> in the
+              <a href="#diffrn_scan">DIFFRN_SCAN</a> category.
+;
+    _item.name             '<a href="#_diffrn_scan_frame.scan_id">_diffrn_scan_frame.scan_id</a>'
+    _item.category_id        diffrn_scan_frame
+    _item.mandatory_code     yes
+    _item_type.code          code
+     save_
+
+
+save_<a name="_diffrn_scan_frame.time_period" >_diffrn_scan_frame.time_period</a>
+    _item_description.description
+;             The time in seconds between the start of this frame and the
+              start of the next frame, if any.  If there is no next frame,
+              a null value should be given.
+;
+    _item.name                 '<a href="#_diffrn_scan_frame.time_period" >_diffrn_scan_frame.time_period</a>'
+    _item.category_id          diffrn_scan_frame
+    _item.mandatory_code       no
+    _item_type.code            float
+    _item_units.code           'seconds'
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0.0
+     save_
+
+
+save_<a name="_diffrn_scan_frame.time_rstrt_incr" >_diffrn_scan_frame.time_rstrt_incr</a>
+    _item_description.description
+;             The time in seconds between the end of integration of this step of the scan
+              and the start of integration of the next step.
+
+              The sum of the values of <a href="#_diffrn_scan_frame.integration_time" >_diffrn_scan_frame.integration_time</a>
+              and  <a href="#_diffrn_scan_frame.time_rstrt_incr" >_diffrn_scan_frame.time_rstrt_incr</a> is the
+              time from the start of integration of one frame and the start of
+              integration for the next frame and should equal the value of
+              <a href="#_diffrn_scan_frame.time_period" >_diffrn_scan_frame.time_period</a> for this
+              frame.   The value of <a href="#_diffrn_scan.time_rstrt_incr" >_diffrn_scan.time_rstrt_incr</a> will be
+              representative of the ensemble of values of
+              <a href="#_diffrn_scan_frame.time_rstrt_incr" >_diffrn_scan_frame.time_rstrt_incr</a> (e.g.
+              the mean).
+
+              If there is no next frame, a null value should be given.
+;
+    _item.name                 '<a href="#_diffrn_scan_frame.time_rstrt_incr" >_diffrn_scan_frame.time_rstrt_incr</a>'
+    _item.category_id          diffrn_scan_frame
+    _item.mandatory_code       no
+    _item_type.code            float
+    _item_units.code           'seconds'
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0.0
+     save_
+
+
+save_<a name="_diffrn_scan_frame.variant" >_diffrn_scan_frame.variant</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_scan_frame.variant" >_diffrn_scan_frame.variant</a> gives the variant
+              to which the given DIFFRN_SCAN_FRAME row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to <a href="#_variant.variant" >_variant.variant</a> in the
+              <a href="#variant">VARIANT</a> category.
+;
+    _item.name                  '<a href="#_diffrn_scan_frame.variant" >_diffrn_scan_frame.variant</a>'
+    _item.category_id             diffrn_scan_frame
+    _item.mandatory_code          implicit
+    _item_default.value           .
+    _item_type.code               code
+     save_
+
+
+##########################
+# <a name="diffrn_scan_frame_axis">DIFFRN_SCAN_FRAME_AXIS</a> #
+##########################
+
+save_DIFFRN_SCAN_FRAME_AXIS
+    _category.description
+;   Data items in the <a href="#diffrn_scan_frame_axis">DIFFRN_SCAN_FRAME_AXIS</a> category describe the
+    settings of axes for particular frames.  Unspecified axes are
+    assumed to be at their zero points.  If, for any given frame,
+    nonzero values apply for any of the data items in this category,
+    those values should be given explicitly in this category and not
+    simply inferred from values in <a href="#diffrn_scan_axis">DIFFRN_SCAN_AXIS</a>.
+;
+    _category.id                   diffrn_scan_frame_axis
+    _category.mandatory_code       no
+<div id="print_NX_diffrn_scan_frame_axis" style="display:block">   #_category.NX_mapping_details in online version <a href="javascript:open_close2('online_NX_diffrn_scan_frame_axis','print_NX_diffrn_scan_frame_axis');">+/-</a>
+</div><div id="online_NX_diffrn_scan_frame_axis" style="display:none">    _category.NX_mapping_details                  #<a href="javascript:open_close2('online_NX_diffrn_scan_frame_axis','print_NX_diffrn_scan_frame_axis');">+/-</a>
+;
+
+    _diffrn_scan_frame_axis.axis_id AXISID
+    _diffrn_scan_frame_axis.angle ANGLE
+    _diffrn_scan_frame_axis.angle_increment ANGLEINCREMENT
+    _diffrn_scan_frame_axis.angle_rstrt_incr ANGLERSTRTINCREMENT
+    _diffrn_scan_frame_axis.displacement DISP 
+    _diffrn_scan_frame_axis.displacement_increment DISPINCREMENT
+    _diffrn_scan_frame_axis.displacement_rstrt_incr DISPRSTRTINCREMENT
+    _diffrn_scan_frame_axis.reference_angle REFANGLE
+    _diffrn_scan_frame_axis.reference_displacement REFDISP
+
+
+    { /entry:NXentry
+      /CBF_scan_id="SCANID"
+      /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+    for AXISEQUIPMENT=="detector"}
+    {  /entry:NXentry
+         /sample:NXsample
+    for AXISEQUIPMENT=="goniometer"}
+    {  /entry:NXentry
+    for AXISEQUIPMENT=="general"}
+         /transformations:NXtransformations
+           /AXISID=[]
+             @diffrn_scan_frame_axis__angle_start=[ANGSTART]
+             @diffrn_scan_frame_axis__angle_range=[ANGRANGE]
+             @diffrn_scan_frame_axis__angle_increment=[ANGINC]
+             @diffrn_scan_frame_axis__angle_rstrt_incr=[ANGRSTRT]
+             @diffrn_scan_frame_axis__displacement_start=[DISPSTART]
+             @diffrn_scan_frame_axis__displacement_range=[DISPRANGE]
+             @diffrn_scan_frame_axis__displacement_increment=[DISPINC]
+             @diffrn_scan_frame_axis__displacement_rstrt_incr=[DISPRSTRT]
+             @diffrn_scan_frame_axis__reference_angle=[ANG]
+             @diffrn_scan_frame_axis__reference_displacement=[DISP]
+
+
+    note that @units="mm" or @units="deg" should also be specified.
+
+    The dimensions of the array depend on np (the number of frames = the
+    value of _diffrn_scan.frames)
+
+    either DISP OR ANGLE is inserted as the i-th element
+    counting from 1 in AXISID where i is the value of
+    _diffrn_scan_frame.frame_number for which the value
+    of _diffrn_scan_frame.frame_id agrees with the
+    value of _diffrn_scan_frame_axis.frame_id
+
+    The remaining tags similarly populate the attribute arrays
+;
+</div>     loop_
+    _category_key.name
+                                  '<a href="#_diffrn_scan_frame_axis.frame_id" >_diffrn_scan_frame_axis.frame_id</a>'
+                                  '<a href="#_diffrn_scan_frame_axis.axis_id" >_diffrn_scan_frame_axis.axis_id</a>'
+                                  '<a href="#_diffrn_scan_frame_axis.variant" >_diffrn_scan_frame_axis.variant</a>'
+     loop_
+    _category_group.id           'inclusive_group'
+                                 'diffrn_group'
+     save_
+
+
+save_<a name="_diffrn_scan_frame_axis.axis_id" >_diffrn_scan_frame_axis.axis_id</a>
+    _item_description.description
+;             The value of this data item is the identifier of one of
+              the axes for the frame for which settings are being specified.
+
+              Multiple axes may be specified for the same value of
+              <a href="#_diffrn_scan_frame.id" >_diffrn_scan_frame.frame_id</a>.
+
+              This item is a pointer to <a href="#_axis.id" >_axis.id</a> in the
+              <a href="#AXIS">AXIS</a> category.
+;
+    _item.name                 '<a href="#_diffrn_scan_frame_axis.axis_id" >_diffrn_scan_frame_axis.axis_id</a>'
+    _item.category_id          diffrn_scan_frame_axis
+    _item.mandatory_code       yes
+    _item_type.code            code
+     save_
+
+
+save_<a name="_diffrn_scan_frame_axis.angle" >_diffrn_scan_frame_axis.angle</a>
+    _item_description.description
+;             The setting of the specified axis in degrees for this frame.
+              This is the setting at the start of the integration time.
+;
+    _item.name                 '<a href="#_diffrn_scan_frame_axis.angle" >_diffrn_scan_frame_axis.angle</a>'
+    _item.category_id          diffrn_scan_frame_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'degrees'
+     save_
+
+
+save_<a name="_diffrn_scan_frame_axis.angle_increment">_diffrn_scan_frame_axis.angle_increment</a>
+    _item_description.description
+;             The increment for this frame for the angular setting of
+              the specified axis in degrees.  The sum of the values
+              of <a href="#_diffrn_scan_frame_axis.angle">_diffrn_scan_frame_axis.angle</a> and
+              <a href="#_diffrn_scan_frame_axis.angle_increment">_diffrn_scan_frame_axis.angle_increment</a> is the
+              angular setting of the axis at the end of the integration
+              time for this frame.
+;
+    _item.name                 '<a href="#_diffrn_scan_frame_axis.angle_increment">_diffrn_scan_frame_axis.angle_increment</a>'
+    _item.category_id          diffrn_scan_frame_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'degrees'
+     save_
+
+
+save_<a name="_diffrn_scan_frame_axis.angle_rstrt_incr">_diffrn_scan_frame_axis.angle_rstrt_incr</a>
+    _item_description.description
+;             The increment after this frame for the angular setting of
+              the specified axis in degrees.  The sum of the values
+              of <a href="#_diffrn_scan_frame_axis.angle">_diffrn_scan_frame_axis.angle</a>,
+              <a href="#_diffrn_scan_frame_axis.angle_increment">_diffrn_scan_frame_axis.angle_increment</a> and
+              <a href="#_diffrn_scan_frame_axis.angle_rstrt_incr">_diffrn_scan_frame_axis.angle_rstrt_incr</a> is the
+              angular setting of the axis at the start of the integration
+              time for the next frame and should equal
+              <a href="#_diffrn_scan_frame_axis.angle">_diffrn_scan_frame_axis.angle</a> for this next frame.
+;
+    _item.name               '<a href="#_diffrn_scan_frame_axis.angle_rstrt_incr">_diffrn_scan_frame_axis.angle_rstrt_incr</a>'
+    _item.category_id          diffrn_scan_frame_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'degrees'
+     save_
+
+
+save_<a name="_diffrn_scan_frame_axis.displacement" >_diffrn_scan_frame_axis.displacement</a>
+    _item_description.description
+;             The setting of the specified axis in millimetres for this
+              frame.  This is the setting at the start of the integration
+              time.
+;
+    _item.name               '<a href="#_diffrn_scan_frame_axis.displacement" >_diffrn_scan_frame_axis.displacement</a>'
+    _item.category_id          diffrn_scan_frame_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save_<a name="_diffrn_scan_frame_axis.displacement_increment">_diffrn_scan_frame_axis.displacement_increment</a>
+    _item_description.description
+;             The increment for this frame for the displacement setting of
+              the specified axis in millimetres.  The sum of the values
+              of <a href="#_diffrn_scan_frame_axis.displacement">_diffrn_scan_frame_axis.displacement</a> and
+              <a href="#_diffrn_scan_frame_axis.displacement_increment">_diffrn_scan_frame_axis.displacement_increment</a> is the
+              angular setting of the axis at the end of the integration
+              time for this frame.
+;
+    _item.name               '<a href="#_diffrn_scan_frame_axis.displacement_increment">_diffrn_scan_frame_axis.displacement_increment</a>'
+    _item.category_id          diffrn_scan_frame_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save_<a name="_diffrn_scan_frame_axis.displacement_rstrt_incr">_diffrn_scan_frame_axis.displacement_rstrt_incr</a>
+    _item_description.description
+;             The increment for this frame for the displacement setting of
+              the specified axis in millimetres.  The sum of the values
+              of <a href="#_diffrn_scan_frame_axis.displacement">_diffrn_scan_frame_axis.displacement</a>,
+              <a href="#_diffrn_scan_frame_axis.displacement_increment">_diffrn_scan_frame_axis.displacement_increment</a> and
+              <a href="#_diffrn_scan_frame_axis.displacement_rstrt_incr">_diffrn_scan_frame_axis.displacement_rstrt_incr</a> is the
+              angular setting of the axis at the start of the integration
+              time for the next frame and should equal
+              <a href="#_diffrn_scan_frame_axis.displacement">_diffrn_scan_frame_axis.displacement</a> for this next frame.
+;
+    _item.name               '<a href="#_diffrn_scan_frame_axis.displacement_rstrt_incr">_diffrn_scan_frame_axis.displacement_rstrt_incr</a>'
+    _item.category_id          diffrn_scan_frame_axis
+    _item.mandatory_code       no
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save_<a name="_diffrn_scan_frame_axis.frame_id" >_diffrn_scan_frame_axis.frame_id</a>
+    _item_description.description
+;             The value of this data item is the identifier of the
+              frame for which axis settings are being specified.
+
+              Multiple axes may be specified for the same value of
+              <a href="#_diffrn_scan_frame.frame_id" >_diffrn_scan_frame.frame_id</a>.
+
+              This item is a pointer to <a href="#_diffrn_data_frame.id" >_diffrn_data_frame.id</a> in the
+              <a href="#DIFFRN_DATA_FRAME">DIFFRN_DATA_FRAME</a> category.
+;
+    _item.name               '<a href="#_diffrn_scan_frame_axis.frame_id" >_diffrn_scan_frame_axis.frame_id</a>'
+    _item.category_id          diffrn_scan_frame_axis
+    _item.mandatory_code       yes
+    _item_type.code            code
+     save_
+
+
+save_<a name="_diffrn_scan_frame_axis.reference_angle" >_diffrn_scan_frame_axis.reference_angle</a>
+    _item_description.description
+;             The setting of the specified axis in degrees
+              against which measurements of the reference beam centre
+              and reference detector distance should be made.
+
+              This is normally the same for all frames, but the
+              option is provided here of making changes when
+              needed.
+
+              If not provided, it is assumed to be zero.
+;
+    _item.name               '<a href="#_diffrn_scan_frame_axis.reference_angle">_diffrn_scan_frame_axis.reference_angle</a>'
+    _item.category_id          diffrn_scan_frame_axis
+    _item.mandatory_code       implicit
+    _item_default.value        0.0
+    _item_type.code            float
+    _item_units.code           'degrees'
+     save_
+
+
+save_<a name="_diffrn_scan_frame_axis.reference_displacement">_diffrn_scan_frame_axis.reference_displacement</a>
+    _item_description.description
+;             The setting of the specified axis in millimetres for this
+              frame against which measurements of the reference beam centre
+              and reference detector distance should be made.
+
+              This is normally the same for all frames, but the
+              option is provided here of making changes when
+              needed.
+
+              If not provided, it is assumed to be equal to
+              <a href="#_diffrn_scan_frame_axis.displacement" >_diffrn_scan_frame_axis.displacement</a>.
+;
+    _item.name               '<a href="#_diffrn_scan_frame_axis.reference_displacement">_diffrn_scan_frame_axis.reference_displacement</a>'
+    _item.category_id          diffrn_scan_frame_axis
+    _item.mandatory_code       implicit
+    _item_type.code            float
+    _item_units.code           'millimetres'
+     save_
+
+
+save_<a name="_diffrn_scan_frame_axis.variant" >_diffrn_scan_frame_axis.variant</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_scan_frame_axis.variant" >_diffrn_scan_frame_axis.variant</a> gives the variant
+              to which the given DIFFRN_SCAN_FRAME_AXIS row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to <a href="#_variant.variant" >_variant.variant</a> in the
+              <a href="#variant">VARIANT</a> category.
+;
+    _item.name                  '<a href="#_diffrn_scan_frame_axis.variant" >_diffrn_scan_frame_axis.variant</a>'
+    _item.category_id             diffrn_scan_frame_axis
+    _item.mandatory_code          implicit
+    _item_default.value           .
+    _item_type.code               code
+     save_
+
+
+#############################
+# <a name="diffrn_scan_frame_monitor" >DIFFRN_SCAN_FRAME_MONITOR</a> #
+#############################
+
+
+save_DIFFRN_SCAN_FRAME_MONITOR
+    _category.description
+;   Data items in the <a href="#diffrn_scan_frame_monitor">DIFFRN_SCAN_FRAME_MONITOR</a> category record
+    the values and details about each monitor for each frame of data
+    during a scan.
+
+    Each monitor value is uniquely identified by the combination of
+    the scan id given by <a href="#_diffrn_scan_frame.scan_id" >_diffrn_scan_frame.scan_id</a>,
+    the frame id given by <a href="#_diffrn_scan_frame_monitor.frame_id" >_diffrn_scan_frame_monitor.frame_id</a>,
+    the monitor's detector id given by 
+    <a href="#_diffrn_scan_frame_monitor.detector_id" >_diffrn_scan_frame_monitor.detector_id</a>,
+    and a 1-based ordinal given by <a href="#_diffrn_scan_frame_monitor.id" >_diffrn_scan_frame_monitor.id</a>.
+
+    If there is only one frame for the scan, the value of
+    <a href="#_diffrn_scan_frame_monitor.frame_id" >_diffrn_scan_frame_monitor.frame_id</a> may be omitted.
+
+    A single frame may have more than one monitor value, and each 
+    monitor value may be the result of integration over the entire
+    frame integration time given by the value of
+    <a href="#_diffrn_scan_frame.integration_time" >_diffrn_scan_frame.integration_time</a>,
+    or many monitor values may be reported over shorter times given 
+    by the value of _diffrn_scan_frame_monitor.integration_time.  If 
+    only one monitor value for a given monitor is collected during 
+    the integration time of the frame, the value of
+    <a href="#_diffrn_scan_frame_monitor.id" >_diffrn_scan_frame_monitor.id</a> may be
+    omitted.
+;
+    _category.id                   diffrn_scan_frame_monitor
+    _category.mandatory_code       no
+<div id="print_NX_diffrn_scan_frame_monitor" style="display:block">   #_category.NX_mapping_details in online version <a href="javascript:open_close2('online_NX_diffrn_scan_frame_monitor','print_NX_diffrn_scan_frame_monitor');">+/-</a>
+</div><div id="online_NX_diffrn_scan_frame_monitor" style="display:none">    _category.NX_mapping_details                  #<a href="javascript:open_close2('online_NX_diffrn_scan_frame_monitor','print_NX_diffrn_scan_frame_monitor');">+/-</a>
+;
+
+    _diffrn_scan_frame_monitor.id MONID -->
+    _diffrn_scan_frame_monitor.detector_id DETECTORNAME -->
+    _diffrn_scan_frame_monitor.scan_id SCANID -->
+    _diffrn_scan_frame_monitor.frame_id FRAMEID -->
+    _diffrn_scan_frame_monitor.integration_time INTEGRATIONTIME -->
+    _diffrn_scan_frame_monitor.monitor_value MONITORVALUE -->
+
+    -->
+
+    /entry:NXentry
+      /CBF_scan_id="SCANID"
+        /instrument:NXinstrument
+          /CBF_diffrn_scan_frame_monitor__DETECTORNAME_MONID:NXmonitor
+            @CBF_detector_id="DETECTORNAME"
+            @CBF_diffrn_scan_frame_monitor__id="MONID"
+            /data=[MONITORVALUE]  
+            /count_time=[INTEGRATIONTIME] 
+
+
+;
+</div>     loop_
+    _category_key.name             '<a href="#_diffrn_scan_frame_monitor.id" >_diffrn_scan_frame_monitor.id</a>'
+                                   '<a href="#_diffrn_scan_frame_monitor.detector_id" >_diffrn_scan_frame_monitor.detector_id</a>'
+                                   '<a href="#_diffrn_scan_frame_monitor.scan_id" >_diffrn_scan_frame_monitor.scan_id</a>'
+                                   '<a href="#_diffrn_scan_frame_monitor.frame_id" >_diffrn_scan_frame_monitor.frame_id</a>'
+                                   '<a href="#_diffrn_scan_frame_monitor.variant" >_diffrn_scan_frame_monitor.variant</a>'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'diffrn_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;   Example 1. The beam intensity for frame FRAME1 is being tracked
+    by a beamstop monitor detector BSM01, made from metal foil and
+    a PIN diode, located 20 mm in front of a MAR345 detector and being
+    sampled every 2 seconds in a 20 second scan.
+;
+;
+
+     # category <a href="#DIFFRN_DETECTOR">DIFFRN_DETECTOR</a>
+     loop_
+     <a href="#_diffrn_detector.diffrn_id">_diffrn_detector.diffrn_id</a>
+     <a href="#_diffrn_detector.id">_diffrn_detector.id</a>
+     <a href="#_diffrn_detector.type">_diffrn_detector.type</a>
+     <a href="#_diffrn_detector.number_of_axes">_diffrn_detector.number_of_axes</a>
+      P6MB MAR345-SN26 'MAR 345' 4
+      P6MB BSM01 'metal foil and PIN diode' 1
+
+     # category <a href="#diffrn_detector_axis">DIFFRN_DETECTOR_AXIS</a>
+     loop_
+     <a href="#_diffrn_detector_axis.detector_id">_diffrn_detector_axis.detector_id</a>
+     <a href="#_diffrn_detector_axis.axis_id">_diffrn_detector_axis.axis_id</a>
+      MAR345-SN26 DETECTOR_X
+      MAR345-SN26 DETECTOR_Y
+      MAR345-SN26 DETECTOR_Z
+      MAR345-SN26 DETECTOR_PITCH
+      BSM01 MONITOR_Z
+
+
+     # category <a href="#DIFFRN_DATA_FRAME">DIFFRN_DATA_FRAME</a>
+     loop_
+     <a href="#_diffrn_data_frame.id">_diffrn_data_frame.id</a>
+     <a href="#_diffrn_data_frame.detector_element_id">_diffrn_data_frame.detector_element_id</a>
+     <a href="#_diffrn_data_frame.array_id">_diffrn_data_frame.array_id</a>
+     <a href="#_diffrn_data_frame.binary_id">_diffrn_data_frame.binary_id</a>
+      FRAME1 ELEMENT1 ARRAY1 1
+
+
+     # category <a href="#diffrn_scan">DIFFRN_SCAN</a>
+     loop_
+     <a href="#_diffrn_scan.id" >_diffrn_scan.id</a>
+     <a href="#_diffrn_scan.frame_id_start" >_diffrn_scan.frame_id_start</a>
+     <a href="#_diffrn_scan.frame_id_end" >_diffrn_scan.frame_id_end</a>
+     <a href="#_diffrn_scan.frames" >_diffrn_scan.frames</a>
+      SCAN1 FRAME1 FRAME1 1
+
+     # category <a href="#diffrn_scan_axis">DIFFRN_SCAN_AXIS</a>
+     loop_
+     <a href="#_diffrn_scan_axis.scan_id" >_diffrn_scan_axis.scan_id</a>
+     <a href="#_diffrn_scan_axis.axis_id" >_diffrn_scan_axis.axis_id</a>
+     <a href="#_diffrn_scan_axis.angle_start" >_diffrn_scan_axis.angle_start</a>
+     <a href="#_diffrn_scan_axis.angle_range" >_diffrn_scan_axis.angle_range</a>
+     <a href="#_diffrn_scan_axis.angle_increment" >_diffrn_scan_axis.angle_increment</a>
+     <a href="#_diffrn_scan_axis.displacement_start" >_diffrn_scan_axis.displacement_start</a>
+     <a href="#_diffrn_scan_axis.displacement_range" >_diffrn_scan_axis.displacement_range</a>
+     <a href="#_diffrn_scan_axis.displacement_increment" >_diffrn_scan_axis.displacement_increment</a>
+      SCAN1 GONIOMETER_OMEGA 12.0 1.0 1.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_KAPPA 23.3 0.0 0.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_PHI -165.8 0.0 0.0 0.0 0.0 0.0
+      SCAN1 DETECTOR_Z 0.0 0.0 0.0 -240.0 0.0 0.0
+      SCAN1 DETECTOR_Y 0.0 0.0 0.0 0.6 0.0 0.0
+      SCAN1 DETECTOR_X 0.0 0.0 0.0 -0.5 0.0 0.0
+      SCAN1 DETECTOR_PITCH 0.0 0.0 0.0 0.0 0.0 0.0
+      SCAN1 MONITOR_Z 0.0 0.0 0.0 -220.0 0.0 0.0
+
+     # category <a href="#diffrn_scan_frame">DIFFRN_SCAN_FRAME</a>
+     loop_
+     <a href="#_diffrn_scan_frame.frame_id" >_diffrn_scan_frame.frame_id</a>
+     <a href="#_diffrn_scan_frame.frame_number" >_diffrn_scan_frame.frame_number</a>
+     <a href="#_diffrn_scan_frame.integration_time" >_diffrn_scan_frame.integration_time</a>
+     <a href="#_diffrn_scan_frame.scan_id" >_diffrn_scan_frame.scan_id</a>
+     <a href="#_diffrn_scan_frame.date" >_diffrn_scan_frame.date</a>
+      FRAME1 1 20.0 SCAN1 1997-12-04T10:23:48
+
+     # category <a href="#diffrn_scan_frame_monitor">DIFFRN_SCAN_FRAME_MONITOR</a>
+     loop_
+     <a href="#_diffrn_scan_frame_monitor.id" >_diffrn_scan_frame_monitor.id</a>
+     <a href="#_diffrn_scan_frame_monitor.detector_id" >_diffrn_scan_frame_monitor.detector_id</a>
+     <a href="#_diffrn_scan_frame_monitor.scan_id" >_diffrn_scan_frame_monitor.scan_id</a>
+     <a href="#_diffrn_scan_frame_monitor.frame_id" >_diffrn_scan_frame_monitor.frame_id</a>
+     <a href="#_diffrn_scan_frame_monitor.integration_time" >_diffrn_scan_frame_monitor.integration_time</a>
+     <a href="#_diffrn_scan_frame_monitor.monitor_value" >_diffrn_scan_frame_monitor.monitor_value</a>
+      1  BSM01 SCAN1 FRAME1 2.0 23838345642
+      2  BSM01 SCAN1 FRAME1 2.0 23843170669
+      3  BSM01 SCAN1 FRAME1 2.0 23839478690
+      4  BSM01 SCAN1 FRAME1 2.0 23856642085
+      5  BSM01 SCAN1 FRAME1 2.0 23781717656
+      6  BSM01 SCAN1 FRAME1 2.0 23788850775
+      7  BSM01 SCAN1 FRAME1 2.0 23815576677
+      8  BSM01 SCAN1 FRAME1 2.0 23789299964
+      9  BSM01 SCAN1 FRAME1 2.0 23830195536
+      10 BSM01 SCAN1 FRAME1 2.0 23673082270
+
+     # category <a href="#diffrn_scan_frame_axis">DIFFRN_SCAN_FRAME_AXIS</a>
+     loop_
+     <a href="#_diffrn_scan_frame_axis.frame_id" >_diffrn_scan_frame_axis.frame_id</a>
+     <a href="#_diffrn_scan_frame_axis.axis_id" >_diffrn_scan_frame_axis.axis_id</a>
+     <a href="#_diffrn_scan_frame_axis.angle" >_diffrn_scan_frame_axis.angle</a>
+     <a href="#_diffrn_scan_frame_axis.displacement" >_diffrn_scan_frame_axis.displacement</a>
+      FRAME1 GONIOMETER_OMEGA 12.0 0.0
+      FRAME1 GONIOMETER_KAPPA 23.3 0.0
+      FRAME1 GONIOMETER_PHI -165.8 0.0
+      FRAME1 DETECTOR_Z 0.0 -240.0
+      FRAME1 DETECTOR_Y 0.0 0.6
+      FRAME1 DETECTOR_X 0.0 -0.5
+      FRAME1 DETECTOR_PITCH 0.0 0.0
+      FRAME1 MONITOR_Z 0.0 -220.0
+
+     # category <a href="#AXIS">AXIS</a>
+     loop_
+     <a href="#_axis.id">_axis.id</a>
+     <a href="#_axis.type">_axis.type</a>
+     <a href="#_axis.equipment">_axis.equipment</a>
+     <a href="#_axis.depends_on">_axis.depends_on</a>
+     <a href="#_axis.vector[1]">_axis.vector[1]</a> <a href="#_axis.vector[2]">_axis.vector[2]</a> <a href="#_axis.vector[3]">_axis.vector[3]</a>
+     <a href="#_axis.offset[1]">_axis.offset[1]</a> <a href="#_axis.offset[2]">_axis.offset[2]</a> <a href="#_axis.offset[3]">_axis.offset[3]</a>
+      GONIOMETER_OMEGA rotation goniometer . 1 0 0 . . .
+      GONIOMETER_KAPPA rotation goniometer GONIOMETER_OMEGA 0.64279
+      0 0.76604 . . .
+      GONIOMETER_PHI   rotation goniometer GONIOMETER_KAPPA 1 0 0
+     . . .
+      SOURCE           general source . 0 0 1 . . .
+      GRAVITY          general gravity . 0 -1 0 . . .
+      DETECTOR_Z       translation detector . 0 0 1 0 0 0
+      DETECTOR_Y       translation detector DETECTOR_Z 0 1 0 0 0 0
+      DETECTOR_X       translation detector DETECTOR_Y 1 0 0 0 0 0
+      DETECTOR_PITCH   rotation    detector DETECTOR_X 0 1 0 0 0 0
+      ELEMENT_X        translation detector DETECTOR_PITCH
+     1 0 0 172.43 -172.43 0
+      ELEMENT_Y        translation detector ELEMENT_X
+     0 1 0 0 0 0
+      MONITOR_Z        translation detector . 0 0 1 0 0 0
+
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save_<a name="_diffrn_scan_frame_monitor.id" >_diffrn_scan_frame_monitor.id</a>
+    _item_description.description
+;             This item is an integer identifier which, along with
+              <a href="#_diffrn_scan_frame_monitor.detector_id" >_diffrn_scan_frame_monitor.detector_id</a>,
+              <a href="#_diffrn_scan_frame_monitor.scan_id" >_diffrn_scan_frame_monitor.scan_id</a>, and
+              <a href="#_diffrn_scan_frame_monitor.frame_id" >_diffrn_scan_frame_monitor.frame_id</a>
+              should uniquely identify the monitor value being recorded.
+
+              If <a href="#_array_data.binary_id" >_array_data.binary_id</a> is not explicitly given,
+              it defaults to 1.
+;
+    _item.name             '<a name="_diffrn_scan_frame_monitor.id" >_diffrn_scan_frame_monitor.id</a>'
+    _item.category_id      diffrn_scan_frame_monitor
+    _item.mandatory_code   implicit
+    _item_default.value           1
+    _item_type.code               int
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            1  1
+                            .  1
+     save_
+
+
+save_<a name="_diffrn_scan_frame_monitor.detector_id" >_diffrn_scan_frame_monitor.detector_id</a>
+    _item_description.description
+;             This data item is a pointer to <a href="#_diffrn_detector.id" >_diffrn_detector.id</a> in
+              the <a href="#DIFFRN_DETECTOR">DIFFRN_DETECTOR</a> category.
+
+;
+    _item.name                  '<a href="#_diffrn_scan_frame_monitor.detector_id" >_diffrn_scan_frame_monitor.detector_id</a>'
+    _item.category_id             diffrn_scan_frame_monitor
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+
+save_<a name="_diffrn_scan_frame_monitor.frame_id" >_diffrn_scan_frame_monitor.frame_id</a>
+    _item_description.description
+;             This item is a pointer to <a href="#_diffrn_data_frame.id" >_diffrn_data_frame.id</a>
+              in the <a href="#DIFFRN_DATA_FRAME">DIFFRN_DATA_FRAME</a> category.
+;
+    _item.name                  '<a href="#_diffrn_scan_frame_monitor.frame_id" >_diffrn_scan_frame_monitor.frame_id</a>'
+    _item.category_id             diffrn_scan_frame_monitor
+    _item.mandatory_code          implicit
+    _item_type.code               code
+     save_
+
+
+save_<a name="_diffrn_scan_frame_monitor.integration_time" >_diffrn_scan_frame_monitor.integration_time</a>
+    _item_description.description
+;             The precise time for integration of the monitor value given in
+              <a href="#_diffrn_scan_frame_monitor.monitor_value" >_diffrn_scan_frame_monitor.monitor_value</a>
+              must be given in <a name="_diffrn_scan_frame_monitor.integration_time" >_diffrn_scan_frame_monitor.integration_time</a>.
+;
+    _item.name                 '<a href="#_diffrn_scan_frame_monitor.integration_time" >_diffrn_scan_frame_monitor.integration_time</a>'
+    _item.category_id          diffrn_scan_frame_monitor
+    _item.mandatory_code       no
+    _item_type.code            float
+    _item_units.code           'seconds'
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0.0
+     save_
+
+
+save_<a name="_diffrn_scan_frame_monitor.monitor_value" >_diffrn_scan_frame_monitor.monitor_value</a>
+    _item_description.description
+;             The value reported by the monitor detector should be given in
+              <a href="#_diffrn_scan_frame_monitor.monitor_value" >_diffrn_scan_frame_monitor.monitor_value</a>.
+
+              The value is typed as float to allow of monitors for very
+              intense beams that cannot report all digits, but when
+              available, all digits of the  monitor should be recorded.
+
+              For convenience in automated validation, the deprecated
+              <a href="#_diffrn_scan_frame_monitor.monitor_value" >_diffrn_scan_frame_monitor.monitor_value</a>
+              is given as an alias, but should be avoided for new data sets.
+;
+    _item.name                 '<a href="#_diffrn_scan_frame_monitor.monitor_value" >_diffrn_scan_frame_monitor.monitor_value</a>'
+    _item.category_id          diffrn_scan_frame_monitor
+    _item.mandatory_code       no
+    _item_aliases.alias_name   '<a href="#_diffrn_scan_frame_monitor.value" >_diffrn_scan_frame_monitor.value</a>'
+    _item_aliases.dictionary   cif_img.dic
+    _item_aliases.version      1.8.2
+    _item_type.code            float
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0.0
+     save_
+
+
+save_<a name="_diffrn_scan_frame_monitor.scan_id" >_diffrn_scan_frame_monitor.scan_id</a>
+    _item_description.description
+;             This item is a pointer to <a href="#_diffrn_scan.id" >_diffrn_scan.id</a> in
+              the <a href="#diffrn_scan" >DIFFRN_SCAN</a> category.
+;
+    _item.name                  '<a href="#_diffrn_scan_frame_monitor.scan_id" >_diffrn_scan_frame_monitor.scan_id</a>'
+    _item.category_id             diffrn_scan_frame_monitor
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+
+save_<a name="_diffrn_scan_frame_monitor.variant" >_diffrn_scan_frame_monitor.variant</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_scan_frame_monitor.variant" >_diffrn_scan_frame_monitor.variant</a> gives the variant
+              to which the given DIFFRN_SCAN_FRAME_MONITOR row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to <a href="#_variant.variant" >_variant.variant</a> in the
+              <a href="#variant">VARIANT</a> category.
+;
+    _item.name                  '<a href="#_diffrn_scan_frame_monitor.variant" >_diffrn_scan_frame_monitor.variant</a>'
+    _item.category_id             diffrn_scan_frame_monitor
+    _item.mandatory_code          implicit
+    _item_default.value           .
+    _item_type.code               code
+     save_
+
+
+#######
+# <a name="map">MAP</a> #
+#######
+
+save_MAP
+    _category.description
+;   Data items in the <a href="#map">MAP</a> category record
+    the details of maps. Maps record values of parameters,
+    such as density, that are functions of position within
+    a cell or are functions of orthogonal coordinates in
+    three space.
+
+    A map is composed of one or more map segments
+    specified in the MAP_SEGMENT category.
+
+    Examples are given in the MAP_SEGMENT category.
+;
+    _category.id                   map
+    _category.mandatory_code       no
+     loop_
+    _category_key.name             '<a href="#_map.id" >_map.id</a>'
+                                   '<a href="#_map.diffrn_id" >_map.diffrn_id</a>'
+                                   '<a href="#_map.entry_id" >_map.entry_id</a>'
+                                   '<a href="#_map.variant" >_map.variant</a>'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'array_data_group'
+                                   'map_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;   Example 1. Identifying an observed density map
+                and a calculated density map
+;
+;
+
+        loop_
+        <a href="#_map.id" >_map.id</a>
+        <a href="#_map.details" >_map.details</a>
+
+        rho_calc
+   ;
+        density calculated from F_calc derived from the ATOM_SITE
+        list
+   ;
+        rho_obs
+   ;
+        density combining the observed structure factors with the
+        calculated phases
+   ;
+;
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save_<a name="_map.details" >_map.details</a>
+    _item_description.description
+;              The value of <a href="#_map.details" >_map.details</a> should give a
+               description of special aspects of each map.
+
+;
+    _item.name                  '<a name="_map.details" >_map.details</a>'
+    _item.category_id             map
+    _item.mandatory_code          no
+    _item_type.code               text
+     loop_
+    _item_examples.case
+    _item_examples.detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;   Example 1. Identifying an observed density map
+                and a calculated density map
+;
+;
+        loop_
+        <a href="#_map.id" >_map.id</a>
+        <a href="#_map.details" >_map.details</a>
+
+        rho_calc
+    ;
+        density calculated from F_calc derived from the ATOM_SITE list
+    ;
+        rho_obs
+    ;
+        density combining the observed structure factors with the
+        calculated phases
+    ;
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save_<a name="_map.diffrn_id" >_map.diffrn_id</a>
+    _item_description.description
+;             This item is a pointer to <a href="#_diffrn.id" >_diffrn.id</a> in the
+              <a href="#DIFFRN">DIFFRN</a> category.
+;
+    _item.name                  '<a href="#_map.diffrn_id" >_map.diffrn_id</a>'
+    _item.category_id             map
+    _item.mandatory_code          implicit
+    _item_type.code               code
+     save_
+
+
+save_<a name="_map.entry_id" >_map.entry_id</a>
+    _item_description.description
+;             This item is a pointer to <a href="#_entry.id" >_entry.id</a> in the
+              <a href="#ENTRY">ENTRY</a> category.
+;
+    _item.name                  '<a href="#_map.entry_id" >_map.entry_id</a>'
+    _item.category_id             map
+    _item.mandatory_code          implicit
+    _item_type.code               code
+     save_
+
+
+save_<a name="_map.id" >_map.id</a>
+    _item_description.description
+;             The value of <a href="#_map.id" >_map.id</a> must uniquely identify
+              each map for the given diffrn.id or entry.id.
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+           '<a href="#_map.id" >_map.id</a>'                map          yes
+           '<a href="#_map_segment.id" >_map_segment.id</a>'        map_segment  yes
+    _item_type.code               code
+     loop_
+    _item_linked.child_name
+    _item_linked.parent_name
+           '<a href="#_map_segment.id" >_map_segment.id</a>'        '<a href="#_map.id" >_map.id</a>'
+     save_
+
+
+save_<a name="_map.variant" >_map.variant</a>
+    _item_description.description
+;             The value of <a href="#_map.variant" >_map.variant</a> gives the variant
+              to which the given map row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to <a href="#_variant.variant" >_variant.variant</a> in the
+              <a href="#variant">VARIANT</a> category.
+;
+    _item.name                  '<a href="#_map.variant" >_map.variant</a>'
+    _item.category_id             map
+    _item.mandatory_code          implicit
+    _item_default.value           .
+    _item_type.code               code
+     save_
+
+
+###############
+# <a name="map_segment">MAP_SEGMENT</a> #
+###############
+
+
+save_MAP_SEGMENT
+    _category.description
+;   Data items in the <a href="#map_segment">MAP_SEGMENT</a> category record
+    the details about each segment (section or brick) of a map. 
+;
+    _category.id                   map_segment
+    _category.mandatory_code       no
+     loop_
+    _category_key.name             '<a href="#_map_segment.id" >_map_segment.id</a>'
+                                   '<a href="#_map_segment.map_id" >_map_segment.map_id</a>'
+                                   '<a href="#_map_segment.variant" >_map_segment.variant</a>'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'array_data_group'
+                                   'map_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;   Example 1. Identifying an observed density map
+                and a calculated density map, each consisting of one
+                segment, both using the same array structure
+                and mask.
+;
+;
+
+        loop_
+        <a href="#_map.id" >_map.id</a>
+        <a href="#_map.details" >_map.details</a>
+
+        rho_calc
+     ;
+        density calculated from F_calc derived from the ATOM_SITE list
+     ;
+        rho_obs
+     ;
+        density combining the observed structure factors with the
+        calculated phases
+     ;
+
+        loop_
+        _map_segment.map_id
+        _map_segment.id
+        _map_segment.array_id
+        _map_segment.binary_id
+        _map_segment.mask_array_id
+        _map_segment.mask_binary_id
+        rho_calc rho_calc map_structure 1 mask_structure 1
+        rho_obs  rho_obs  map_structure 2 mask_structure 1
+;
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save_<a name="_map_segment.array_id" >_map_segment.array_id</a>
+    _item_description.description
+;             The value of _map_segment.array_id identifies the array 
+              structure into which the map is organized.
+
+              This item is a pointer to <a href="#_array_structure.id" >_array_structure.id</a> in the
+              <a href="#array_structure">ARRAY_STRUCTURE</a> category.
+;
+    _item.name                  '<a href="#_map_segement.array_id" >_map_segment.array_id</a>'
+    _item.category_id             map_segment
+    _item.mandatory_code          implicit
+    _item_type.code               code
+     save_
+
+
+save_<a name="_map_segment.array_section_id" >_map_segment.array_section_id</a>
+    _item_description.description
+;             This item is a pointer to <a href="#_array_structure_list_section.id">_array_structure_list_section.id</a>
+              in the <a href="#array_structure_list_section">ARRAY_STRUCTURE_LIST_SECTION</a> category.
+;
+    _item.name                  '<a href="#_map_segment.array_section_id" >_map_segment.array_section_id</a>'
+    _item.category_id             map_segment
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+
+save_<a name="_map_segment.binary_id" >_map_segment.binary_id</a>
+    _item_description.description
+;             The value of <a href="#_map_segment.binary_id">_map_segment.binary_id</a> distinguishes the particular 
+              set of data organized according to <a href="#_map_segment.mask_array_id">_map_segment.array_id</a> in 
+              which the data values of the map are stored.
+
+              This item is a pointer to <a href="#_array_data.binary_id" >_array_data.binary_id</a> in the
+              <a href="#array_data">ARRAY_DATA</a> category.
+;
+    _item.name                  '<a href="#_map_segment.binary_id" >_map_segment.binary_id</a>'
+    _item.category_id             map_segment
+    _item.mandatory_code          implicit
+    _item_type.code               int
+     save_
+
+
+save_<a name="_map_segment.mask_array_id" >_map_segment.mask_array_id</a>
+    _item_description.description
+;             The value of <a href="#_map_segment.mask_array_id">_map_segment.mask_array_id</a>, if given, describes
+              the array structure into which the mask for the map is
+              organized.  If no value is given, then all elements of
+              the map are valid.  If a value is given, then only
+              elements of the map for which the corresponding element
+              of the mask is non-zero are valid.  The value of
+              <a href="#_map_segment.mask_array_id">_map_segment.mask_array_id</a> differs from the value of
+              <a href="#_map_segment.array_id">_map_segment.array_id</a> in order to permit the mask to be
+              given as, say, unsigned 8-bit integers, while the map is
+              given as a data type with more range.  However, the two
+              array structures must be aligned, using the same axes in
+              the same order with the same displacements and
+              increments.
+
+              This item is a pointer to <a href="#_array_structure.id" >_array_structure.id</a> in the
+              <a href="#array_structure">ARRAY_STRUCTURE</a> category.
+;
+    _item.name                  '<a href="#_map_segment.mask_array_id" >_map_segment.mask_array_id</a>'
+    _item.category_id             map_segment
+    _item.mandatory_code          implicit
+    _item_type.code               code
+     save_
+
+
+save_<a name="_map_segment.mask_binary_id" >_map_segment.mask_binary_id</a>
+    _item_description.description
+;             The value of <a href="#_map_segment.mask_binary_id">_map_segment.mask_binary_id</a> identifies the 
+              particular set of data organized according to 
+              _map_segment.mask_array_id specifying the mask for the map.
+
+              This item is a pointer to <a href="#_array_data.binary_id" >_array_data.binary_id</a> in the
+              <a href="#array_data">ARRAY_DATA</a> category.
+;
+    _item.name                  '<a href="#_map_segment.mask_binary_id" >_map_segment.mask_binary_id</a>'
+    _item.category_id             map_segment
+    _item.mandatory_code          implicit
+    _item_type.code               int
+     save_
+
+
+save_<a name="_map_segment.mask_array_section_id" >_map_segment.mask_array_section_id</a>
+    _item_description.description
+;             This item is a pointer to <a href="#_array_structure_list_section.id">_array_structure_list_section.id</a>
+              in the <a href="#array_structure_list_section">ARRAY_STRUCTURE_LIST_SECTION</a> category.
+;
+    _item.name                  '<a href="#_map_segment.mask_array_section_id" >_map_segment.mask_array_section_id</a>'
+    _item.category_id             map_segment
+    _item.mandatory_code          yes
+    _item_type.code               code
+    save_
+
+
+save_<a name="_map_segment.id" >_map_segment.id</a>
+    _item_description.description
+;             The value of <a href="#_map_segment.id" >_map_segment.id</a> must uniquely
+              identify each segment of a map.
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+           '<a href="#_map_segment.id" >_map_segment.id</a>'
+           map_segment
+           yes
+    _item_type.code               code
+     save_
+
+
+save_<a name="_map_segment.map_id" >_map_segment.map_id</a>
+    _item_description.description
+;             This item is a pointer to <a href="#_map.id" >_map.id</a>
+              in the <a href="#map">MAP</a> category.
+;
+    _item.name                  '<a href="#_map_segment.map_id" >_map_segment.map_id</a>'
+    _item.category_id             map_segment
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+
+save_<a name="_map_segment.details" >_map_segment.details</a>
+    _item_description.description
+;             The value of <a href="#_map_segment.details" >_map_segment.details</a> should give a
+              description of special aspects of each segment of a map.
+;
+    _item.name                  '<a name="_map_segment.details" >_map_segment.details</a>'
+    _item.category_id             map_segment
+    _item.mandatory_code          no
+    _item_type.code               text
+     loop_
+    _item_examples.case
+    _item_examples.detail
+;               Example to be provided
+;
+;               
+                . . .
+;
+     save_
+
+
+save_<a name="_map_segment.variant" >_map_segment.variant</a>
+    _item_description.description
+;             The value of <a href="#_map_segment.variant" >_map_segment.variant</a> gives the variant
+              to which the given map segment is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to <a href="#_variant.variant" >_variant.variant</a> in the
+              <a href="#variant">VARIANT</a> category.
+;
+    _item.name                  '<a href="#_map_segment.variant" >_map_segment.variant</a>'
+    _item.category_id             map_segment
+    _item.mandatory_code          implicit
+    _item_default.value           .
+    _item_type.code               code
+     save_
+
+
+###########
+# <a name="variant">VARIANT</a> #
+###########
+
+save_VARIANT
+    _category.description
+;   Data items in the <a href="#variant">VARIANT</a> category record
+    the details about sets of variants of data items.
+
+    There is sometimes a need to allow for multiple versions of the
+    same data items in order to allow for refinements and corrections
+    to earlier assumptions, observations and calculations.  In order
+    to allow data sets to contain more than one variant of the same
+    information, an optional *.variant data item as a pointer to
+    _variant.variant has been added to the key of every category,
+    as an implicit data item with a null (empty) default value.
+
+    All rows in a category with the same variant value are considered
+    to be related to one another and to all rows in other categories
+    with the same variant value.  For a given variant, all such rows
+    are also considered to be related to all rows with a null variant
+    value, except that a row with a null variant value for which all
+    other components of its key are identical to those entries in
+    another row with a non-null variant value is not related the
+    the rows with that non-null variant value.  This behaviour is
+    similar to the convention for identifying alternate conformers
+    in an atom list.
+
+    An optional role may be specified for a variant as the value of
+    _variant.role.  Possible roles are null, 'preferred',
+    'raw data', 'unsuccessful trial'.
+
+    variants may carry an optional timestamp as the value of
+    _variant.timestamp.
+
+    variants may be related to other variants from which they were
+    derived by the value of _variant.variant_of.
+
+    Further details about the variant may be specified as the value
+    of _variant.details.
+
+    In order to allow variant information from multiple datasets to
+    be combined, _variant.diffrn_id and/or _variant.entry_id may
+    be used.
+;
+    _category.id                   variant
+    _category.mandatory_code       no
+     loop_
+    _category_key.name             '<a href="#_variant.variant" >_variant.variant</a>'
+                                   '<a href="#_variant.diffrn_id" >_variant.diffrn_id</a>'
+                                   '<a href="#_variant.entry_id" >_variant.entry_id</a>'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'variant_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;   Example 1. Distinguishing between a raw beam centre and a refined beam
+       centre inferred after indexing.  Detector d1 is composed of
+       four CCD detector elements, each 200 mm by 200 mm, arranged
+       in a square, in the pattern
+
+                   1     2
+                      *
+                   3     4
+
+       Note that the beam centre is slightly displaced from each of the
+       detector elements, just beyond the lower right corner of 1,
+       the lower left corner of 2, the upper right corner of 3 and
+       the upper left corner of 4.  For each element, the detector
+       face coordinate system is assumed to have the fast axis
+       running from left to right and the slow axis running from
+       top to bottom with the origin at the top left corner.
+
+       After indexing and refinement, the centre is shifted by 0.2 mm
+       left and 0.1 mm down.
+;
+;
+
+        loop_
+        _variant.variant
+        _variant.role
+        _variant.timestamp
+        _variant.variant_of
+        _variant.details
+            . "raw data" 2007-08-03T23:20:00 . .
+            indexed "preferred" 2007-08-04T01:17:28 .
+              "indexed cell and refined beam centre"
+
+        loop_
+        <a href="#_diffrn_detector_element.detector_id" >_diffrn_detector_element.detector_id</a>
+        <a href="#_diffrn_detector_element.id" >_diffrn_detector_element.id</a>
+        <a href="#_diffrn_detector_elelemt.reference_center_fast" >_diffrn_detector_element.reference_center_fast</a>
+        <a href="#_diffrn_detector_element.reference_center_slow" >_diffrn_detector_element.reference_center_slow</a>
+        <a href="#_diffrn_detector_element.reference_center_units" >_diffrn_detector_element.reference_center_units</a>
+        <a href="#_diffrn_detector_element.variant" >_diffrn_detector_element.variant</a>
+        d1     d1_ccd_1  201.5 201.5  mm  .
+        d1     d1_ccd_2  -1.8  201.5  mm  .
+        d1     d1_ccd_3  201.6  -1.4  mm  .
+        d1     d1_ccd_4  -1.7   -1.5  mm  .
+        d1     d1_ccd_1  201.3 201.6  mm  indexed
+        d1     d1_ccd_2  -2.0  201.6  mm  indexed
+        d1     d1_ccd_3  201.3  -1.5  mm  indexed
+        d1     d1_ccd_4  -1.9   -1.6  mm  indexed
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+     save_
+
+save_<a name="_variant.details" >_variant.details</a>
+    _item_description.description
+;             A description of special aspects of the variant.
+;
+    _item.name                  '<a href="#_variant.details" >_variant.details</a>'
+    _item.category_id             variant
+    _item.mandatory_code          no
+    _item_type.code               text
+    _item_examples.case
+;                                indexed cell and refined beam centre
+;
+     save_
+
+save_<a name="_variant.diffrn_id" >_variant.diffrn_id</a>
+    _item_description.description
+;             This item is a pointer to <a href="#_diffrn.id">_diffrn.id</a> in the
+              <a href="#diffrn">diffrn</a> category.
+;
+    _item.name                  '<a href="#_variant.diffrn_id">_variant.diffrn_id</a>'
+    _item.category_id             variant
+    _item.mandatory_code          implicit
+    _item_type.code               code
+     save_
+
+save_<a name="_variant.entry_id" >_variant.entry_id</a>
+    _item_description.description
+;             This item is a pointer to <a href="#_entry.id">_entry.id</a> in the
+              <a href="#entry">entry</a> category
+;
+    _item.name                  '<a href="#_variant.entry_id">_variant.entry_id</a>'
+    _item.category_id             variant
+    _item.mandatory_code          yes
+    _item_type.code               code
+     save_
+
+
+save_<a name="_variant.role" >_variant.role</a>
+    _item_description.description
+;             The value of <a href="#_variant.role" >_variant.role</a>  specified a role
+              for this variant.  Possible roles are null, 'preferred',
+              'raw data', and 'unsuccessful trial'.
+
+              A null value for <a href="#_variant.role" >_variant.role</a> leaves the
+              precise role of the variant unspecified.  No inference should
+              be made that the variant with the latest time stamp is
+              preferred.
+;
+    _item.name                  '<a href="#_variant.role" >_variant.role</a>'
+    _item.category_id            variant
+    _item.mandatory_code         no
+    _item_type.code              uline
+     loop_
+    _item_enumeration.value
+    _item_enumeration.detail
+     "preferred"
+;    A value of 'preferred' indicates that rows of any categories specifying
+     this variant should be used in preference to rows with the same key
+     specifying other variants or the null variant.  It is an error to specify
+     two variants that appear in the same category with the same key as being
+     preferred, but it is not an error to specify more than one variant as
+     preferred in other cases.
+;
+     "raw data"
+;    A value of 'raw data' indicates data prior to any corrections, 
+     calculations or refinements.  It is not necessarily an error for raw data
+     also to be a variant of an earlier variant.  It may be replacement raw 
+     data for earlier data believed to be erroneous.
+;
+     "unsuccessful trial"
+;    A value of 'unsuccessful trial' indicates data that should not be used
+     for further calculation.
+;
+     save_
+
+
+save_<a name="_variant.timestamp">_variant.timestamp</a>
+    _item_description.description
+;             The date and time identifying a variant.  This is not 
+              necessarily the precise time of the measurement or calculation
+              of the individual related data items, but a timestamp that 
+              reflects the order in which the variants were defined.
+;
+    _item.name                 '<a href="#_variant.timestamp">_variant.timestamp</a>'
+    _item.category_id          variant
+    _item.mandatory_code       no
+    _item_type.code            yyyy-mm-dd
+     save_
+
+
+save_<a name="_variant.variant" >_variant.variant</a>
+    _item_description.description
+;             The value of <a href="#_variant.variant" >_variant.variant</a> must uniquely identify
+              each variant for the given diffraction experiment and/or entry
+
+              This item has been made implicit and given a default value of 
+              null.
+;
+
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+             '<a href="#_variant.variant" >_variant.variant</a>'                    variant             implicit
+             '<a href="#_variant.variant_of" >_variant.variant_of</a>'                 variant             implicit
+             '<a href="#_array_data.variant" >_array_data.variant</a>'                 array_data          implicit
+             '<a href="#_array_data_external_data.variant" >_array_data_external_data.variant</a>'   array_data_external_data
+                                                                       implicit
+             '<a href="#_array_element_size.variant" >_array_element_size.variant</a>'         array_element_size  implicit
+             '<a href="#_array_intensities.variant" >_array_intensities.variant</a>'          array_intensities   implicit
+             '<a href="#_array_structure.variant" >_array_structure.variant</a>'            array_structure     implicit
+             '<a href="#_array_structure_list.variant" >_array_structure_list.variant</a>'       array_structure_list
+                                                                       implicit
+             '<a href="#_array_structure_list_axis.variant" >_array_structure_list_axis.variant</a>'  array_structure_list_axis
+                                                                       implicit
+             '<a href="#_array_structure_list_section.variant" >_array_structure_list_section.variant</a>'
+                                 array_structure_list_axis_section
+                                                                       implicit
+             '<a href="#_axis.variant" >_axis.variant</a>'                       axis                implicit
+             '<a href="#_diffrn_data_frame.variant" >_diffrn_data_frame.variant</a>'          diffrn_data_frame   implicit
+             '<a href="#_diffrn_detector.variant" >_diffrn_detector.variant</a>'            diffrn_detector     implicit
+             '<a href="#_diffrn_detector_axis.variant" >_diffrn_detector_axis.variant</a>'       diffrn_detector_axis
+                                                                       implicit
+             '<a href="#_diffrn_detector_element.variant" >_diffrn_detector_element.variant</a>'    diffrn_detector_element
+                                                                       implicit
+             '<a href="#_diffrn_measurement.variant" >_diffrn_measurement.variant</a>'         diffrn_measurement  implicit
+             '<a href="#_diffrn_measurement_axis.variant" >_diffrn_measurement_axis.variant</a>'    diffrn_measurement_axis
+                                                                       implicit
+             '<a href="#_diffrn_radiation.variant" >_diffrn_radiation.variant</a>'           diffrn_radiation    implicit
+             '<a href="#_diffrn_refln.variant" >_diffrn_refln.variant</a>'               diffrn_refln        implicit
+             '<a href="#_diffrn_scan.variant" >_diffrn_scan.variant</a>'                diffrn_scan         implicit
+             '<a href="#_diffrn_scan_axis.variant" >_diffrn_scan_axis.variant</a>'           diffrn_scan_axis    implicit
+             '<a href="#_diffrn_scan_collection.variant" >_diffrn_scan_collection.variant</a>'     diffrn_scan_collection
+                                                                       implicit
+             '<a href="#_diffrn_scan_frame.variant" >_diffrn_scan_frame.variant</a>'          diffrn_scan_frame   implicit
+             '<a href="#_diffrn_scan_frame_axis.variant" >_diffrn_scan_frame_axis.variant</a>'     diffrn_scan_frame_axis
+                                                                       implicit
+             '<a href="#_diffrn_scan_frame_monitor.variant" >_diffrn_scan_frame_monitor.variant</a>'  diffrn_scan_frame_monitor
+                                                                       implicit
+             '<a href="#_map.variant" >_map.variant</a>'                        map                 implicit
+             '<a href="#_map_segment.variant" >_map_segment.variant</a>'                map_segment         implicit
+
+
+    _item_default.value           .
+    _item_type.code               code
+     loop_
+    _item_linked.child_name
+    _item_linked.parent_name
+             '<a href="#_array_data.variant" >_array_data.variant</a>'                 '<a href="#_variant.variant" >_variant.variant</a>'
+             '<a href="#_array_element_size.variant" >_array_element_size.variant</a>'         '<a href="#_variant.variant" >_variant.variant</a>'
+             '<a href="#_array_intensities.variant" >_array_intensities.variant</a>'          '<a href="#_variant.variant" >_variant.variant</a>'
+             '<a href="#_array_structure.variant" >_array_structure.variant</a>'            '<a href="#_variant.variant" >_variant.variant</a>'
+             '<a href="#_array_structure_list.variant" >_array_structure_list.variant</a>'       '<a href="#_variant.variant" >_variant.variant</a>'
+             '<a href="#_array_structure_list_axis.variant" >_array_structure_list_axis.variant</a>'  '<a href="#_variant.variant" >_variant.variant</a>'
+             '<a href="#_axis.variant" >_axis.variant</a>'                       '<a href="#_variant.variant" >_variant.variant</a>'
+             '<a href="#_diffrn_data_frame.variant" >_diffrn_data_frame.variant</a>'          '<a href="#_variant.variant" >_variant.variant</a>'
+             '<a href="#_diffrn_detector.variant" >_diffrn_detector.variant</a>'            '<a href="#_variant.variant" >_variant.variant</a>'
+             '<a href="#_diffrn_detector_axis.variant" >_diffrn_detector_axis.variant</a>'       '<a href="#_variant.variant" >_variant.variant</a>'
+             '<a href="#_diffrn_detector_element.variant" >_diffrn_detector_element.variant</a>'    '<a href="#_variant.variant" >_variant.variant</a>'
+             '<a href="#_diffrn_measurement.variant" >_diffrn_measurement.variant</a>'         '<a href="#_variant.variant" >_variant.variant</a>'
+             '<a href="#_diffrn_measurement_axis.variant" >_diffrn_measurement_axis.variant</a>'    '<a href="#_variant.variant" >_variant.variant</a>'
+             '<a href="#_diffrn_radiation.variant" >_diffrn_radiation.variant</a>'           '<a href="#_variant.variant" >_variant.variant</a>'
+             '<a href="#_diffrn_refln.variant" >_diffrn_refln.variant</a>'               '<a href="#_variant.variant" >_variant.variant</a>'
+             '<a href="#_diffrn_scan.variant" >_diffrn_scan.variant</a>'                '<a href="#_variant.variant" >_variant.variant</a>'
+             '<a href="#_diffrn_scan_axis.variant" >_diffrn_scan_axis.variant</a>'           '<a href="#_variant.variant" >_variant.variant</a>'
+             '<a href="#_diffrn_scan_collection.variant" >_diffrn_scan_collection.variant</a>'     '<a href="#_variant.variant" >_variant.variant</a>'
+             '<a href="#_diffrn_scan_frame.variant" >_diffrn_scan_frame.variant</a>'          '<a href="#_variant.variant" >_variant.variant</a>'
+             '<a href="#_diffrn_scan_frame_axis.variant" >_diffrn_scan_frame_axis.variant</a>'     '<a href="#_variant.variant" >_variant.variant</a>'
+             '<a href="#_diffrn_scan_frame_monitor.variant" >_diffrn_scan_frame_monitor.variant</a>'  '<a href="#_variant.variant" >_variant.variant</a>'
+             '<a href="#_map.variant" >_map.variant</a>'                        '<a href="#_variant.variant" >_variant.variant</a>'
+             '<a href="#_map_segment.variant" >_map_segment.variant</a>'                '<a href="#_variant.variant" >_variant.variant</a>'
+
+     save_
+
+
+save_<a name="_variant.variant_of" >_variant.variant_of</a>
+    _item_description.description
+;            The value of <a href="#_variant.variant_of" >_variant.variant_of</a> gives the variant
+             from which this variant was derived.  If this value is not given,
+             the variant is assumed to be derived from the default null 
+             variant.
+
+             This item is a pointer to <a href="#_variant.variant" >_variant.variant</a> in the
+             <a href="#variant">VARIANT</a> category.
+;
+    _item.name                  '<a href="#_variant.variant_of" >_variant.variant_of</a>'
+    _item.category_id             variant
+    _item.mandatory_code          implicit
+    _item_type.code               code
+     save_
+
+
+
+
+########################   DEPRECATED DATA ITEMS ########################
+
+save_<a name="_diffrn_detector_axis.id">_diffrn_detector_axis.id</a>
+    _item_description.description
+;             This data item is a pointer to <a href="#_diffrn_detector.id">_diffrn_detector.id</a> in
+              the <a href="#DIFFRN_DETECTOR">DIFFRN_DETECTOR</a> category.
+
+              DEPRECATED -- DO NOT USE
+;
+    _item.name                  '<a href="#_diffrn_detector_axis.id">_diffrn_detector_axis.id</a>'
+    _item.category_id             diffrn_detector_axis
+    _item.mandatory_code          no
+    _item_type.code               code
+     save_
+
+
+save_<a name="_diffrn_detector_element.center[1]" >_diffrn_detector_element.center[1]</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_detector_element.center[1]" >_diffrn_detector_element.center[1]</a> is the <b>X</b>
+              component of the distortion-corrected beam centre in
+              millimetres from the (0, 0) (lower-left) corner of the
+              detector element viewed from the sample side.
+
+              The <b>X</b> and <b>Y</b> axes are the laboratory coordinate system
+              coordinates defined in the <a href="#AXIS">AXIS category</a> measured
+              when all positioning axes for the detector are at their zero
+              settings.  If the resulting <b>X</b> or <b>Y</b> axis is then orthogonal to the
+              detector, the <b>Z</b> axis is used instead of the orthogonal axis.
+
+              Because of ambiguity about the setting used to determine this
+              centre, use of this data item is deprecated.  The data item
+              <a href="#_diffrn_data_frame.center_fast">_diffrn_data_frame.center_fast</a>
+              which is referenced to the detector coordinate system and not
+              directly to the laboratory coordinate system should be used
+              instead.
+
+;
+    _item.name                  '<a href="#_diffrn_detector_element.center[1]" >_diffrn_detector_element.center[1]</a>'
+    _item.category_id             diffrn_detector_element
+    _item.mandatory_code          no
+    _item_default.value           0.0
+    _item_sub_category.id         vector
+    _item_type.code               float
+    _item_related.related_name  '<a href="#_diffrn_data_frame.center_fast" >_diffrn_data_frame.center_fast</a>'
+    _item_related.function_code   replacedby
+    _item_units.code              millimetres
+
+     save_
+
+
+save_<a name="_diffrn_detector_element.center[2]" >_diffrn_detector_element.center[2]</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_detector_element.center[2]" >_diffrn_detector_element.center[2]</a> is the <b>Y</b>
+              component of the distortion-corrected beam centre in
+              millimetres from the (0, 0) (lower-left) corner of the
+              detector element viewed from the sample side.
+
+              The <b>X</b> and <b>Y</b> axes are the laboratory coordinate system
+              coordinates defined in the <a href="#AXIS">AXIS category</a> measured
+              when all positioning axes for the detector are at their zero
+              settings.  If the resulting <b>X</b> or <b>Y</b> axis is then orthogonal to the
+              detector, the <b>Z</b> axis is used instead of the orthogonal axis.
+
+              Because of ambiguity about the setting used to determine this
+              centre, use of this data item is deprecated. The data item
+              <a href="#_diffrn_data_frame.center_slow">_diffrn_data_frame.center_slow</a>
+              which is referenced to the detector coordinate system and not
+              directly to the laboratory coordinate system should be used
+              instead.
+
+;
+    _item.name                  '<a href="#_diffrn_detector_element.center[2]" >_diffrn_detector_element.center[2]</a>'
+    _item.category_id             diffrn_detector_element
+    _item.mandatory_code          no
+    _item_default.value           0.0
+    _item_sub_category.id         vector
+    _item_type.code               float
+    _item_related.related_name  '<a href="#_diffrn_data_frame.center_slow" >_diffrn_data_frame.center_slow</a>'
+    _item_related.function_code   replacedby
+    _item_units.code              millimetres
+
+     save_
+
+
+
+save_<a name="_diffrn_measurement_axis.id">_diffrn_measurement_axis.id</a>
+    _item_description.description
+;             This data item is a pointer to <a href="#_diffrn_measurement.id">_diffrn_measurement.id</a> in
+              the <a href="#diffrn_measurement">DIFFRN_MEASUREMENT</a> category.
+
+              DEPRECATED -- DO NOT USE
+;
+    _item.name                   '<a href="#_diffrn_measurement_axis.id">_diffrn_measurement_axis.id</a>'
+    _item.category_id             diffrn_measurement_axis
+    _item.mandatory_code          no
+    _item_related.related_name   '<a href="#_diffrn_measurement_axis.measurement_id">_diffrn_measurement_axis.measurement_id</a>'
+    _item_related.function_code   replacedby
+    _item_type.code               code
+     save_
+
+
+save_<a name="_diffrn_scan_frame_monitor.value" >_diffrn_scan_frame_monitor.value</a>
+    _item_description.description
+;             This is a deprecated version of
+              <a href="#_diffrn_scan_frame_monitor.monitor_value" >_diffrn_scan_frame_monitor.monitor_value</a>.
+
+              The value is typed as float to allow of monitors for very
+              intense beams that cannot report all digits, but when available,
+              all digits of the monitor should be recorded.
+
+              DEPRECATED -- DO NOT USE
+;
+    _item.name                   '<a href="#_diffrn_scan_frame_monitor.value" >_diffrn_scan_frame_monitor.value</a>'
+    _item.category_id             diffrn_scan_frame_monitor
+    _item.mandatory_code          no
+    _item_related.related_name   '<a href="#_diffrn_scan_frame_monitor.monitor_value" >_diffrn_scan_frame_monitor.monitor_value</a>'
+    _item_related.function_code   replacedby
+    _item_type.code               float
+     loop_
+    _item_range.maximum
+    _item_range.minimum
+                            .   0.0
+     save_
+
+
+#########################   DEPRECATED CATEGORY #########################
+#####################
+# <a name="diffrn_frame_data" >DIFFRN_FRAME_DATA</a> #
+#####################
+
+
+save_DIFFRN_FRAME_DATA
+    _category.description
+;   Data items in the DIFFRN_FRAME_DATA category record
+    the details about each frame of data.
+
+    The items in this category are now in the
+    <a href="#DIFFRN_DATA_FRAME">DIFFRN_DATA_FRAME</a> category.
+
+    The items in the DIFFRN_FRAME_DATA category
+    are now deprecated.  The items from this category
+    are provided as aliases in the 1.0 dictionary
+    or, in the case of _diffrn_frame_data.details,
+    in the 1.4 dictionary.  THESE ITEMS SHOULD NOT
+    BE USED FOR NEW WORK.
+
+    The items from the old category are provided
+    in this dictionary for completeness
+    but should not be used or cited.  To avoid
+    confusion, the example has been removed
+    and the redundant parent-child links to other
+    categories have been removed.
+
+    All _item.mandatory_code values have been changed to 'no'.
+;
+    _category.id                   diffrn_frame_data
+    _category.mandatory_code       no
+     loop_
+    _category_key.name             '<a href="#_diffrn_frame_data.id" >_diffrn_frame_data.id</a>'
+                                   '<a href="#_diffrn_frame_data.detector_element_id" >_diffrn_frame_data.detector_element_id</a>'
+     loop_
+    _category_group.id             'inclusive_group'
+                                   'array_data_group'
+     loop_
+    _category_examples.detail
+    _category_examples.case
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    THE DIFFRN_FRAME_DATA category is deprecated and should not be used.
+;
+;
+       # EXAMPLE REMOVED #
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+     save_
+
+
+save_<a name="_diffrn_frame_data.array_id" >_diffrn_frame_data.array_id</a>
+    _item_description.description
+;             This item is a pointer to <a href="#_array_structure.id" >_array_structure.id</a> in the
+              ARRAY_STRUCTURE category.
+
+              DEPRECATED -- DO NOT USE
+;
+    _item.name                  '<a href="#_diffrn_frame_data.array_id" >_diffrn_frame_data.array_id</a>'
+    _item.category_id             diffrn_frame_data
+    _item.mandatory_code          no
+    _item_related.related_name   '<a href="#_diffrn_data.array_id" >_diffrn_data_frame.array_id</a>'
+    _item_related.function_code   replacedby
+    _item_type.code               code
+     save_
+
+
+save_<a name="_diffrn_frame_data.binary_id" >_diffrn_frame_data.binary_id</a>
+    _item_description.description
+;             This item is a pointer to <a href="#_array_data.binary_id" >_array_data.binary_id</a> in the
+              ARRAY_STRUCTURE category.
+
+              DEPRECATED -- DO NOT USE
+;
+    _item.name                  '<a href="#_diffrn_frame_data.binary_id" >_diffrn_frame_data.binary_id</a>'
+    _item.category_id             diffrn_frame_data
+    _item.mandatory_code          implicit
+    _item_related.related_name   '<a href="#_diffrn_data.binary_id" >_diffrn_data_frame.binary_id</a>'
+    _item_related.function_code   replacedby
+    _item_type.code               int
+     save_
+
+
+save_<a name="_diffrn_frame_data.detector_element_id" >_diffrn_frame_data.detector_element_id</a>
+    _item_description.description
+;             This item is a pointer to <a href="#_diffrn_detector_element.id">_diffrn_detector_element.id</a>
+              in the DIFFRN_DETECTOR_ELEMENT category.
+
+              DEPRECATED -- DO NOT USE
+;
+    _item.name                  '<a href="#_diffrn_frame_data.detector_element_id" >_diffrn_frame_data.detector_element_id</a>'
+    _item.category_id             diffrn_frame_data
+    _item.mandatory_code          yes
+    _item_related.related_name   '<a href="#_diffrn_data.detector_element_id" >_diffrn_data_frame.detector_element_id</a>'
+    _item_related.function_code   replacedby
+    _item_type.code               code
+     save_
+
+
+save_<a name="_diffrn_frame_data.id" >_diffrn_frame_data.id</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_frame_data.id" >_diffrn_frame_data.id</a> must uniquely identify
+              each complete frame of data.
+
+              DEPRECATED -- DO NOT USE
+;
+     loop_
+    _item.name
+    _item.category_id
+    _item.mandatory_code
+           '<a href="#_diffrn_frame_data.id" >_diffrn_frame_data.id</a>'        diffrn_frame_data  yes
+    _item_related.related_name   '<a href="#_diffrn_data_frame.id" >_diffrn_data_frame.id</a>'
+    _item_related.function_code   replacedby
+    _item_type.code               code
+     save_
+
+
+save_<a name="_diffrn_frame_data.details" >_diffrn_frame_data.details</a>
+    _item_description.description
+;             The value of <a href="#_diffrn_frame_data.details" >_diffrn_frame_data.details</a> should give a
+              description of special aspects of each frame of data.
+
+              DEPRECATED -- DO NOT USE
+;
+    _item.name                  '<a name="_diffrn_frame_data.details" >_diffrn_frame_data.details</a>'
+    _item.category_id             diffrn_frame_data
+    _item.mandatory_code          no
+    _item_related.related_name   '<a href="#_diffrn_data_frame.details" >_diffrn_data_frame.details</a>'
+    _item_related.function_code   replacedby
+    _item_type.code               text
+     save_
+
+
+################ END DEPRECATED SECTION ###########
+
+
+####################
+## <a name="ITEM_TYPE_LIST">ITEM_TYPE_LIST</a> ##
+####################
+#
+#
+#  The regular expressions defined here are not compliant
+#  with the POSIX 1003.2 standard as they include the
+#  '\n' and '\t' special characters.  These regular expressions
+#  have been tested using version 0.12 of Richard Stallman's
+#  GNU regular expression library in POSIX mode.
+#  In order to allow presentation of a regular expression
+#  in a text field concatenate any line ending in a backslash
+#  with the following line, after discarding the backslash.
+#
+#  A formal definition of the '\n' and '\t' special characters
+#  is most properly done in the DDL, but for completeness, please
+#  note that '\n' is the line termination character ('newline')
+#  and '\t' is the horizontal tab character.  There is a formal
+#  ambiguity in the use of '\n' for line termination, in that
+#  the intention is that the equivalent machine/OS-dependent line
+#  termination character sequence should be accepted as a match, e.g.
+#
+#      '\r' (control-M) under MacOS
+#      '\n' (control-J) under Unix
+#      '\r\n' (control-M control-J) under DOS and MS Windows
+#
+     loop_
+    _item_type_list.code
+    _item_type_list.primitive_code
+    _item_type_list.construct
+    _item_type_list.detail
+               code      char
+               '[_,.;:&quot;&amp;&lt;&gt;()/\{}'`~!@#$%A-Za-z0-9*|+-]*'
+;              code item types/single words ...
+;
+               ucode      uchar
+               '[_,.;:&quot;&amp;&lt;&gt;()/\{}'`~!@#$%A-Za-z0-9*|+-]*'
+;              code item types/single words (case insensitive) ...
+;
+               line      char
+               '[][ \t_(),.;:&quot;&amp;&lt;&gt;/\{}'`~!@#$%?+=*A-Za-z0-9|^-]*'
+;              char item types / multi-word items ...
+;
+               uline     uchar
+               '[][ \t_(),.;:&quot;&amp;&lt;&gt;/\{}'`~!@#$%?+=*A-Za-z0-9|^-]*'
+;              char item types / multi-word items (case insensitive)...
+;
+               text      char
+               '[][ \n\t()_,.;:&quot;&amp;&lt;&gt;/\{}'`~!@#$%?+=*A-Za-z0-9|^-]*'
+;              text item types / multi-line text ...
+;
+               binary    char
+;\n--CIF-BINARY-FORMAT-SECTION--\n\
+[][ \n\t()_,.;:&quot;&amp;&lt;&gt;/\{}'`~!@#$%?+=*A-Za-z0-9|^-]*\
+\n--CIF-BINARY-FORMAT-SECTION----
+;
+;              binary items are presented as MIME-like ascii-encoded
+               sections in an imgCIF.  In a CBF, raw octet streams
+               are used to convey the same information.
+;
+               int       numb
+               '-?[0-9]+'
+;              int item types are the subset of numbers that are the negative
+               or positive integers.
+;
+               float     numb
+          '-?(([0-9]+)[.]?|([0-9]*[.][0-9]+))([(][0-9]+[)])?([eE][+-]?[0-9]+)?'
+;              float item types are the subset of numbers that are the floating
+               point numbers.
+;
+               any       char
+               '.*'
+;              A catch all for items that may take any form...
+;
+               yyyy-mm-dd  char
+;\
+[0-9]?[0-9]?[0-9][0-9]-[0-9]?[0-9]-[0-9]?[0-9]\
+((T[0-2][0-9](:[0-5][0-9](:[0-5][0-9](.[0-9]+)?)?)?)?\
+([+-][0-5][0-9]:[0-5][0-9]))?
+;
+;
+               Standard format for CIF date and time strings (see
+               http://www.iucr.org/iucr-top/cif/spec/datetime.html),
+               consisting of a yyyy-mm-dd date optionally followed by
+               the character 'T' followed by a 24-hour clock time,
+               optionally followed by a signed time-zone offset.
+
+               The IUCr standard has been extended to allow for an optional
+               decimal fraction on the seconds of time.
+
+               Time is local time if no time-zone offset is given.
+
+               Note that this type extends the mmCIF yyyy-mm-dd type
+               but does not conform to the mmCIF yyyy-mm-dd:hh:mm
+               type that uses a ':' in place of the 'T' specified
+               by the IUCr standard.  For reading, both forms should
+               be accepted,  but for writing, only the IUCr form should
+               be used.
+
+               For maximal compatibility, the special time zone
+               indicator 'Z' (for 'Zulu') should be accepted on
+               reading in place of '+00:00' for GMT.
+;
+
+
+#####################
+## <a name="ITEM_UNITS_LIST">ITEM_UNITS_LIST</a> ##
+#####################
+
+     loop_
+    _item_units_list.code
+    _item_units_list.detail
+#
+     'metres'                 'metres'
+     'centimetres'            'centimetres (metres * 10^( -2)^)'
+     'millimetres'            'millimetres (metres * 10^( -3)^)'
+     'micrometres'            'micrometres (metres * 10^( -6)^)'
+     'nanometres'             'nanometres  (metres * 10^( -9)^)'
+     'angstroms'              '\%angstr\"oms   (metres * 10^(-10)^)'
+     'picometres'             'picometres  (metres * 10^(-12)^)'
+     'femtometres'            'femtometres (metres * 10^(-15)^)'
+#
+     'reciprocal_metres'      'reciprocal metres (metres^(-1)^)'
+     'reciprocal_centimetres'
+        'reciprocal centimetres ((metres * 10^( -2)^)^(-1)^)'
+     'reciprocal_millimetres'
+        'reciprocal millimetres ((metres * 10^( -3)^)^(-1)^)'
+     'reciprocal_nanometres'
+        'reciprocal nanometres  ((metres * 10^( -9)^)^(-1)^)'
+     'reciprocal_angstroms'
+        'reciprocal \%angstr\"oms   ((metres * 10^(-10)^)^(-1)^)'
+     'reciprocal_picometres'
+        'reciprocal picometres  ((metres * 10^(-12)^)^(-1)^)'
+#
+     'nanometres_squared'     'nanometres squared (metres * 10^( -9)^)^2^'
+     'angstroms_squared'      '\%angstr\"oms squared  (metres * 10^(-10)^)^2^'
+     '8pi2_angstroms_squared'
+       '8\p^2^ * \%angstr\"oms squared (metres * 10^(-10)^)^2^'
+     'picometres_squared'     'picometres squared (metres * 10^(-12)^)^2^'
+#
+     'nanometres_cubed'       'nanometres cubed (metres * 10^( -9)^)^3^'
+     'angstroms_cubed'        '\%angstr\"oms cubed  (metres * 10^(-10)^)^3^'
+     'picometres_cubed'       'picometres cubed (metres * 10^(-12)^)^3^'
+#
+     'kilopascals'            'kilopascals'
+     'gigapascals'            'gigapascals'
+#
+     'hours'                  'hours'
+     'minutes'                'minutes'
+     'seconds'                'seconds'
+     'microseconds'           'microseconds'
+#
+     'degrees'                'degrees (of arc)'
+     'degrees_squared'        'degrees (of arc) squared'
+#
+     'degrees_per_minute'     'degrees (of arc) per minute'
+#
+     'celsius'                'degrees (of temperature) Celsius'
+     'kelvins'                'degrees (of temperature) Kelvin'
+#
+     'counts'                 'counts'
+     'counts_per_photon'      'counts per photon'
+#
+     'electrons'              'electrons'
+#
+     'electrons_squared'      'electrons squared'
+#
+     'electrons_per_nanometres_cubed'
+; electrons per nanometres cubed (electrons/(metres * 10^( -9)^)^(-3)^)
+;
+     'electrons_per_angstroms_cubed'
+; electrons per \%angstr\"oms cubed (electrons/(metres * 10^(-10)^)^(-3)^)
+;
+     'electrons_per_picometres_cubed'
+; electrons per picometres cubed (electrons/(metres * 10^(-12)^)^(-3)^)
+;
+     'kilowatts'              'kilowatts'
+     'milliamperes'           'milliamperes'
+     'kilovolts'              'kilovolts'
+#
+     'pixels_per_element'     '(image) pixels per (array) element'
+#
+     'arbitrary'
+; arbitrary system of units.
+;
+#
+
+     loop_
+    _item_units_conversion.from_code
+    _item_units_conversion.to_code
+    _item_units_conversion.operator
+    _item_units_conversion.factor
+###
+     'metres'                   'centimetres'              '*'   1.0E+02
+     'metres'                   'millimetres'              '*'   1.0E+03
+     'metres'                   'nanometres'               '*'   1.0E+09
+     'metres'                   'angstroms'                '*'   1.0E+10
+     'metres'                   'picometres'               '*'   1.0E+12
+     'metres'                   'femtometres'              '*'   1.0E+15
+#
+     'centimetres'              'metres'                   '*'   1.0E-02
+     'centimetres'              'millimetres'              '*'   1.0E+01
+     'centimetres'              'nanometres'               '*'   1.0E+07
+     'centimetres'              'angstroms'                '*'   1.0E+08
+     'centimetres'              'picometres'               '*'   1.0E+10
+     'centimetres'              'femtometres'              '*'   1.0E+13
+#
+     'millimetres'              'metres'                   '*'   1.0E-03
+     'millimetres'              'centimetres'              '*'   1.0E-01
+     'millimetres'              'nanometres'               '*'   1.0E+06
+     'millimetres'              'angstroms'                '*'   1.0E+07
+     'millimetres'              'picometres'               '*'   1.0E+09
+     'millimetres'              'femtometres'              '*'   1.0E+12
+#
+     'nanometres'               'metres'                   '*'   1.0E-09
+     'nanometres'               'centimetres'              '*'   1.0E-07
+     'nanometres'               'millimetres'              '*'   1.0E-06
+     'nanometres'               'angstroms'                '*'   1.0E+01
+     'nanometres'               'picometres'               '*'   1.0E+03
+     'nanometres'               'femtometres'              '*'   1.0E+06
+#
+     'angstroms'                'metres'                   '*'   1.0E-10
+     'angstroms'                'centimetres'              '*'   1.0E-08
+     'angstroms'                'millimetres'              '*'   1.0E-07
+     'angstroms'                'nanometres'               '*'   1.0E-01
+     'angstroms'                'picometres'               '*'   1.0E+02
+     'angstroms'                'femtometres'              '*'   1.0E+05
+#
+     'picometres'               'metres'                   '*'   1.0E-12
+     'picometres'               'centimetres'              '*'   1.0E-10
+     'picometres'               'millimetres'              '*'   1.0E-09
+     'picometres'               'nanometres'               '*'   1.0E-03
+     'picometres'               'angstroms'                '*'   1.0E-02
+     'picometres'               'femtometres'              '*'   1.0E+03
+#
+     'femtometres'              'metres'                   '*'   1.0E-15
+     'femtometres'              'centimetres'              '*'   1.0E-13
+     'femtometres'              'millimetres'              '*'   1.0E-12
+     'femtometres'              'nanometres'               '*'   1.0E-06
+     'femtometres'              'angstroms'                '*'   1.0E-05
+     'femtometres'              'picometres'               '*'   1.0E-03
+###
+     'reciprocal_centimetres'   'reciprocal_metres'        '*'   1.0E+02
+     'reciprocal_centimetres'   'reciprocal_millimetres'   '*'   1.0E-01
+     'reciprocal_centimetres'   'reciprocal_nanometres'    '*'   1.0E-07
+     'reciprocal_centimetres'   'reciprocal_angstroms'     '*'   1.0E-08
+     'reciprocal_centimetres'   'reciprocal_picometres'    '*'   1.0E-10
+#
+     'reciprocal_millimetres'   'reciprocal_metres'        '*'   1.0E+03
+     'reciprocal_millimetres'   'reciprocal_centimetres'   '*'   1.0E+01
+     'reciprocal_millimetres'   'reciprocal_nanometres'    '*'   1.0E-06
+     'reciprocal_millimetres'   'reciprocal_angstroms'     '*'   1.0E-07
+     'reciprocal_millimetres'   'reciprocal_picometres'    '*'   1.0E-09
+#
+     'reciprocal_nanometres'    'reciprocal_metres'        '*'   1.0E+09
+     'reciprocal_nanometres'    'reciprocal_centimetres'   '*'   1.0E+07
+     'reciprocal_nanometres'    'reciprocal_millimetres'   '*'   1.0E+06
+     'reciprocal_nanometres'    'reciprocal_angstroms'     '*'   1.0E-01
+     'reciprocal_nanometres'    'reciprocal_picometres'    '*'   1.0E-03
+#
+     'reciprocal_angstroms'     'reciprocal_metres'        '*'   1.0E+10
+     'reciprocal_angstroms'     'reciprocal_centimetres'   '*'   1.0E+08
+     'reciprocal_angstroms'     'reciprocal_millimetres'   '*'   1.0E+07
+     'reciprocal_angstroms'     'reciprocal_nanometres'    '*'   1.0E+01
+     'reciprocal_angstroms'     'reciprocal_picometres'    '*'   1.0E-02
+#
+     'reciprocal_picometres'    'reciprocal_metres'        '*'   1.0E+12
+     'reciprocal_picometres'    'reciprocal_centimetres'   '*'   1.0E+10
+     'reciprocal_picometres'    'reciprocal_millimetres'   '*'   1.0E+09
+     'reciprocal_picometres'    'reciprocal_nanometres'    '*'   1.0E+03
+     'reciprocal_picometres'    'reciprocal_angstroms'     '*'   1.0E+01
+###
+     'nanometres_squared'       'angstroms_squared'        '*'   1.0E+02
+     'nanometres_squared'       'picometres_squared'       '*'   1.0E+06
+#
+     'angstroms_squared'        'nanometres_squared'       '*'   1.0E-02
+     'angstroms_squared'        'picometres_squared'       '*'   1.0E+04
+     'angstroms_squared'        '8pi2_angstroms_squared'   '*'   78.9568
+
+#
+     'picometres_squared'       'nanometres_squared'       '*'   1.0E-06
+     'picometres_squared'       'angstroms_squared'        '*'   1.0E-04
+###
+     'nanometres_cubed'         'angstroms_cubed'          '*'   1.0E+03
+     'nanometres_cubed'         'picometres_cubed'         '*'   1.0E+09
+#
+     'angstroms_cubed'          'nanometres_cubed'         '*'   1.0E-03
+     'angstroms_cubed'          'picometres_cubed'         '*'   1.0E+06
+#
+     'picometres_cubed'         'nanometres_cubed'         '*'   1.0E-09
+     'picometres_cubed'         'angstroms_cubed'          '*'   1.0E-06
+###
+     'kilopascals'              'gigapascals'              '*'   1.0E-06
+     'gigapascals'              'kilopascals'              '*'   1.0E+06
+###
+     'hours'                    'minutes'                  '*'   6.0E+01
+     'hours'                    'seconds'                  '*'   3.6E+03
+     'hours'                    'microseconds'             '*'   3.6E+09
+#
+     'minutes'                  'hours'                    '/'   6.0E+01
+     'minutes'                  'seconds'                  '*'   6.0E+01
+     'minutes'                  'microseconds'             '*'   6.0E+07
+#
+     'seconds'                  'hours'                    '/'   3.6E+03
+     'seconds'                  'minutes'                  '/'   6.0E+01
+     'seconds'                  'microseconds'             '*'   1.0E+06
+#
+     'microseconds'             'hours'                    '/'   3.6E+09
+     'microseconds'             'minutes'                  '/'   6.0E+07
+     'microseconds'             'seconds'                  '/'   1.0E+06
+###
+     'celsius'                  'kelvins'                  '-'     273.0
+     'kelvins'                  'celsius'                  '+'     273.0
+###
+     'electrons_per_nanometres_cubed'
+     'electrons_per_angstroms_cubed'                       '*'   1.0E+03
+     'electrons_per_nanometres_cubed'
+     'electrons_per_picometres_cubed'                      '*'   1.0E+09
+#
+     'electrons_per_angstroms_cubed'
+     'electrons_per_nanometres_cubed'                      '*'   1.0E-03
+     'electrons_per_angstroms_cubed'
+     'electrons_per_picometres_cubed'                      '*'   1.0E+06
+#
+     'electrons_per_picometres_cubed'
+     'electrons_per_nanometres_cubed'                      '*'   1.0E-09
+     'electrons_per_picometres_cubed'
+     'electrons_per_angstroms_cubed'                       '*'   1.0E-06
+###
+
+########################
+## <a name="DICTIONARY_HISTORY">DICTIONARY_HISTORY</a> ##
+########################
+
+     loop_
+    _dictionary_history.version
+    _dictionary_history.update
+    _dictionary_history.revision
+
+    1.8.6    2022-05-11
+
+;   Add missing archive tags to external data tags, clarify use of 
+    those tags and correct typos (jrh, hjb)
+
+    + Add <a href="#_array_data_external_data.archive_format" >_array_data_external_data.archive_format</a>
+    + Add <a href="#_array_data_external_data.archive_path" >_array_data_external_data.archive_path</a>
+
+;
+
+    1.8.5    2021-07-09
+
+;   Handling of external data (jrh, ab, hjb)
+
+    + Remove preliminary versions of external data tags in <a href="#array_data">ARRAY_DATA</a>
+    + Add <a href="#array_data_external_data">ARRAY_DATA_EXTERNAL_DATA</a>
+    + Add <a href="#_array_data.external_data_id" >_array_data.external_data_id</a>
+    + Add <a href="#_array_data_external_data.format" >_array_data_external_data.format</a>
+    + Add <a href="#_array_data_external_data.frame" >_array_data_external_data.frame</a>
+    + Add <a href="#_array_data_external_data.id" >_array_data_external_data.id</a>
+    + Add <a href="#_array_data_external_data.path" >_array_data_external_data.path</a>
+    + Add <a href="#_array_data_external_data.uri" >_array_data_external_data.uri</a>
+    + Add <a href="#_array_data_external_data.variant" >_array_data_external_data.variant</a>
+    + Add <a href="#_array_data_external_data.version" >_array_data_external_data.version</a>
+
+;
+
+    1.8.4    2021-04-15
+
+;   Copy-editing refinements (bm)
+
+    + Add _item_related.related_name and
+      "_item_related.function_code replacedby" to deprecated items.
+    + Add "_item_default.value  ." to *_variant items
+    + Change uses of \%Angstroms to \%angstr\"oms
+    + Change category save frames to upper case names
+    + Fix misssing superscript terminating ^
+
+    Preliminary version of external data tags (jrh)
+
+    + Add <a href="#_array_data.external_format" >_array_data.external_format</a>
+    + Add <a href="#_array_data.external_version" >_array_data.external_version</a>
+    + Add <a href="#_array_data.external_location_uri" >_array_data.external_location_uri</a>
+    + Add <a href="#_array_data.external_path" >_array_data.external_path</a>
+    + Add <a href="#_array_data.external_frame" >_array_data.external_frame</a>
+    + Add <a href="#_array_data.external_archive_path" >_array_data.external_archive_path</a>
+    + Add <a href="#_array_data.external_archive_format" >_array_data.external_archive_format</a>
+
+    Note the second block of mads is a preliminary version.  When they are
+    done they may well be removed from here and reappear in a 1.8.5
+    dictionary.
+
+;
+
+    1.8.3    2021-02-28
+
+;   Correction as per Brian McMahon
+
+    + Fix _item.name for <a href="#_array_structure_list.array_section_id" >_array_structure_list.array_section_id</a>
+    + Remove spurious _item_aliases.alias_name from
+      <a href="#_diffrn_radiation.polarisn_ratio_esd">_diffrn_radiation.polarisn_ratio_esd</a>
+    + Remove spurious reference to _diffrn_scan_frame.time_rstrt_incr
+    + Provide missing <a href="#_diffrn_scan_frame_monitor.monitor_value" >_diffrn_scan_frame_monitor.monitor_value</a> definition
+    + Deprecate <a href="#_diffrn_scan_frame_monitor.value" >_diffrn_scan_frame_monitor.value</a>
+;
+
+    1.8.2    2021-02-21
+
+;   Corrections and additions for ITVG 2021
+
+    + Add McStas as an axis coordinate system
+    + Add <a href="#_array_intensities.underload" >_array_intensities.underload</a> as optional
+    + Add <a href="#_diffrn_scan_collection.details" >_diffrn_scan_collection.details</a> as optional
+    + Add <a href="#_diffrn_scan_collection.variant" >_diffrn_scan_collection.variant</a> as optional
+;
+
+    1.8.1    2021-01-30
+
+;   Copy-paste error corrections (JRH)
+
+    + Fix double underscore in <a href="#_diffrn_data_frame.center_derived" >_diffrn_data_frame.center_derived</a>
+    + Fix wrong _item.name in <a href="#_diffrn_scan.date_end_estimated" >_diffrn_scan.date_end_estimated</a>
+    + Fix wrong _item.mandatory_code in <a href="#_diffrn_scan_frame_monitor.frame_id" >_diffrn_scan_frame_monitor.frame_id<a/>
+    + Fix wrong _item.mandatory_code in <a href="#_variant.variant_of" >_variant.variant_of</a>
+;
+
+    1.8.0    2021-01-24
+
+;   Changes for 2021 ITVG and conformance with Gold Standard and NXmx (HJB)
+
+    + Add <a href="#_diffrn_data_frame.center_derived" >_diffrn_data_frame.center_derived</a> as optional
+    + Add <a href="#_diffrn_measurement.sample_detector_distance_derived">_diffrn_measurement.sample_detector_distance_derived</a> as optional
+    + Change <a href="#_diffrn_scan.date_start">_diffrn_scan.date_start</a> to mandatory
+    + Add <a href="#_diffrn_scan.date_end_estimated">_diffrn_scan.date_end_estimated</a> as mandatory
+    + Fix .array_id and .binary_id columns to be implicit in all cases to
+      facilitate mini_cbfs
+
+;
+
+
+    1.7.11   2018-12-03
+
+;   Changes for CBFlib 0.9.6 release (HJB)
+
+    + Remove _array_structure_list.array_section_id
+    + Revisions to _category.NX_mapping_details in most categories for
+    array sections.
+    + Change to uniform use of entry:NXentry
+    + Change to uniform use of identification of NXdetector by detector
+    element
+    + Change to uniform use of data_ARRAYID_BINARYID
+    + Add <a href="#_array_structure_list.array_section_id">_array_structure_list.array_section_id</a>
+    + Add <a href="#_map_segment.mask_array_section_id">_map_segment.mask_array_section_id</a>
+    + Add <a href="#_diffrn_scan_collection.scan_id">_diffrn_scan_collection.scan_id</a>
+    + Add <a href="#_diffrn_scan_collection.type">_diffrn_scan_collection.type</a>
+    + Add <a href="#_diffrn_scan_collection.translation_width">_diffrn_scan_collection.translation_width</a>
+    + Add <a href="#_map_segment._diffrn_radiation.beam_width">_diffrn_radiation.beam_width</a>
+    + Add <a href="#_map_segment._diffrn_radiation.beam_height">_diffrn_radiation.beam_height</a>
+    + Add <a href="#_map_segment._diffrn_radiation.beam_flux">_diffrn_radiation.beam_flux</a>
+
+;
+
+
+    1.7.10   2014-04-25
+
+;  Additions of esd's to polarization tags.  Change to NeXus mapping to use
+   NXtransformations instead of NXpoise (HJB)
+
+    + Add <a href="#_diffrn_radiation.polarisn_norm_esd">_diffrn_radiation.polarisn_norm_esd</a>,
+    <a href="#_diffrn_radiation.polarisn_ratio_esd">_diffrn_radiation.polarisn_ratio_esd</a>,
+    <a href="#_diffrn_radiation.polarizn_source_norm_esd" >_diffrn_radiation.polarizn_source_norm_esd</a>,
+    <a href="#_diffrn_radiation.polarizn_source_ratio_esd" >_diffrn_radiation.polarizn_source_ratio_esd</a>,
+    <a href="#_diffrn_radiation.polarizn_Stokes_I_esd">_diffrn_radiation.polarizn_Stokes_I_esd</a>,
+    <a href="#_diffrn_radiation.polarizn_Stokes_Q_esd">_diffrn_radiation.polarizn_Stokes_Q_esd</a>,
+    <a href="#_diffrn_radiation.polarizn_Stokes_U_esd">_diffrn_radiation.polarizn_Stokes_U_esd</a>,
+    <a href="#_diffrn_radiation.polarizn_Stokes_V_esd">_diffrn_radiation.polarizn_Stokes_V_esd</a>,
+    <a href="#_diffrn_scan_frame.polarizn_Stokes_I_esd">_diffrn_scan_frame.polarizn_Stokes_I_esd</a>,
+    <a href="#_diffrn_scan_frame.polarizn_Stokes_Q_esd">_diffrn_scan_frame.polarizn_Stokes_Q_esd</a>,
+    <a href="#_diffrn_scan_frame.polarizn_Stokes_U_esd">_diffrn_scan_frame.polarizn_Stokes_U_esd</a>,
+    <a href="#_diffrn_scan_frame.polarizn_Stokes_V_esd">_diffrn_scan_frame.polarizn_Stokes_V_esd</a>.
+    + Change NeXus mapping for <a href="#array_structure_list">ARRAY_STRUCTURE_LIST</a>
+    <a href="#array_structure_list_axis">ARRAY_STRUCTURE_LIST_AXIS</a>, <a href="#axis">AXIS</a>,
+    <a href="#diffrn_detector_axis">DIFFRN_DETECTOR_AXIS</a>, <a href="#diffrn_measurement_axis">DIFFRN_MEASUREMENT_AXIS</a>,
+    <a href="#diffrn_scan_frame_axis">DIFFRN_SCAN_FRAME_AXIS</a>.
+
+;
+
+    1.7.9   2014-04-05
+
+;  Corrections to Stokes parameter description. (HJB)
+
+    + Clarify the meaning of <a href="#_diffrn_radiation.polarizn_Stokes_I">_diffrn_radiation.polarizn_Stokes_I</a>
+    and <a href="#_diffrn_scan_frame.polarizn_Stokes_I">_diffrn_scan_frame.polarizn_Stokes_I</a> to explicitly include non-polarized
+        component.
+
+    + Provide missing factor of 2 in <a href="#_diffrn_radiation.polarizn_Stokes_V">_diffrn_radiation.polarizn_Stokes_V</a>
+    description and <a href="#_diffrn_scan_frame.polarizn_Stokes_V">_diffrn_scan_frame.polarizn_Stokes_V</a> description.
+
+;
+
+
+    1.7.8   2014-02-22
+
+;  Minor changes to NeXus mapping. (HJB)
+
+       + Conform NeXus mapping of <a href=#diffrn_detector>DIFFRN_DETECTOR</a> to neXus
+       NXdetector base class terminology
+
+       + Add <a href="#_diffrn_detector.gain_setting">_diffrn_detector.gain_setting</a> to handle
+       the reverse mapping from NeXus of the equivalent field in NXdetector.
+;
+
+    1.7.7   2014-02-22
+
+;  Major changes to NeXus mapping to conform to JS functional
+    mapping prototype, add Stoke parameter tags for polarization
+    and beam intensity, and add an new tag for FEL axes (HJB)
+
+       + Add
+       <a href="#_axis.equipment_component">_axis.equipment_component</a>,
+       <a href="#_diffrn_radiation.polarizn_Stokes_I">_diffrn_radiation.polarizn_Stokes_I</a>,
+       <a href="#_diffrn_radiation.polarizn_Stokes_Q">_diffrn_radiation.polarizn_Stokes_Q</a>,
+       <a href="#_diffrn_radiation.polarizn_Stokes_U">_diffrn_radiation.polarizn_Stokes_U</a>,
+       <a href="#_diffrn_radiation.polarizn_Stokes_V">_diffrn_radiation.polarizn_Stokes_V</a>,
+       <a href="#_diffrn_scan_frame.polarizn_Stokes_I">_diffrn_scan_frame.polarizn_Stokes_I</a>,
+       <a href="#_diffrn_scan_frame.polarizn_Stokes_Q">_diffrn_scan_frame.polarizn_Stokes_Q</a>,
+       <a href="#_diffrn_scan_frame.polarizn_Stokes_U">_diffrn_scan_frame.polarizn_Stokes_U</a>,
+       <a href="#_diffrn_scan_frame.polarizn_Stokes_V">_diffrn_scan_frame.polarizn_Stokes_V</a>.
+       + Remove erroneous type code from <a href="#_diffrn_scan_frame_monitor.value">_diffrn_scan_frame_monitor.value</a>.
+       + Update dictionary version
+;
+
+
+
+    1.7.6   2013-10-29
+
+;  To avoid a conflict with PDB software, remove the null value
+    enumeration for <a href=#_variant.role>_variant.role</a> (HJB)
+
+;
+
+
+    1.7.5   2013-10-27
+
+;  At request of JW for the PDB move _category.NX_mapping_details
+   to be adjacent to other category tags. (HJB)
+
+;
+
+    1.7.4   2013-10-23
+
+;  Minor cleanup and remove spurious tag
+
+    +  remove spurious _array_structure_list_section.array_set_id
+    references. (JS)
+    +  Change case of category names to conform to PDB conventions. (JW)
+
+;
+
+
+    1.7.3   2013-10-15
+
+;  Major cleanup of dictionary typos, misplaced loops, etc
+       by John Westbrook
+
+    +  Change _item.mandatory_code of all *.variant to implicit
+    +  Add <a href="#_diffrn_refln.id">_diffrn_refln.id</a> and <a href="#_diffrn_refln.diffrn_id">_diffrn_refln.diffrn_id</a>
+    +  Correct many _item.name values that were wrong or missing
+       quote marks
+
+;
+
+
+
+    1.7.2   2013-10-07
+
+;  Add FEL detector positioning tags and change back to NXgoniometer
+
+    +  Add
+       <a href="#_axis.rotation_axis">_axis.rotation_axis</a> and
+       <a href="#_axis.rotation">_axis.rotation</a> and
+    +  Change NXsample back to NXgoniometer
+
+;
+
+    1.7.1   2013-08-10
+
+;  Minor cleanup (HJB)
+
+    +  Correction to description of
+         <a href="#_diffrn_data_frame.array_section_id">_diffrn_data_frame.array_section_id</a>
+    +  Change NXgoniometer to NXsample
+    +  Fix typos in NeXus mappings
+
+;
+
+    1.7     2013-06-18
+
+;  Additions to start merge of CBF, HDF5 and NeXus (HJB)
+
+    +  Define new ARRAY_STRUCTURE_LIST_SECTION category
+    +  Add new _category.NX_mapping_details DDL tag to carry
+       details on NeXus category mappings.
+    +  Define new tags <a href="#_array_structure_list_section.array_id" >_array_structure_list_section.array_id</a>,
+       <a href="#_array_structure_list_section.id" >_array_structure_list_section.id</a>,
+       <a href="#_array_structure_list_section.index" >_array_structure_list_section.index</a>,
+       <a href="#_array_structure_list_section.end" >_array_structure_list_section.end</a>,
+       <a href="#_array_structure_list_section.start" >_array_structure_list_section.start</a>,
+       <a href="#_array_structure_list_section.stride" >_array_structure_list_section.stride</a>,
+       <a href="#_array_structure_list_section.variant" >_array_structure_list_section.variant</a>,
+       <a href="#_diffrn_data_frame.array_section_id" >_diffrn_data_frame.array_section_id</a>,
+       <a href="#_diffrn_detector.layer_thickness" >_diffrn_detector.layer_thickness</a>,
+       <a href="#_map_segment.array_section_id" >_map_segment.array_section_id</a>,
+       <a href="#_map_segment.mask_array_section_id" >_map_segment.mask_array_section_id</a>
+
+;
+
+    1.6.4   2011-07-02
+
+;  Corrections to support DLS Dectris header as per G. Winter (HJB)
+
+    +  Define new tags <a href="#_diffrn_scan.time_period">_diffrn_scan.time_period</a>,
+       <a href="#_diffrn_scan.time_rstrt_incr">_diffrn_scan.time_rstrt_incr</a>,
+       <a href="#_diffrn_scan_frame.time_period">_diffrn_scan_frame.time_period</a>,
+       <a href="#_diffrn_scan_frame.time_rstrt_incr">_diffrn_scan_frame.time_rstrt_incr</a> 
+    +  fix bad category name in loop in <a href="#_diffrn_detector.id">_diffrn_detector.id</a>
+    +  remove stray text field terminator at line 4642
+    +  fix unquoted tag as a value in <a href="#_diffrn_scan_frame_monitor.id">_diffrn_scan_frame_monitor.id</a>
+    +  make formerly mandatory and implicit deprecated items non-mandatory
+
+;
+
+   1.6.3   2010-08-26
+
+;  Cumulative corrections from 1.6.0, 1, 2 drafts (HJB)
+
+    +  Move descriptive dictionary comments into 
+    _datablock.description with category tree described
+    +  add default <a href="#_array_data.array_id">_array_data.array_id</a> value of 1
+    +  add option of CBF_BACKGROUND_OFFSET_DELTA compression
+    +  add VARIANT category and tags
+    +  add DIFFRN_SCAN_FRAME_MONITOR category
+
+;
+
+   1.5.4   2007-07-28
+
+;  Typographics corrections (HJB)
+
+     + Corrected embedded degree characters to \%
+     + Corrected embedded Aring to \%A
+     + Added trailing ^ for a power
+     + Removed 2 cases of a space after an underscore
+       in tag name.
+;
+
+   1.5.3   2007-07-08
+
+;  Changes to support SLS miniCBF and suggestions
+   from the 24 May 07 BNL imgCIF workshop (HJB)
+
+     + Added new data items
+       '<a href="#_array_data.header_contents" >_array_data.header_contents</a>',
+       '<a href="#_array_data.header_convention" >_array_data.header_convention</a>',
+       '<a href="#_diffrn_data_frame.center_fast" >_diffrn_data_frame.center_fast</a>',
+       '<a href="#_diffrn_data_frame.center_slow" >_diffrn_data_frame.center_slow</a>',
+       '<a href="#_diffrn_data_frame.center_units" >_diffrn_data_frame.center_units</a>',
+       '<a href="#_diffrn_measurement.sample_detector_distance" >_diffrn_measurement.sample_detector_distance</a>',
+       '<a href="#_diffrn_measurement.sample_detector_voffset" >_diffrn_measurement.sample_detector_voffset</a>
+     + Deprecated data items
+       '<a href="#_diffrn_detector_element.center[1]" >_diffrn_detector_element.center[1]</a>',
+       '<a href="#_diffrn_detector_element.center[2]" >_diffrn_detector_element.center[2]</a>'
+     + Added comments and example on miniCBF
+     + Changed all array_id data items to implicit
+;
+
+   1.5.2   2007-05-06
+
+;  Further clarifications of the coordinate system. (HJB)
+;
+
+   1.5.1   2007-04-26
+
+;  Improve definition of X-axis to cover the case of no goniometer
+   and clean up more line folds (HJB)
+;
+
+   1.5     2007-07-25
+
+;  This is a cumulative list of the changes proposed since the
+   imgCIF workshop in Hawaii in July 2006.  It is the result
+   of contributions by H. J. Bernstein, A. Hammersley,
+   J. Wright and W. Kabsch.
+
+   2007-02-19 Consolidated changes (edited by HJB)
+     + Added new data items
+       '<a href="#_array_structure.compression_type_flag" >_array_structure.compression_type_flag</a>',
+       '<a href="#_array_structure_list_axis.fract_displacement">_array_structure_list_axis.fract_displacement</a>',
+       '<a href="#_array_structure_list_axis.fract_displacement_increment" >_array_structure_list_axis.displacement_increment</a>',
+       '<a href="#_array_structure_list_axis.reference_angle" >_array_structure_list_axis.reference_angle</a>',
+       '<a href="#_array_structure_list_axis.reference_displacement" >_array_structure_list_axis.reference_displacement</a>',
+       '<a href="#_axis.sdystem" >_axis.system</a>',
+       '<a href="#_diffrn_detector_element.reference_center_fast" >_diffrn_detector_element.reference_center_fast</a>',
+       '<a href="#_diffrn_detector_element.reference_center_slow" >_diffrn_detector_element.reference_center_slow</a>',
+       '<a href="#_diffrn_scan_axis.reference_angle" >_diffrn_scan_axis.reference_angle</a>',
+       '<a href="#_diffrn_scan_axis.reference_displacement" >_diffrn_scan_axis.reference_displacement</a>',
+       '<a href="#_map.details" >_map.details</a>', '<a href="#_map.diffrn_id" >_map.diffrn_id</a>',
+       '<a href="#_map.entry_id" >_map.entry_id</a>', '<a href="#_map.id" >_map.id</a>',
+       '<a href="#_map_segment.array_id" >_map_segment.array_id</a>', '<a href="#_map_segment.binary_id" >_map_segment.binary_id</a>',
+       '<a href="#_map_segment.mask_array_id" >_map_segment.mask_array_id</a>', '<a href="#_map_segment.mask_binary_id" >_map_segment.mask_binary_id</a>',
+       '<a href="#_map_segment.id" >_map_segment.id</a>', '<a href="#_map_segment.map_id" >_map_segment.map_id</a>',
+       '<a href="#_map_segment.details" >_map_segment.details</a>.
+     + Change type of 
+       '<a href="#_array_structure.byte_order" >_array_structure.byte_order</a>' and
+       '<a href="#_array_structure.compression_type" >_array_structure.compression_type</a>'
+       to ucode to make these values case-insensitive
+     + Add values 'packed_v2' and 'byte_offset' to enumeration of values for
+       '<a href="#_array_structure.compression_type" >_array_structure.compression_type</a>'
+     + Add to definitions for the binary data type to handle new compression
+       types, maps, and a variety of new axis types.
+    2007-07-25 Cleanup of typos for formal release (HJB)
+     + Corrected text fields for reference_ tag descriptions that
+       were off by one column
+     + Fix typos in comments listing fract_ tags
+     + Changed name of release from 1.5_DRAFT to 1.5
+     + Fix unclosed text fields in various map definitions
+
+;
+
+   1.4     2006-07-04
+
+;  This is a change to reintegrate all changes made in the course of
+   publication of ITVG, by the RCSB from April 2005 through
+   August 2008 and changes for the 2006 imgCIF workshop in
+   Hawaii.
+
+   2006-07-04 Consolidated changes for the 2006 imgCIF workshop (edited by HJB)
+     + Correct type of '<a href="#_array_structure_list.direction">_array_structure_list.direction</a>' from 'int' to 'code'.
+     + Added new data items suggested by CN
+       '<a href="#_diffrn_data_frame.details">_diffrn_data_frame.details</a>'
+       '<a href="#_array_intensities.pixel_fast_bin_size" >_array_intensities.pixel_fast_bin_size</a>',
+       '<a href="#_array_intensities.pixel_slow_bin_size" >_array_intensities.pixel_slow_bin_size</a> and
+       '<a href="#_array_intensities.pixel_binning_method" >_array_intensities.pixel_binning_method</a>
+     + Added deprecated item for completeness
+       '<a href="#_diffrn_frame_data.details">_diffrn_frame_data.details</a>'
+     + Added entry for missing item in contents list
+       '<a href="#_array_structure_list_axis.displacement" >_array_structure_list_axis.displacement</a>'
+     + Added new MIME type <b>X</b>-BASE32K based on work by VL, KM, GD, HJB
+     + Correct description of MIME boundary delimiter to start in
+       column 1.
+     + General cleanup of text fields to conform to changes for ITVG
+       by removing empty lines at start and finish of text field.
+     + Amend example for ARRAY_INTENSITIES to include binning.
+     + Add local copy of type specification (as 'code') for all children
+       of '<a href="#_diffrn.id">_diffrn.id</a>'.
+     + For consistency, change all references to 'pi' to '\p' and all
+       references to 'Angstroms' to '\%Angstroms'.
+     + Clean up all powers to use IUCr convention of '^power^', as in
+       '10^3^' for '10**3'.
+     + Update 'yyyy-mm-dd' type regex to allow truncation from the right
+       and improve comments to explain handling of related mmCIF
+       'yyyy-mm-dd:hh:mm' type, and use of 'Z' for GMT time zone.
+
+   2005-03-08 and
+   2004-08-08 fixed cases where _item_units.code  used
+              instead of _item_type.code (JDW)
+   2004-04-15 fixed item ordering in
+               _diffrn_measurement_axis.measurement_id
+               added sub_category 'vector' (JDW)
+;
+
+   1.3.2   2005-06-25
+
+;  2005-06-25 ITEM_TYPE_LIST: code, ucode, line, uline regexps updated
+              to those of current mmCIF; float modified by allowing integers
+              terminated by a point as valid. The 'time' part of
+              yyyy-mm-dd types made optional in the regexp. (BM)
+
+   2005-06-17 Minor corrections as for proofs for IT G Chapter 4.6
+   (NJA)
+
+   2005-02-21  Minor corrections to spelling and punctuation
+   (NJA)
+
+   2005-01-08 Changes as per Nicola Ashcroft.
+   + Updated example 1 for DIFFRN_MEASUREMENT to agree with mmCIF.
+   + Spelled out "micrometres" for "um" and "millimetres" for "mm".
+   + Removed phrase "which may be stored" from ARRAY_STRUCTURE
+     description.
+   + Removed unused 'byte-offsets' compressions and updated
+     cites to ITVG for '_array_structure.compression_type'.
+   (HJB)
+;
+
+   1.3.1   2003-08-13
+;
+   Changes as per Frances C. Bernstein.
+   + Identify initials.
+   + Adopt British spelling for centre in text.
+   + Set \p and \%Angstrom and powers.
+   + Clean up commas and unclear wordings.
+   + Clean up tenses in history.
+   Changes as per Gotzon Madariaga.
+   + Fix the ARRAY_DATA example to align '_array_data.binary_id'
+   and <b>X</b>-Binary-ID.
+   + Add a range to '<a href="#_array_intensities.gain_esd">_array_intensities.gain_esd</a>'.
+   + In the example of DIFFRN_DETECTOR_ELEMENT,
+   '<a href="#_diffrn_detector_element.id">_diffrn_detector_element.id</a>' and
+   '<a href="#_diffrn_detector_element.detector_id">_diffrn_detector_element.detector_id</a>' interchanged.
+   + Fix typos for direction, detector and axes.
+   + Clarify description of polarisation.
+   + Clarify axes in '<a href="#_diffrn_detector_element.center[1]">_diffrn_detector_element.center[1]</a>'
+    '<a href="#_diffrn_detector_element.center[2]">_diffrn_detector_element.center[2]</a>'.
+   + Add local item types for items that are pointers.
+   (HJB)
+;
+
+
+   1.3.0   2003-07-24
+;
+   Changes as per Brian McMahon.
+   + Consistently quote tags embedded in text.
+   + Clean up introductory comments.
+   + Adjust line lengths to fit in 80 character window.
+   + Fix several descriptions in AXIS category which
+     referred to '_axis.type' instead of the current item.
+   + Fix erroneous use of deprecated item
+     '_diffrn_detector_axis.id' in examples for
+     DIFFRN_SCAN_AXIS.
+   + Add deprecated items '_diffrn_detector_axis.id'
+     and '_diffrn_measurement_axis.id'.
+   (HJB)
+;
+
+
+   1.2.4   2003-07-14
+;
+   Changes as per I. David Brown.
+   + Enhance descriptions in DIFFRN_SCAN_AXIS to make them less
+     dependent on the descriptions in DIFFRN_SCAN_FRAME_AXIS.
+   + Provide a copy of the deprecated DIFFRN_FRAME_DATA
+     category for completeness.
+   (HJB)
+;
+
+
+   1.2.3   2003-07-03
+;
+   Cleanup to conform to ITVG.
+   + Correct sign error in ..._cubed units.
+   + Correct '_diffrn_radiation.polarisn_norm' range.
+   (HJB)
+;
+
+
+   1.2.2   2003-03-10
+;
+   Correction of typos in various DIFFRN_SCAN_AXIS descriptions.
+   (HJB)
+;
+
+
+   1.2.1   2003-02-22
+;
+   Correction of ATOM_ for ARRAY_ typos in various descriptions.
+   (HJB)
+;
+
+
+   1.2     2003-02-07
+;
+   Corrections to encodings (remove extraneous hyphens) remove
+   extraneous underscore in '<a href="#_array_structure.encoding_type">_array_structure.encoding_type</a>'
+   enumeration.  Correct typos in items units list.  (HJB)
+;
+
+
+   1.1.3   2001-04-19
+;
+   Another typo corrections by Wilfred Li, and cleanup by HJB.
+;
+
+
+   1.1.2   2001-03-06
+;
+   Several typo corrections by Wilfred Li.
+;
+
+
+   1.1.1   2001-02-16
+;
+   Several typo corrections by JW.
+;
+
+
+   1.1     2001-02-06
+;
+   Draft resulting from discussions on header for use at NSLS.  (HJB)
+
+   + Change DIFFRN_FRAME_DATA to <a href="#DIFFRN_DATA_FRAME">DIFFRN_DATA_FRAME</a>.
+
+   + Change '_diffrn_detector_axis.id' to '<a href="#_diffrn_detector_axis.detector_id">_diffrn_detector_axis.detector_id</a>'.
+
+   + Add '<a href="#_diffrn_measurement_axis.measurement_device">_diffrn_measurement_axis.measurement_device</a>' and change
+     '_diffrn_measurement_axis.id' to
+     '<a href="#_diffrn_measurement_axis.measurement_id">_diffrn_measurement_axis.measurement_id</a>'.
+
+   + Add '<a href="#_diffrn_radiation.div_x_source">_diffrn_radiation.div_x_source</a>', '<a href="#_diffrn_radiation.div_y_source">_diffrn_radiation.div_y_source</a>',
+    '<a href="#_diffrn_radiation.div_x_y_source">_diffrn_radiation.div_x_y_source</a>',
+    '<a href="#_diffrn_radiation.polarizn_source_norm">_diffrn_radiation.polarizn_source_norm</a>',
+   '<a href="#_diffrn_radiation.polarizn_source_ratio">_diffrn_radiation.polarizn_source_ratio</a>', '<a href="#_diffrn_scan.date_end">_diffrn_scan.date_end</a>',
+   '<a href="#_diffrn_scan.date_start">_diffrn_scan.date_start</a>', '<a href="#_diffrn_scan_axis.angle_rstrt_incr">_diffrn_scan_axis.angle_rstrt_incr</a>',
+   '<a href="#_diffrn_scan_axis.displacement_rstrt_incr">_diffrn_scan_axis.displacement_rstrt_incr</a>',
+   '<a href="#_diffrn_scan_frame_axis.angle_increment">_diffrn_scan_frame_axis.angle_increment</a>',
+   '<a href="#_diffrn_scan_frame_axis.angle_rstrt_incr">_diffrn_scan_frame_axis.angle_rstrt_incr</a>',
+   '<a href="#_diffrn_scan_frame_axis.displacement">_diffrn_scan_frame_axis.displacement</a>',
+   '<a href="#_diffrn_scan_frame_axis.displacement_increment">_diffrn_scan_frame_axis.displacement_increment</a>',and
+   '<a href="#_diffrn_scan_frame_axis.displacement_rstrt_incr">_diffrn_scan_frame_axis.displacement_rstrt_incr</a>'.
+
+   + Add '<a href="#_diffrn_measurement.device">_diffrn_measurement.device</a>' to category key.
+
+   + Update yyyy-mm-dd to allow optional time with fractional seconds
+     for time stamps.
+
+   + Fix typos caught by RS.
+
+   + Add <a href="#array_structure_list_axis">ARRAY_STRUCTURE_LIST_AXIS</a> category, and use concept of axis sets to
+     allow for coupled axes, as in spiral scans.
+
+   + Add examples for fairly complete headers thanks to R. Sweet and P.
+     Ellis.
+;
+
+
+   1.0     2000-12-21
+;
+   Release version - few typos and tidying up.  (BM &amp; HJB)
+
+   + Move ITEM_TYPE_LIST, ITEM_UNITS_LIST and DICTIONARY_HISTORY to end
+   of dictionary.
+
+   + Alphabetize dictionary.
+;
+
+
+   0.7.1   2000-09-29
+;
+   Cleanup fixes.  (JW)
+
+   + Correct spelling of DIFFRN_MEASUREMENT_AXIS in '<a href="#_axis.id">_axis.id</a>'
+
+   + Correct ordering of uses of '_item.mandatory_code' and
+   '_item_default.value'.
+;
+
+
+   0.7.0   2000-09-09
+;
+   Respond to comments by I. David Brown.  (HJB)
+
+   + Add further comments on '\n' and '\t'.
+
+   + Update ITEM_UNITS_LIST by taking section from mmCIF dictionary
+     and adding metres.  Change 'meter' to 'metre' throughout.
+
+   + Add missing enumerations to '<a href="#_array_structure.compression_type">_array_structure.compression_type</a>'
+     and make 'none' the default.
+
+   + Remove parent-child relationship between
+     '<a href="#_array_structure_list.index">_array_structure_list.index</a>' and '<a href="#_array_structure_list.precedence">_array_structure_list.precedence</a>'.
+
+   + Improve alphabetization.
+
+   + Fix '<a href="#_array_intensities.gain_esd">_array_intensities.gain_esd</a>' related function.
+
+   + Improve comments in <a href="#AXIS">AXIS</a>.
+
+   + Fix DIFFRN_FRAME_DATA example.
+
+   + Remove erroneous <a href="#diffrn_measurement">DIFFRN_MEASUREMENT</a> example.
+
+   + Add '<a href="#_diffrn_measurement_axis.id">_diffrn_measurement_axis.id</a>' to the category key.
+;
+
+
+   0.6.0   1999-01-14
+;
+   Remove redundant information for ENC_NONE data.  (HJB)
+
+   + After the D5 remove binary section identifier, size and
+     compression type.
+
+   + Add Control-L to header.
+;
+
+
+   0.5.1   1999-01-03
+;
+   Cleanup of typos and syntax errors.  (HJB)
+
+   + Cleanup example details for <a href="#diffrn_scan">DIFFRN_SCAN</a> category.
+
+   + Add missing quote marks for '<a href="#_diffrn_scan.id" >_diffrn_scan.id</a>' definition.
+;
+
+
+   0.5   1999-01-01
+;
+   Modifications for axis definitions and reduction of binary header.  (HJB)
+
+   + Restore '<a href="#_diffrn_detector.diffrn_id" >_diffrn_detector.diffrn_id</a>' to <a href="#DIFFRN_DETECTOR">DIFFRN_DETECTOR</a> KEY.
+
+   + Add <a href="#AXIS">AXIS</a> category.
+
+   + Bring in complete <a href="#DIFFRN_DETECTOR">DIFFRN_DETECTOR</a> and <a href="#diffrn_measurement">DIFFRN_MEASUREMENT</a> categories
+     from cif_mm.dic for clarity.
+
+   + Change '<a href="#_array_structure.encoding_type">_array_structure.encoding_type</a>' from type code to uline and
+     added X-Binary-Element-Type to MIME header.
+
+   + Add detector beam centre '<a href="#_diffrn_detector_element.center[1]">_diffrn_detector_element.center[1]</a>' and
+     '<a href="#_diffrn_detector_element.center[2]">_diffrn_detector_element.center[2]</a>'.
+
+   + Correct item name of '<a href="#_diffrn_refln.frame_id">_diffrn_refln.frame_id</a>'.
+
+   + Replace reference to '_array_intensities.undefined' by
+     '_array_intensities.undefined_value'.
+
+   + Replace references to '_array_intensity.scaling' with
+     '_array_intensities.scaling'.
+
+   + Add <a href="#diffrn_scan">DIFFRN_SCAN</a>... categories.
+;
+
+
+   0.4   1998-08-11
+;
+   Modifications to the 0.3 imgCIF draft.  (HJB)
+
+   + Reflow comment lines over 80 characters and corrected typos.
+
+   + Update examples and descriptions of MIME encoded data.
+
+   + Change name to cbfext98.dic.
+;
+
+
+   0.3   1998-07-04
+;
+   Modifications for imgCIF.  (HJB)
+
+   + Add binary type, which is a text field containing a variant on
+     MIME encoded data.
+
+   + Change type of '<a href="#_array_data.data" >_array_data.data</a>' to binary and specify internal
+     structure of raw binary data.
+
+   + Add '<a href="#_array_data.binary_id" >_array_data.binary_id</a>', and make
+     '<a href="#_diffrn_frame_data.binary_id" >_diffrn_frame_data.binary_id</a>' and '<a href="#_array_intensities.binary_id" >_array_intensities.binary_id</a>'
+     into pointers to this item.
+;
+
+
+   0.2   1997-12-02
+;
+   Modifications to the CBF draft.  (JW)
+
+   + Add category hierarchy for describing frame data developed from
+     discussions at the BNL imgCIF Workshop Oct 1997.   The following
+     changes are made in implementing the workshop draft.  Category
+     DIFFRN_array_data is renamed to DIFFRN_FRAME_DATA.  Category
+     DIFFRN_FRAME_TYPE is renamed to <a href="#diffrn_detector_element">DIFFRN_DETECTOR_ELEMENT</a>.   The
+     parent item for '<a href="#_diffrn_frame_data.array_id" >_diffrn_frame_data.array_id</a>' is changed from
+     '_array_structure_list.array_id' to '_array_structure.id'. Item
+     '_diffrn_detector.array_id' is deleted.
+   + Add data item '<a href="#_diffrn_frame_data.binary_id" >_diffrn_frame_data.binary_id</a>' to identify data
+     groups within a binary section.  The formal identification of the
+     binary section is still fuzzy.
+;
+
+
+   0.1   1997-01-24
+;
+   First draft of this dictionary in DDL 2.1 compliant format by John
+   Westbrook (JW).  This version is adapted from the Crystallographic
+   Binary File (CBF) Format Draft Proposal provided by Andy Hammersley
+   (AH).
+
+   Modifications to the CBF draft.  (JW)
+
+   + In this version the array description has been cast in the categories
+     <a href="#array_structure">ARRAY_STRUCTURE</a> and <a href="#array_structure_list">ARRAY_STRUCTURE_LIST</a>.  These categories
+     have been generalized to describe array data  of arbitrary dimension.
+
+   + Array data in this description are contained in the category
+     <a href="#array_data">ARRAY_DATA</a>.  This departs from the CBF notion of data existing
+     in some special comment. In this description, data are handled as an
+     ordinary data item encapsulated in a character data type.   Although
+     data this manner deviates from CIF conventions, it does not violate
+     any DDL 2.1 rules.  DDL 2.1 regular expressions can be used to define
+     the binary representation which will permit some level of data
+     validation.  In this version, the placeholder type code "any" has
+     been used. This translates to a regular expression which will match
+     any pattern.
+
+     It should be noted that DDL 2.1 already supports array data objects
+     although these have not been used in the current mmCIF dictionary.
+     It may be possible to use the DDL 2.1 ITEM_STRUCTURE and
+     ITEM_STRUCTURE_LIST categories to provide the information that is
+     carried in by the <a href="#array_structure">ARRAY_STRUCTURE</a> and <a href="#array_structure_list">ARRAY_STRUCTURE_LIST</a>.  By
+     moving the array structure to the DDL level it would be possible to
+     define an array type as well as a regular expression defining the
+     data format.
+
+   + Multiple array sections can be properly handled within a single
+     datablock.
+;
+
+
+#-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof
+</PRE>
+</BODY>
+</HTML>


### PR DESCRIPTION
cif_img_1.8.7.dic and cif_img_1.8.7.html added as straight copies of 1.8.6, then updated to 1.8.7 with empty version history.  Overload then clarified:

Old: the value above which correct intensities may not be recorded
New: the value at or above which correct intensities may not be recorded